### PR TITLE
fix: resolve modulation matrix synchronization and multi-output source issues

### DIFF
--- a/Source/AudioEngine.cpp
+++ b/Source/AudioEngine.cpp
@@ -33,9 +33,11 @@ std::vector<AudioEngine::ModRoutingInfo> AudioEngine::getActiveModRoutings() con
         if (dynamic_cast<AttenuverterModule*>(node->getProcessor()) != nullptr) {
             ModRoutingInfo info;
             info.attenuverterNodeID = node->nodeID;
+            info.sourceChannelIndex = 0;
             for (auto& conn : mainProcessorGraph.getConnections()) {
                 if (conn.destination.nodeID == node->nodeID && conn.destination.channelIndex == 0) {
                     info.sourceNodeID = conn.source.nodeID;
+                    info.sourceChannelIndex = conn.source.channelIndex;
                     break;
                 }
             }
@@ -59,14 +61,14 @@ std::vector<AudioEngine::ModRoutingInfo> AudioEngine::getActiveModRoutings() con
     return routings;
 }
 
-void AudioEngine::addModRouting(juce::AudioProcessorGraph::NodeID sourceNodeID,
+void AudioEngine::addModRouting(juce::AudioProcessorGraph::NodeID sourceNodeID, int sourceChannelIndex,
                                 juce::AudioProcessorGraph::NodeID destNodeID, int destChannelIndex) {
     auto attenuverterNode = mainProcessorGraph.addNode(std::make_unique<AttenuverterModule>());
     if (attenuverterNode == nullptr)
         return;
     if (auto* param = dynamic_cast<juce::AudioParameterFloat*>(attenuverterNode->getProcessor()->getParameters()[0]))
         param->setValueNotifyingHost(param->convertTo0to1(1.0f));
-    mainProcessorGraph.addConnection({{sourceNodeID, 0}, {attenuverterNode->nodeID, 0}});
+    mainProcessorGraph.addConnection({{sourceNodeID, sourceChannelIndex}, {attenuverterNode->nodeID, 0}});
     mainProcessorGraph.addConnection({{attenuverterNode->nodeID, 0}, {destNodeID, destChannelIndex}});
 }
 
@@ -153,8 +155,8 @@ void AudioEngine::createDefaultPatch() {
     outputNode->properties.set("x", 2250.0f);
     outputNode->properties.set("y", 300.0f);
 
-    addModRouting(adsrNode->nodeID, vcaNode->nodeID, 1);
-    addModRouting(filterAdsrNode->nodeID, filterNode->nodeID, 1);
+    addModRouting(adsrNode->nodeID, 0, vcaNode->nodeID, 1);
+    addModRouting(filterAdsrNode->nodeID, 0, filterNode->nodeID, 1);
     for (int i = 0; i < 4; ++i)
         addEmptyModRouting();
 

--- a/Source/AudioEngine.h
+++ b/Source/AudioEngine.h
@@ -27,14 +27,15 @@ public:
     struct ModRoutingInfo {
         juce::AudioProcessorGraph::NodeID attenuverterNodeID;
         juce::AudioProcessorGraph::NodeID sourceNodeID;
+        int sourceChannelIndex;
         juce::AudioProcessorGraph::NodeID destNodeID;
         int destChannelIndex;
         bool isBypassed;
     };
 
     std::vector<ModRoutingInfo> getActiveModRoutings() const;
-    void addModRouting(juce::AudioProcessorGraph::NodeID sourceNodeID, juce::AudioProcessorGraph::NodeID destNodeID,
-                       int destChannelIndex);
+    void addModRouting(juce::AudioProcessorGraph::NodeID sourceNodeID, int sourceChannelIndex,
+                       juce::AudioProcessorGraph::NodeID destNodeID, int destChannelIndex);
     void addEmptyModRouting();
     void removeModRouting(juce::AudioProcessorGraph::NodeID attenuverterNodeID);
     void toggleModBypass(juce::AudioProcessorGraph::NodeID attenuverterNodeID);

--- a/Source/Modules/FX/DistortionModule.h
+++ b/Source/Modules/FX/DistortionModule.h
@@ -58,7 +58,6 @@ public:
                 // But let's just use the current smoothed values + CV
                 int sampleIdx = (int)i / (int)oversampling->getOversamplingFactor();
                 float driveMod = cvDrive ? cvDrive[std::min(sampleIdx, numSamples - 1)] : 0.0f;
-                float mixMod = cvMix ? cvMix[std::min(sampleIdx, numSamples - 1)] : 0.0f;
 
                 float drive = juce::jlimit(1.0f, 20.0f, smoothedDrive.getNextValue() + (driveMod * 10.0f));
 

--- a/Source/UI/GraphEditor.cpp
+++ b/Source/UI/GraphEditor.cpp
@@ -214,31 +214,31 @@ void GraphEditor::endConnectionDrag(juce::Point<int> screenPos) {
             }
 
             if (srcNode && dstNode) {
-                if (dragSourceIsMidi) {
-                    graph.addConnection({{srcNode->nodeID, juce::AudioProcessorGraph::midiChannelIndex},
-                                         {dstNode->nodeID, juce::AudioProcessorGraph::midiChannelIndex}});
-                } else {
-                    int sPort = dragSourceIsInput ? port->index : dragSourceChannel;
-                    int dPort = dragSourceIsInput ? dragSourceChannel : port->index;
+                // Determine real source and destination based on drag direction
+                auto* realSrc = dragSourceIsInput ? dstNode : srcNode;
+                auto* realDst = dragSourceIsInput ? srcNode : dstNode;
+                int sPort = dragSourceIsInput ? port->index : dragSourceChannel;
+                int dPort = dragSourceIsInput ? dragSourceChannel : port->index;
 
-                    juce::String dstName = dstNode->getProcessor()->getName();
+                if (dragSourceIsMidi) {
+                    graph.addConnection({{realSrc->nodeID, juce::AudioProcessorGraph::midiChannelIndex},
+                                         {realDst->nodeID, juce::AudioProcessorGraph::midiChannelIndex}});
+                } else {
                     bool isCV = false;
-                    if (dstName == "Filter" && dPort >= 1)
-                        isCV = true;
-                    if (dstName == "VCA" && dPort == 1)
-                        isCV = true;
-                    if (dstName == "Oscillator" && dPort >= 0)
-                        isCV = true;
+                    if (auto* modBase = dynamic_cast<ModuleBase*>(realDst->getProcessor())) {
+                        auto targets = modBase->getModulationTargets();
+                        for (const auto& t : targets) {
+                            if (t.channelIndex == dPort) {
+                                isCV = true;
+                                break;
+                            }
+                        }
+                    }
 
                     if (isCV) {
-                        // Create Attenuverter
-                        auto attenNode = graph.addNode(std::make_unique<AttenuverterModule>());
-                        if (attenNode) {
-                            graph.addConnection({{srcNode->nodeID, sPort}, {attenNode->nodeID, 0}});
-                            graph.addConnection({{attenNode->nodeID, 0}, {dstNode->nodeID, dPort}});
-                        }
+                        audioEngine.addModRouting(realSrc->nodeID, sPort, realDst->nodeID, dPort);
                     } else {
-                        graph.addConnection({{srcNode->nodeID, sPort}, {dstNode->nodeID, dPort}});
+                        graph.addConnection({{realSrc->nodeID, sPort}, {realDst->nodeID, dPort}});
                     }
                 }
             }
@@ -395,18 +395,7 @@ void GraphEditor::mouseDoubleClick(const juce::MouseEvent& e) {
     auto localPos = content.getLocalPoint(this, e.getPosition());
     auto attenId = getAttenuverterNodeAt(localPos.toFloat());
     if (attenId.uid != 0) {
-        auto& graph = audioEngine.getGraph();
-        std::vector<juce::AudioProcessorGraph::Connection> toRemove;
-        for (auto& c : graph.getConnections()) {
-            if (c.source.nodeID == attenId || c.destination.nodeID == attenId) {
-                toRemove.push_back(c);
-            }
-        }
-        for (auto& c : toRemove) {
-            graph.removeConnection(c);
-        }
-        modMatrix.clearRows();
-        graph.removeNode(attenId);
+        audioEngine.removeModRouting(attenId);
         content.repaint();
     }
 }
@@ -420,10 +409,11 @@ juce::AudioProcessorGraph::NodeID GraphEditor::getAttenuverterNodeAt(juce::Point
         if (!node1 || !node2)
             continue;
 
-        auto name2 = node2->getProcessor()->getName();
-        if (name2.startsWith("Attenuverter") || name2.startsWith("Mod Slot")) {
+        // An attenuverter always has a source connection into its port 0
+        if (dynamic_cast<AttenuverterModule*>(node2->getProcessor()) != nullptr) {
             juce::AudioProcessorGraph::Node* realDstNode = nullptr;
             int realDstPort = 0;
+            // Find the output connection FROM this attenuverter
             for (auto& c : graph.getConnections()) {
                 if (c.source.nodeID == node2->nodeID) {
                     realDstNode = graph.getNodeForId(c.destination.nodeID);
@@ -516,11 +506,25 @@ void GraphEditor::disconnectPort(ModuleComponent* module, int portIndex, bool is
     for (auto& c : graph.getConnections()) {
         if (isInput) {
             if (c.destination.nodeID == nodeId && c.destination.channelIndex == targetChannel) {
-                toRemove.push_back(c);
+                // If this is coming from an attenuverter, remove the whole routing
+                if (auto* srcNode = graph.getNodeForId(c.source.nodeID)) {
+                    if (dynamic_cast<AttenuverterModule*>(srcNode->getProcessor()) != nullptr) {
+                        audioEngine.removeModRouting(srcNode->nodeID);
+                    } else {
+                        toRemove.push_back(c);
+                    }
+                }
             }
         } else {
             if (c.source.nodeID == nodeId && c.source.channelIndex == targetChannel) {
-                toRemove.push_back(c);
+                // If this is going to an attenuverter, remove the whole routing
+                if (auto* dstNode = graph.getNodeForId(c.destination.nodeID)) {
+                    if (dynamic_cast<AttenuverterModule*>(dstNode->getProcessor()) != nullptr) {
+                        audioEngine.removeModRouting(dstNode->nodeID);
+                    } else {
+                        toRemove.push_back(c);
+                    }
+                }
             }
         }
     }

--- a/Source/UI/ModMatrixComponent.cpp
+++ b/Source/UI/ModMatrixComponent.cpp
@@ -149,7 +149,6 @@ void ModMatrixComponent::updateRowsFromGraph() {
     }
 
     // Refresh combo items if the number of nodes in graph changed
-    static int lastNodeCount = 0;
     int currentNodeCount = audioEngine.getGraph().getNumNodes();
     if (currentNodeCount != lastNodeCount) {
         audioEngine.updateModuleNames();
@@ -273,8 +272,13 @@ void ModMatrixComponent::ModRow::populateCombos() {
                 auto* module = static_cast<ModuleBase*>(node->getProcessor());
                 juce::String displayName = module->getName();
 
-                if (module->getTotalNumOutputChannels() > 0)
-                    sourceCombo.addItem(displayName, (int)node->nodeID.uid);
+                for (int i = 0; i < module->getTotalNumOutputChannels(); ++i) {
+                    int itemId = (int)((node->nodeID.uid << 8) | (uint32_t)i);
+                    juce::String label = displayName;
+                    if (module->getTotalNumOutputChannels() > 1)
+                        label += " Out " + juce::String(i + 1);
+                    sourceCombo.addItem(label, itemId);
+                }
 
                 auto targets = module->getModulationTargets();
                 for (const auto& target : targets) {
@@ -299,8 +303,19 @@ void ModMatrixComponent::ModRow::populateCombos() {
                 juce::String displayName = module->getName();
 
                 if (module->getTotalNumOutputChannels() > 0) {
-                    catSourceSub.addItem((int)node->nodeID.uid, displayName);
-                    sourceCombo.addItem(displayName, (int)node->nodeID.uid);
+                    if (module->getTotalNumOutputChannels() == 1) {
+                        int itemId = (int)((node->nodeID.uid << 8) | 0);
+                        catSourceSub.addItem(itemId, displayName);
+                        sourceCombo.addItem(displayName, itemId);
+                    } else {
+                        juce::PopupMenu instSourceSub;
+                        for (int i = 0; i < module->getTotalNumOutputChannels(); ++i) {
+                            int itemId = (int)((node->nodeID.uid << 8) | (uint32_t)i);
+                            instSourceSub.addItem(itemId, "Out " + juce::String(i + 1));
+                            sourceCombo.addItem(displayName + " Out " + juce::String(i + 1), itemId);
+                        }
+                        catSourceSub.addSubMenu(displayName, instSourceSub);
+                    }
                     sourceItems++;
                 }
 
@@ -329,20 +344,24 @@ void ModMatrixComponent::ModRow::populateCombos() {
 }
 
 void ModMatrixComponent::ModRow::refresh(const AudioEngine::ModRoutingInfo& info) {
-    sourceCombo.setSelectedId((int)info.sourceNodeID.uid, juce::dontSendNotification);
+    int srcId = (int)((info.sourceNodeID.uid << 8) | (uint32_t)info.sourceChannelIndex);
+    sourceCombo.setSelectedId(srcId, juce::dontSendNotification);
     int destId = (int)((info.destNodeID.uid << 8) | (uint32_t)info.destChannelIndex);
     destCombo.setSelectedId(destId, juce::dontSendNotification);
 }
 
 void ModMatrixComponent::ModRow::comboBoxChanged(juce::ComboBox* comboBox) {
     if (comboBox == &sourceCombo || comboBox == &destCombo) {
-        uint32_t srcId = (uint32_t)sourceCombo.getSelectedId();
+        uint32_t srcEncoded = (uint32_t)sourceCombo.getSelectedId();
         uint32_t destEncoded = (uint32_t)destCombo.getSelectedId();
+
+        uint32_t srcNodeId = srcEncoded >> 8;
+        int srcChannel = (int)(srcEncoded & 0xFF);
 
         uint32_t dstNodeId = destEncoded >> 8;
         int dstChannel = (int)(destEncoded & 0xFF);
 
-        if (srcId != 0 || dstNodeId != 0) {
+        if (srcNodeId != 0 || dstNodeId != 0) {
             auto& graph = owner.audioEngine.getGraph();
 
             for (auto& conn : graph.getConnections()) {
@@ -351,8 +370,8 @@ void ModMatrixComponent::ModRow::comboBoxChanged(juce::ComboBox* comboBox) {
                     break;
                 }
             }
-            if (srcId != 0)
-                graph.addConnection({{juce::AudioProcessorGraph::NodeID(srcId), 0}, {attenuverterId, 0}});
+            if (srcNodeId != 0)
+                graph.addConnection({{juce::AudioProcessorGraph::NodeID(srcNodeId), srcChannel}, {attenuverterId, 0}});
 
             for (auto& conn : graph.getConnections()) {
                 if (conn.source.nodeID == attenuverterId && conn.source.channelIndex == 0) {

--- a/Source/UI/ModMatrixComponent.h
+++ b/Source/UI/ModMatrixComponent.h
@@ -67,5 +67,7 @@ private:
     void updateRowsFromGraph();
     void addModulation();
 
+    int lastNodeCount = 0;
+
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(ModMatrixComponent)
 };

--- a/Tests/ModMatrixTests.cpp
+++ b/Tests/ModMatrixTests.cpp
@@ -24,7 +24,7 @@ TEST_F(ModMatrixTest, AddModRoutingWorks) {
     ASSERT_NE(lfoNode, nullptr);
     ASSERT_NE(filterNode, nullptr);
 
-    engine.addModRouting(lfoNode->nodeID, filterNode->nodeID, 1); // 1 = Cutoff
+    engine.addModRouting(lfoNode->nodeID, 0, filterNode->nodeID, 1); // 1 = Cutoff
 
     auto routings = engine.getActiveModRoutings();
     ASSERT_EQ(routings.size(), 1);
@@ -40,7 +40,7 @@ TEST_F(ModMatrixTest, RemoveModRoutingWorks) {
     auto lfoNode = graph.addNode(std::make_unique<LFOModule>());
     auto filterNode = graph.addNode(std::make_unique<FilterModule>());
 
-    engine.addModRouting(lfoNode->nodeID, filterNode->nodeID, 1);
+    engine.addModRouting(lfoNode->nodeID, 0, filterNode->nodeID, 1);
     auto routings = engine.getActiveModRoutings();
     ASSERT_EQ(routings.size(), 1);
 
@@ -68,13 +68,13 @@ TEST_F(ModMatrixTest, SidechainModulationWorks) {
     auto filterNode = graph.addNode(std::make_unique<FilterModule>());
 
     // 1. Primary Routing: LFO -> Attenuverter A -> Filter Cutoff
-    engine.addModRouting(lfoNode->nodeID, filterNode->nodeID, 1);
+    engine.addModRouting(lfoNode->nodeID, 0, filterNode->nodeID, 1);
     auto routings = engine.getActiveModRoutings();
     ASSERT_EQ(routings.size(), 1);
     auto attenuverterA = routings[0].attenuverterNodeID;
 
     // 2. Sidechain Routing: Env -> Attenuverter B -> Attenuverter A (Amount)
-    engine.addModRouting(envNode->nodeID, attenuverterA, 1); // 1 = Amount target
+    engine.addModRouting(envNode->nodeID, 0, attenuverterA, 1); // 1 = Amount target
     routings = engine.getActiveModRoutings();
     ASSERT_EQ(routings.size(), 2);
 
@@ -100,7 +100,7 @@ TEST_F(ModMatrixTest, BypassModRoutingWorks) {
     auto lfoNode = graph.addNode(std::make_unique<LFOModule>());
     auto filterNode = graph.addNode(std::make_unique<FilterModule>());
 
-    engine.addModRouting(lfoNode->nodeID, filterNode->nodeID, 1);
+    engine.addModRouting(lfoNode->nodeID, 0, filterNode->nodeID, 1);
     auto routings = engine.getActiveModRoutings();
     ASSERT_EQ(routings.size(), 1);
     auto attNodeID = routings[0].attenuverterNodeID;


### PR DESCRIPTION
This PR resolves the issues with the modulation matrix synchronization and multi-output source support.

### Fixes:
- **Matrix Synchronization**: Fixed a bug where UI-connected modules weren't appearing in the matrix by correcting the connection drag logic and using metadata-based CV port detection.
- **Multi-Output Support**: Updated `AudioEngine` and the matrix to correctly handle modules with multiple outputs, such as the LFO (LFO Out 1, LFO Out 2).
- **Graph Cleanup**: Ensured `AttenuverterModule` nodes are properly removed when connections are deleted in the UI.
- **Improved Reliability**: Replaced hardcoded module name checks with dynamic metadata checks for more robust port identification.

Closes #27