### PR TITLE
fix: AI Model Response Parameter Application (fixes #15)

### DIFF
--- a/Source/AI/AIIntegrationService.cpp
+++ b/Source/AI/AIIntegrationService.cpp
@@ -11,25 +11,31 @@ AIIntegrationService::~AIIntegrationService() {}
 
 void AIIntegrationService::setProvider(std::unique_ptr<AIProvider> newProvider) { provider = std::move(newProvider); }
 
-void AIIntegrationService::sendMessage(const juce::String& text, AIProvider::CompletionCallback callback) {
+void AIIntegrationService::sendMessage(const juce::String& text, AIProvider::CompletionCallback callback,
+                                       bool useStructuredOutput) {
     // Before sending, we could inject the current patch context as a developer message or hidden part of prompt
     // For now, let's just add the user text.
     chatHistory.push_back({"user", text});
 
     if (provider) {
         auto weakThis = juce::WeakReference<AIIntegrationService>(this);
-        provider->sendPrompt(chatHistory, [weakThis, callback](const juce::String& response, bool success) {
-            if (weakThis.get() == nullptr)
-                return; // Service was destroyed
+        auto schema = useStructuredOutput ? AIStateMapper::getPatchSchema() : juce::var();
 
-            auto* self = weakThis.get();
-            if (success) {
-                self->chatHistory.push_back({"assistant", response});
-            }
-            if (callback) {
-                callback(response, success);
-            }
-        });
+        provider->sendPrompt(
+            chatHistory,
+            [weakThis, callback](const juce::String& response, bool success) {
+                if (weakThis.get() == nullptr)
+                    return; // Service was destroyed
+
+                auto* self = weakThis.get();
+                if (success) {
+                    self->chatHistory.push_back({"assistant", response});
+                }
+                if (callback) {
+                    callback(response, success);
+                }
+            },
+            schema);
     } else {
         if (callback) {
             callback("Error: No AI provider selected.", false);
@@ -38,12 +44,41 @@ void AIIntegrationService::sendMessage(const juce::String& text, AIProvider::Com
 }
 
 bool AIIntegrationService::applyPatch(const juce::String& jsonString) {
-    juce::var json = juce::JSON::parse(jsonString);
+    juce::String extractedJson = extractJsonFromResponse(jsonString);
+    juce::var json = juce::JSON::parse(extractedJson);
     if (AIStateMapper::applyJSONToGraph(json, audioGraph)) {
         listeners.call([](Listener& l) { l.aiPatchApplied(); });
         return true;
     }
     return false;
+}
+
+juce::String AIIntegrationService::extractJsonFromResponse(const juce::String& response) {
+    // 1. Try to find JSON between backticks
+    int start = response.indexOf("```json");
+    if (start != -1) {
+        start += 7;
+        int end = response.indexOf(start, "```");
+        if (end != -1)
+            return response.substring(start, end).trim();
+    }
+
+    // 2. Try to find JSON between any backticks
+    start = response.indexOf("```");
+    if (start != -1) {
+        start += 3;
+        int end = response.indexOf(start, "```");
+        if (end != -1)
+            return response.substring(start, end).trim();
+    }
+
+    // 3. Try to find first '{' and last '}'
+    start = response.indexOf("{");
+    int end = response.lastIndexOf("}");
+    if (start != -1 && end != -1 && end > start)
+        return response.substring(start, end + 1).trim();
+
+    return response.trim();
 }
 
 juce::String AIIntegrationService::getPatchContext() {
@@ -57,28 +92,42 @@ void AIIntegrationService::clearHistory() {
 }
 
 void AIIntegrationService::initSystemPrompt() {
-    chatHistory.push_back(
-        {"system", "You are Gravisynth AI, an expert sound designer for the Gravisynth modular synthesizer. "
-                   "Your goal is to help users create and modify patches. "
-                   "Gravisynth uses a nodes-and-connections model. "
-                   "When asked to create a patch, provide a JSON block inside backticks that describes the nodes and "
-                   "connections. "
-                   "Example format:\n"
-                   "```json\n"
-                   "{\n"
-                   "  \"nodes\": [\n"
-                   "    { \"id\": 1, \"type\": \"Oscillator\", \"params\": { \"Frequency\": 0.2 } },\n"
-                   "    { \"id\": 2, \"type\": \"Audio Output\" }\n"
-                   "  ],\n"
-                   "  \"connections\": [\n"
-                   "    { \"src\": 1, \"srcPort\": 0, \"dst\": 2, \"dstPort\": 0 }\n"
-                   "  ]\n"
-                   "}\n"
-                   "```\n"
-                   "Available modules: Oscillator, Filter, LFO, ADSR, VCA, Sequencer, Distortion, Delay, Reverb. "
-                   "IO nodes: Audio Input, Audio Output, Midi Input. "
-                   "Keep your explanations concise, but *always* provide a brief textual summary of the changes "
-                   "you made *before* the JSON block."});
+    juce::String schema = AIStateMapper::getModuleSchema();
+
+    juce::String systemMsg =
+        "You are Gravisynth AI, an expert sound designer for the Gravisynth modular synthesizer. "
+        "Your goal is to help users create and modify patches. "
+        "Gravisynth uses a nodes-and-connections model. "
+        "\n\n" +
+        schema +
+        "\n"
+        "### MODES OF OPERATION:\n"
+        "1. **Conversational Mode**: When the user asks a general question, respond naturally in Markdown.\n"
+        "2. **Structured Patch Mode**: When requested to create or modify a patch, you MUST provide a JSON block. "
+        "If a 'format' schema is provided in the API request, your entire response MUST be the raw JSON adhering to "
+        "that schema, with NO additional text or Markdown formatting.\n"
+        "\n"
+        "### IMPORTANT INSTRUCTIONS FOR PATCHES:\n"
+        "- **Parameter IDs are Case-Sensitive**: Use the exact `Parameter ID` from the table above (e.g., use "
+        "`cutoff`, not `Cutoff`).\n"
+        "- **Values**: Use raw, unnormalized values within the specified ranges.\n"
+        "- **Choice Parameters**: Use the exact string name (e.g., `\"waveform\": \"Saw\"`).\n"
+        "- **Connections**: Ensure `srcPort` and `dstPort` are valid for the given module type. Most modules use port "
+        "0 for their primary audio/midi signal.\n"
+        "\nExample format:\n"
+        "```json\n"
+        "{\n"
+        "  \"nodes\": [\n"
+        "    { \"id\": 1, \"type\": \"Oscillator\", \"params\": { \"frequency\": 440.0, \"waveform\": \"Saw\" } },\n"
+        "    { \"id\": 2, \"type\": \"Audio Output\" }\n"
+        "  ],\n"
+        "  \"connections\": [\n"
+        "    { \"src\": 1, \"srcPort\": 0, \"dst\": 2, \"dstPort\": 0 }\n"
+        "  ]\n"
+        "}\n"
+        "```";
+
+    chatHistory.push_back({"system", systemMsg});
 }
 
 void AIIntegrationService::setModel(const juce::String& name) {

--- a/Source/AI/AIIntegrationService.h
+++ b/Source/AI/AIIntegrationService.h
@@ -37,7 +37,8 @@ public:
     /**
      * @brief Sends a user message and gets a response.
      */
-    void sendMessage(const juce::String& text, AIProvider::CompletionCallback callback);
+    void sendMessage(const juce::String& text, AIProvider::CompletionCallback callback,
+                     bool useStructuredOutput = false);
 
     /**
      * @brief Applies a JSON patch to the graph.
@@ -73,6 +74,11 @@ private:
     juce::ListenerList<Listener> listeners;
 
     void initSystemPrompt();
+
+    /**
+     * @brief Helper to extract JSON from a response that might contain conversational text.
+     */
+    juce::String extractJsonFromResponse(const juce::String& response);
 
     JUCE_DECLARE_WEAK_REFERENCEABLE(AIIntegrationService)
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(AIIntegrationService)

--- a/Source/AI/AIProvider.h
+++ b/Source/AI/AIProvider.h
@@ -26,8 +26,12 @@ public:
 
     /**
      * @brief Sends a prompt to the AI and calls the callback when the response is ready.
+     * @param conversation The chat history
+     * @param callback Callback for result
+     * @param responseSchema Optional JSON schema for structured output
      */
-    virtual void sendPrompt(const std::vector<Message>& conversation, CompletionCallback callback) = 0;
+    virtual void sendPrompt(const std::vector<Message>& conversation, CompletionCallback callback,
+                            const juce::var& responseSchema = juce::var()) = 0;
 
     /**
      * @brief Returns the name of the provider.

--- a/Source/AI/AIStateMapper.h
+++ b/Source/AI/AIStateMapper.h
@@ -23,10 +23,26 @@ public:
      */
     static bool applyJSONToGraph(const juce::var& json, juce::AudioProcessorGraph& graph, bool clearExisting = true);
 
+    /**
+     * @brief Gets a Markdown-formatted string of all available modules and their parameters.
+     */
+    static juce::String getModuleSchema();
+
+    /**
+     * @brief Generates a JSON schema for patch validation and structured AI output.
+     */
+    static juce::var getPatchSchema();
+
     static std::unique_ptr<juce::AudioProcessor> createModule(const juce::String& type);
 
 private:
     static bool validatePatchJSON(const juce::var& json);
+
+    /**
+     * @brief Helper to find the index of a string choice in an AudioParameterChoice.
+     * @return index if found, -1 otherwise.
+     */
+    static int findChoiceIndex(juce::AudioParameterChoice* p, const juce::String& choiceText);
 };
 
 } // namespace gsynth

--- a/Source/AI/OllamaProvider.cpp
+++ b/Source/AI/OllamaProvider.cpp
@@ -104,6 +104,9 @@ void OllamaProvider::processRequest(const Request& req) {
     }
     body->setProperty("messages", messages);
 
+    if (!req.responseSchema.isVoid())
+        body->setProperty("format", req.responseSchema);
+
     juce::String jsonString = juce::JSON::toString(juce::var(body.get()));
 
     juce::String responseText;

--- a/Source/AI/OllamaProvider.h
+++ b/Source/AI/OllamaProvider.h
@@ -28,10 +28,11 @@ public:
 
     ~OllamaProvider() override { stopThread(2000); }
 
-    void sendPrompt(const std::vector<Message>& conversation, CompletionCallback callback) override {
+    void sendPrompt(const std::vector<Message>& conversation, CompletionCallback callback,
+                    const juce::var& responseSchema = juce::var()) override {
         {
             const juce::ScopedLock sl(queueLock);
-            pendingRequests.push_back({conversation, callback});
+            pendingRequests.push_back({conversation, callback, responseSchema});
         }
 
         if (!isThreadRunning())
@@ -57,6 +58,7 @@ private:
     struct Request {
         std::vector<Message> conversation;
         AIProvider::CompletionCallback callback;
+        juce::var responseSchema;
     };
 
     juce::CriticalSection queueLock;


### PR DESCRIPTION
This PR addresses issue #15 by correcting the way AI-generated parameter values are applied to JUCE AudioProcessor modules.

Previously, the AIIntegrationService was not correctly converting unnormalized parameter values from the AI JSON into the normalized range expected by JUCE's AudioProcessor parameters. This resulted in parameters not being set as intended.

The fix involves:
- Casting parameters to 'juce::RangedAudioParameter*' to access range-specific methods.
- Using 'p->getNormalisableRange().snapToLegalValue(value)' to ensure the raw value from the AI is within the parameter's legal range and snapped to the closest valid step.
- Using 'p->getNormalisableRange().convertTo0to1(value)' to convert the snapped raw value into a normalized 0-1 range.
- Setting the parameter with the correctly normalized value using 'p->setValue(normalizedValue)'.
- Correcting an assertion in 'Tests/AIStateMapperTests.cpp' where the expected normalized value for a clamped frequency was incorrect.

This ensures that the AI's intended parameter values are accurately reflected in the synthesizer modules.