### PR TITLE
feat: Add build artifacts GitHub workflow

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -75,16 +75,18 @@ jobs:
       run: |
         brew install cmake ninja
 
-    # Windows Dependencies
-    - name: Install Windows Dependencies
-      if: runner.os == 'Windows'
-      run: |
-        choco install cmake ninja -y
+    # Windows Dependencies (cmake is pre-installed)
+    # No extra dependencies needed for MSVC build
 
     # Configure CMake
     - name: Configure CMake
+      shell: bash
       run: |
-        cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release
+        if [ "$RUNNER_OS" == "Windows" ]; then
+          cmake -B build -DCMAKE_BUILD_TYPE=Release
+        else
+          cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release
+        fi
 
     # Build
     - name: Build
@@ -95,7 +97,12 @@ jobs:
       if: runner.os == 'Linux'
       run: |
         mkdir -p artifact
-        cp build/Gravisynth_artefacts/Release/Gravisynth artifact/
+        # Find the executable, ignoring intermediates
+        find build -name Gravisynth -type f -perm /111 -exec cp {} artifact/ \; || true
+        # Fallback if permission check fails or distinct structure
+        if [ ! -f artifact/Gravisynth ]; then
+            find build -name Gravisynth -type f -exec cp {} artifact/ \;
+        fi
         chmod +x artifact/Gravisynth
 
     # Package macOS
@@ -103,15 +110,15 @@ jobs:
       if: runner.os == 'macOS'
       run: |
         mkdir -p artifact
-        cp -r build/Gravisynth_artefacts/Release/Gravisynth.app artifact/
+        find build -name Gravisynth.app -type d -exec cp -r {} artifact/ \;
 
     # Package Windows
     - name: Package Windows Artifact
       if: runner.os == 'Windows'
+      shell: pwsh
       run: |
-        mkdir artifact
-        copy build\Gravisynth_artefacts\Release\Gravisynth.exe artifact\
-      shell: cmd
+        New-Item -ItemType Directory -Force -Path artifact
+        Get-ChildItem -Path build -Recurse -Filter Gravisynth.exe | Copy-Item -Destination artifact\
 
     # Upload Artifact
     - name: Upload Artifact

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -1,0 +1,122 @@
+name: Build Artifacts
+
+on:
+  # Manual trigger
+  workflow_dispatch:
+  # Automatic trigger on push to main (after PR merge)
+  push:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    name: Build ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Linux x64
+          - os: ubuntu-latest
+            platform: Linux
+            arch: x64
+            artifact_name: Gravisynth-Linux-x64
+          
+          # macOS x64 (Intel)
+          - os: macos-13
+            platform: macOS
+            arch: x64
+            artifact_name: Gravisynth-macOS-x64
+          
+          # macOS arm64 (Apple Silicon)
+          - os: macos-latest
+            platform: macOS
+            arch: arm64
+            artifact_name: Gravisynth-macOS-arm64
+          
+          # Windows x64
+          - os: windows-latest
+            platform: Windows
+            arch: x64
+            artifact_name: Gravisynth-Windows-x64
+
+    steps:
+    - uses: actions/checkout@v4
+
+    # Linux Dependencies
+    - name: Install Linux Dependencies
+      if: runner.os == 'Linux'
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          cmake \
+          ninja-build \
+          libasound2-dev \
+          libx11-dev \
+          libxinerama-dev \
+          libxext-dev \
+          libxcomposite-dev \
+          libxcursor-dev \
+          libxrandr-dev \
+          libxrender-dev \
+          libfontconfig1-dev \
+          libfreetype6-dev \
+          libwebkit2gtk-4.1-dev \
+          libglu1-mesa-dev \
+          libcurl4-openssl-dev \
+          libgtk-3-dev \
+          libjack-jackd2-dev \
+          freeglut3-dev \
+          libsoup-3.0-dev \
+          pkg-config
+
+    # macOS Dependencies
+    - name: Install macOS Dependencies
+      if: runner.os == 'macOS'
+      run: |
+        brew install cmake ninja
+
+    # Windows Dependencies
+    - name: Install Windows Dependencies
+      if: runner.os == 'Windows'
+      run: |
+        choco install cmake ninja -y
+
+    # Configure CMake
+    - name: Configure CMake
+      run: |
+        cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release
+
+    # Build
+    - name: Build
+      run: cmake --build build --config Release
+
+    # Package Linux
+    - name: Package Linux Artifact
+      if: runner.os == 'Linux'
+      run: |
+        mkdir -p artifact
+        cp build/Gravisynth_artefacts/Release/Gravisynth artifact/
+        chmod +x artifact/Gravisynth
+
+    # Package macOS
+    - name: Package macOS Artifact
+      if: runner.os == 'macOS'
+      run: |
+        mkdir -p artifact
+        cp -r build/Gravisynth_artefacts/Release/Gravisynth.app artifact/
+
+    # Package Windows
+    - name: Package Windows Artifact
+      if: runner.os == 'Windows'
+      run: |
+        mkdir artifact
+        copy build\Gravisynth_artefacts\Release\Gravisynth.exe artifact\
+      shell: cmd
+
+    # Upload Artifact
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ matrix.artifact_name }}
+        path: artifact/
+        retention-days: 90


### PR DESCRIPTION
This PR adds a GitHub Actions workflow that automates building and packaging the Gravisynth application for multiple platforms (Linux, macOS, Windows).

## Summary
- Adds  workflow file
- Builds for Linux (x64), macOS (x64 and arm64), and Windows (x64)
- Installs necessary dependencies for each platform
- Uses CMake with Ninja generator for building
- Packages the application into platform-specific artifacts
- Uploads artifacts to GitHub Actions for download

## Test plan
- [ ] Workflow should run successfully on push to main
- [ ] Artifacts should be available in GitHub Actions after workflow completion
- [ ] Build should work correctly for all target platforms