### PR TITLE
Fix macOS 'damaged app' error for GitHub Release artifacts

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -131,6 +131,11 @@ jobs:
           exit 1
         fi
         echo "Found app at: $APP_PATH"
+        
+        # Ad-hoc code sign the app bundle
+        codesign --force --deep -s - "$APP_PATH"
+        codesign --verify --verbose "$APP_PATH"
+        
         ditto -c -k --sequesterRsrc --keepParent "$APP_PATH" artifact/${{ matrix.artifact_name }}.zip
 
     # Package Windows

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,7 @@ endif()
 juce_add_gui_app(Gravisynth
     PRODUCT_NAME "Gravisynth"
     VERSION "0.0.1"
+    BUNDLE_ID "com.gravisynth.app"
 )
 
 juce_generate_juce_header(Gravisynth)


### PR DESCRIPTION
## Summary

- Add `BUNDLE_ID` to CMake config for proper macOS bundle identification
- Ad-hoc codesign the `.app` bundle in CI before packaging the artifact
- Verify the signature in CI so the build fails if signing doesn't work

## Problem

Users downloading the macOS artifact from GitHub Releases see "Gravisynth.app is damaged and can't be opened" because the app is completely unsigned and macOS Gatekeeper rejects quarantined unsigned apps.

## Solution

Ad-hoc code signing (`codesign --force --deep -s -`) eliminates the "damaged" error. Users will instead see an "unverified developer" warning, which is bypassable via right-click → Open.

## Test plan

- [ ] Push changes and let CI build
- [ ] Download macOS zip from the release
- [ ] Verify signature: `codesign -dv Gravisynth.app`
- [ ] Open the app — should show "unverified developer" instead of "damaged"