### PR TITLE
feat: add chorus, phaser, compressor, flanger, limiter FX modules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@ The project follows a modular architecture with:
 - **GraphEditor**: Visual editor for connecting modules with zoom/pan and drag-to-connect
 - **ModuleComponent**: Auto-UI generation from module parameters with type-safe layout switching via `ModuleType` enum
 - **AttenuverterModule**: Intermediary module for modulation routing with bypass and CV amount control
+- **Port Labels**: Virtual `getInputPortLabel()`/`getOutputPortLabel()` on ModuleBase, overridden per-module for descriptive port names in the UI
 - **GravisynthUndoManager**: Snapshot-based undo/redo system wrapping `juce::UndoManager`, captures full graph state on every change
 
 ### Audio Modules
@@ -32,7 +33,7 @@ The project follows a modular architecture with:
 - LFO: Low Frequency Oscillator for modulation
 - Sequencer: Step sequencer with per-step pitch control
 - MIDI Keyboard: Interactive on-screen keyboard for MIDI input
-- FX Modules: Delay, Distortion, Reverb
+- FX Modules: Delay, Distortion, Reverb, Chorus, Phaser, Compressor, Flanger, Limiter
 - Preset System: Factory presets with categorized organization
 
 ## Build System
@@ -68,7 +69,7 @@ bash scripts/coverage.sh
 - Edge case tests (zero-length buffers, extreme parameters, sample rate changes)
 - Integration tests (signal chains, modulation routing)
 - Code coverage enforcement (threshold: 69%, CI pipeline enforces)
-- ~169 tests across 28 suites (unit, edge case, integration, undo/redo, filter modes)
+- ~200+ tests across 35+ suites (unit, edge case, integration, undo/redo, filter modes, port labels)
 - CI runs on Ubuntu + macOS with linting, building, testing, and coverage
 
 ## Key Files to Understand
@@ -84,5 +85,11 @@ bash scripts/coverage.sh
 - `Source/UI/ModuleComponent.cpp`: Auto-UI with type-safe `ModuleType` switching, parameter listener for undo, safe detach lifecycle, FrequencyResponseComponent integration and spectrum toggle
 - `Source/UI/FrequencyResponseComponent.h`: Serum-style frequency response curve with FFT spectrum overlay
 - `Source/UI/GraphEditor.cpp`: Graph editor with attenuverter knob rendering, modulation routing, and undo integration
+- `Source/UI/ModuleLibraryComponent.h`: Categorized sidebar with section headers for module drag-and-drop
 - `Source/UI/ModMatrixComponent.cpp`: Modulation matrix with undo tracking for routing and parameter changes
-- `Tests/`: ~169 tests across 28 suites (unit, edge case, integration, undo/redo, filter modes)
+- `Source/Modules/FX/ChorusModule.h`: Chorus effect using `juce::dsp::Chorus`, CV modulation on Rate/Depth
+- `Source/Modules/FX/PhaserModule.h`: Phaser effect using `juce::dsp::Phaser`, CV modulation on Rate/Depth
+- `Source/Modules/FX/CompressorModule.h`: Compressor with manual makeup gain
+- `Source/Modules/FX/FlangerModule.h`: Flanger via `juce::dsp::Chorus` with low-delay tuning
+- `Source/Modules/FX/LimiterModule.h`: Brickwall limiter with input gain drive
+- `Tests/`: ~200+ tests across 35+ suites (unit, edge case, integration, undo/redo, filter modes, port labels)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,11 @@ add_library(GravisynthCore STATIC
     Source/Modules/FX/DelayModule.h
     Source/Modules/FX/DistortionModule.h
     Source/Modules/FX/ReverbModule.h
+    Source/Modules/FX/ChorusModule.h
+    Source/Modules/FX/PhaserModule.h
+    Source/Modules/FX/CompressorModule.h
+    Source/Modules/FX/FlangerModule.h
+    Source/Modules/FX/LimiterModule.h
     # AI
     Source/AI/AIProvider.h
     Source/AI/OllamaProvider.h

--- a/Source/AI/AIStateMapper.cpp
+++ b/Source/AI/AIStateMapper.cpp
@@ -1,8 +1,13 @@
 #include "AIStateMapper.h"
 #include "../Modules/ADSRModule.h"
 #include "../Modules/AttenuverterModule.h"
+#include "../Modules/FX/ChorusModule.h"
+#include "../Modules/FX/CompressorModule.h"
 #include "../Modules/FX/DelayModule.h"
 #include "../Modules/FX/DistortionModule.h"
+#include "../Modules/FX/FlangerModule.h"
+#include "../Modules/FX/LimiterModule.h"
+#include "../Modules/FX/PhaserModule.h"
 #include "../Modules/FX/ReverbModule.h"
 #include "../Modules/FilterModule.h"
 #include "../Modules/LFOModule.h"
@@ -44,7 +49,12 @@ static const std::unordered_map<juce::String, ModuleFactoryFunc> moduleFactory =
     {"Poly MIDI", []() { return std::make_unique<PolyMidiModule>(); }},
     {"Poly Sequencer", []() { return std::make_unique<PolySequencerModule>(); }},
     {"Attenuverter", []() { return std::make_unique<AttenuverterModule>(); }},
-    {"Mod Slot", []() { return std::make_unique<AttenuverterModule>(); }}};
+    {"Mod Slot", []() { return std::make_unique<AttenuverterModule>(); }},
+    {"Chorus", []() { return std::make_unique<ChorusModule>(); }},
+    {"Phaser", []() { return std::make_unique<PhaserModule>(); }},
+    {"Compressor", []() { return std::make_unique<CompressorModule>(); }},
+    {"Flanger", []() { return std::make_unique<FlangerModule>(); }},
+    {"Limiter", []() { return std::make_unique<LimiterModule>(); }}};
 
 bool AIStateMapper::validatePatchJSON(const juce::var& json) {
     if (!json.isObject()) {
@@ -136,6 +146,16 @@ static juce::String getFactoryTypeName(juce::AudioProcessor* processor) {
             return "Distortion";
         case ModuleType::Reverb:
             return "Reverb";
+        case ModuleType::Chorus:
+            return "Chorus";
+        case ModuleType::Phaser:
+            return "Phaser";
+        case ModuleType::Compressor:
+            return "Compressor";
+        case ModuleType::Flanger:
+            return "Flanger";
+        case ModuleType::Limiter:
+            return "Limiter";
         }
     }
     return processor->getName();
@@ -279,9 +299,12 @@ void AIStateMapper::applyParamsToProcessor(juce::AudioProcessor* processor, cons
                     // Detect likely normalized 0-1 values from AI models that ignore range instructions.
                     // If the actual range extends beyond [0,1] but the value is within [0,1],
                     // the AI probably sent a normalized value — convert it to the actual range.
+                    // Skip this heuristic for integer params — small values like 0 or 1 are
+                    // almost always valid denormalized values, not normalized.
+                    bool isIntParam = (dynamic_cast<juce::AudioParameterInt*>(p) != nullptr);
                     bool rangeIsUnitInterval = (range.start >= 0.0f && range.end <= 1.0f);
                     bool wasConverted = false;
-                    if (!rangeIsUnitInterval && val >= 0.0f && val <= 1.0f) {
+                    if (!isIntParam && !rangeIsUnitInterval && val >= 0.0f && val <= 1.0f) {
                         float originalVal = val;
                         val = range.convertFrom0to1(val);
                         wasConverted = true;
@@ -454,8 +477,9 @@ bool AIStateMapper::applyJSONToGraph(const juce::var& json, juce::AudioProcessor
 
         if (audioOutputNode != nullptr) {
             // Types that produce audio and should auto-connect to output
-            static const std::set<juce::String> audioNodeTypes = {"Oscillator", "Filter", "VCA",     "Distortion",
-                                                                  "Delay",      "Reverb", "Amp Env", "Filter Env"};
+            static const std::set<juce::String> audioNodeTypes = {
+                "Oscillator", "Filter", "VCA",    "Distortion", "Delay",   "Reverb", "Amp Env",
+                "Filter Env", "Chorus", "Phaser", "Compressor", "Flanger", "Limiter"};
 
             for (auto newNodeId : newlyCreatedNodes) {
                 auto* node = graph.getNodeForId(newNodeId);
@@ -544,7 +568,8 @@ juce::var AIStateMapper::getPatchSchema() {
         juce::JSON::parse("{\"type\": \"string\", \"enum\": [\"Audio Input\", \"Audio Output\", \"Midi "
                           "Input\", \"Oscillator\", \"Filter\", \"VCA\", \"ADSR\", \"Sequencer\", \"LFO\", "
                           "\"Distortion\", \"Delay\", \"Reverb\", \"MIDI Keyboard\", \"Amp Env\", \"Filter Env\", "
-                          "\"Poly MIDI\", \"Poly Sequencer\", \"Attenuverter\"]}"));
+                          "\"Poly MIDI\", \"Poly Sequencer\", \"Attenuverter\", \"Chorus\", \"Phaser\", "
+                          "\"Compressor\", \"Flanger\", \"Limiter\"]}"));
     nodeProperties->setProperty("params", juce::JSON::parse("{\"type\": \"object\"}"));
 
     nodeItems->setProperty("properties", juce::var(nodeProperties.get()));

--- a/Source/Modules/ADSRModule.h
+++ b/Source/Modules/ADSRModule.h
@@ -53,6 +53,8 @@ public:
     }
 
     ModulationCategory getModulationCategory() const override { return ModulationCategory::Envelope; }
+    juce::String getInputPortLabel(int) const override { return "Gate"; }
+    juce::String getOutputPortLabel(int) const override { return "Env"; }
     ModuleType getModuleType() const override { return ModuleType::ADSR; }
 
 private:

--- a/Source/Modules/AttenuverterModule.h
+++ b/Source/Modules/AttenuverterModule.h
@@ -47,6 +47,9 @@ public:
     }
 
     std::vector<ModulationTarget> getModulationTargets() const override { return {{"Amount", 1}}; }
+    juce::String getInputPortLabel(int i) const override { return i == 0 ? "Signal" : "Amount"; }
+    juce::String getOutputPortLabel(int) const override { return "Out"; }
+
     ModuleType getModuleType() const override { return ModuleType::Attenuverter; }
 
 private:

--- a/Source/Modules/FX/ChorusModule.h
+++ b/Source/Modules/FX/ChorusModule.h
@@ -1,0 +1,90 @@
+#pragma once
+
+#include "../ModuleBase.h"
+#include <juce_dsp/juce_dsp.h>
+
+class ChorusModule : public ModuleBase {
+public:
+    ChorusModule()
+        : ModuleBase("Chorus", 4, 2) {
+        addParameter(rateParam = new juce::AudioParameterFloat("rate", "Rate (Hz)", 0.1f, 10.0f, 0.5f));
+        addParameter(depthParam = new juce::AudioParameterFloat("depth", "Depth", 0.0f, 1.0f, 0.5f));
+        addParameter(centreDelayParam =
+                         new juce::AudioParameterFloat("centreDelay", "Centre Delay (ms)", 1.0f, 30.0f, 7.0f));
+        addParameter(feedbackParam = new juce::AudioParameterFloat("feedback", "Feedback", -1.0f, 1.0f, 0.0f));
+        addParameter(mixParam = new juce::AudioParameterFloat("mix", "Mix", 0.0f, 1.0f, 0.5f));
+    }
+
+    void prepareToPlay(double sampleRate, int samplesPerBlock) override {
+        juce::dsp::ProcessSpec spec;
+        spec.sampleRate = sampleRate;
+        spec.maximumBlockSize = (juce::uint32)samplesPerBlock;
+        spec.numChannels = 2;
+        chorus.prepare(spec);
+        chorus.reset();
+
+        smoothedRate.reset(sampleRate, 0.05);
+        smoothedDepth.reset(sampleRate, 0.005);
+        smoothedRate.setCurrentAndTargetValue(*rateParam);
+        smoothedDepth.setCurrentAndTargetValue(*depthParam);
+    }
+
+    void processBlock(juce::AudioBuffer<float>& buffer, juce::MidiBuffer& midiMessages) override {
+        juce::ignoreUnused(midiMessages);
+
+        const int numSamples = buffer.getNumSamples();
+        if (numSamples == 0 || buffer.getNumChannels() < 2)
+            return;
+
+        const float* cvRate = (buffer.getNumChannels() > 2) ? buffer.getReadPointer(2) : nullptr;
+        const float* cvDepth = (buffer.getNumChannels() > 3) ? buffer.getReadPointer(3) : nullptr;
+
+        float cvRateVal = cvRate ? cvRate[0] : 0.0f;
+        float cvDepthVal = cvDepth ? cvDepth[0] : 0.0f;
+
+        smoothedRate.setTargetValue(*rateParam);
+        smoothedDepth.setTargetValue(*depthParam);
+
+        float rate = juce::jlimit(0.1f, 10.0f, smoothedRate.getCurrentValue() + cvRateVal * 5.0f);
+        float depth = juce::jlimit(0.0f, 1.0f, smoothedDepth.getCurrentValue() + cvDepthVal);
+
+        chorus.setRate(rate);
+        chorus.setDepth(depth);
+        chorus.setCentreDelay(*centreDelayParam);
+        chorus.setFeedback(*feedbackParam);
+        chorus.setMix(*mixParam);
+
+        juce::dsp::AudioBlock<float> fullBlock(buffer);
+        juce::dsp::AudioBlock<float> audioBlock = fullBlock.getSubsetChannelBlock(0, 2);
+        juce::dsp::ProcessContextReplacing<float> context(audioBlock);
+        chorus.process(context);
+
+        smoothedRate.skip(numSamples);
+        smoothedDepth.skip(numSamples);
+
+        for (int ch = 2; ch < buffer.getNumChannels(); ++ch)
+            buffer.clear(ch, 0, numSamples);
+    }
+
+    juce::String getInputPortLabel(int i) const override {
+        const juce::String labels[] = {"Left", "Right", "Rate", "Depth"};
+        return (i >= 0 && i < 4) ? labels[i] : ModuleBase::getInputPortLabel(i);
+    }
+    juce::String getOutputPortLabel(int i) const override { return i == 0 ? "Left" : "Right"; }
+
+    std::vector<ModulationTarget> getModulationTargets() const override { return {{"Rate", 2}, {"Depth", 3}}; }
+    ModulationCategory getModulationCategory() const override { return ModulationCategory::FX; }
+    ModuleType getModuleType() const override { return ModuleType::Chorus; }
+
+private:
+    juce::dsp::Chorus<float> chorus;
+
+    juce::SmoothedValue<float, juce::ValueSmoothingTypes::Linear> smoothedRate;
+    juce::SmoothedValue<float, juce::ValueSmoothingTypes::Linear> smoothedDepth;
+
+    juce::AudioParameterFloat* rateParam;
+    juce::AudioParameterFloat* depthParam;
+    juce::AudioParameterFloat* centreDelayParam;
+    juce::AudioParameterFloat* feedbackParam;
+    juce::AudioParameterFloat* mixParam;
+};

--- a/Source/Modules/FX/CompressorModule.h
+++ b/Source/Modules/FX/CompressorModule.h
@@ -1,0 +1,80 @@
+#pragma once
+
+#include "../ModuleBase.h"
+#include <juce_dsp/juce_dsp.h>
+
+class CompressorModule : public ModuleBase {
+public:
+    CompressorModule()
+        : ModuleBase("Compressor", 2, 2) {
+        addParameter(thresholdParam =
+                         new juce::AudioParameterFloat("threshold", "Threshold (dB)", -60.0f, 0.0f, -12.0f));
+        addParameter(ratioParam = new juce::AudioParameterFloat("ratio", "Ratio", 1.0f, 20.0f, 4.0f));
+        addParameter(attackParam = new juce::AudioParameterFloat("attack", "Attack (ms)", 0.1f, 200.0f, 10.0f));
+        addParameter(releaseParam = new juce::AudioParameterFloat("release", "Release (ms)", 10.0f, 1000.0f, 100.0f));
+        addParameter(makeupGainParam =
+                         new juce::AudioParameterFloat("makeupGain", "Makeup Gain (dB)", 0.0f, 24.0f, 0.0f));
+    }
+
+    void prepareToPlay(double sampleRate, int samplesPerBlock) override {
+        juce::dsp::ProcessSpec spec;
+        spec.sampleRate = sampleRate;
+        spec.maximumBlockSize = (juce::uint32)samplesPerBlock;
+        spec.numChannels = 2;
+        compressor.prepare(spec);
+        compressor.reset();
+
+        smoothedThreshold.reset(sampleRate, 0.01);
+        smoothedMakeupGain.reset(sampleRate, 0.005);
+        smoothedThreshold.setCurrentAndTargetValue(*thresholdParam);
+        smoothedMakeupGain.setCurrentAndTargetValue(*makeupGainParam);
+    }
+
+    void processBlock(juce::AudioBuffer<float>& buffer, juce::MidiBuffer& midiMessages) override {
+        juce::ignoreUnused(midiMessages);
+
+        const int numSamples = buffer.getNumSamples();
+        if (numSamples == 0 || buffer.getNumChannels() < 2)
+            return;
+
+        smoothedThreshold.setTargetValue(*thresholdParam);
+        smoothedMakeupGain.setTargetValue(*makeupGainParam);
+
+        compressor.setThreshold(smoothedThreshold.getCurrentValue());
+        compressor.setRatio(*ratioParam);
+        compressor.setAttack(*attackParam);
+        compressor.setRelease(*releaseParam);
+
+        juce::dsp::AudioBlock<float> block(buffer);
+        juce::dsp::ProcessContextReplacing<float> context(block);
+        compressor.process(context);
+
+        // Apply makeup gain per-sample (smoothed)
+        for (int i = 0; i < numSamples; ++i) {
+            float linearGain = juce::Decibels::decibelsToGain(smoothedMakeupGain.getNextValue());
+            buffer.getWritePointer(0)[i] *= linearGain;
+            buffer.getWritePointer(1)[i] *= linearGain;
+        }
+
+        smoothedThreshold.skip(numSamples);
+    }
+
+    juce::String getInputPortLabel(int i) const override { return i == 0 ? "Left" : "Right"; }
+    juce::String getOutputPortLabel(int i) const override { return i == 0 ? "Left" : "Right"; }
+
+    std::vector<ModulationTarget> getModulationTargets() const override { return {}; }
+    ModulationCategory getModulationCategory() const override { return ModulationCategory::FX; }
+    ModuleType getModuleType() const override { return ModuleType::Compressor; }
+
+private:
+    juce::dsp::Compressor<float> compressor;
+
+    juce::SmoothedValue<float, juce::ValueSmoothingTypes::Linear> smoothedThreshold;
+    juce::SmoothedValue<float, juce::ValueSmoothingTypes::Linear> smoothedMakeupGain;
+
+    juce::AudioParameterFloat* thresholdParam;
+    juce::AudioParameterFloat* ratioParam;
+    juce::AudioParameterFloat* attackParam;
+    juce::AudioParameterFloat* releaseParam;
+    juce::AudioParameterFloat* makeupGainParam;
+};

--- a/Source/Modules/FX/DelayModule.h
+++ b/Source/Modules/FX/DelayModule.h
@@ -65,6 +65,9 @@ public:
         writePos = localWritePos;
     }
 
+    juce::String getInputPortLabel(int i) const override { return i == 0 ? "Left" : "Right"; }
+    juce::String getOutputPortLabel(int i) const override { return i == 0 ? "Left" : "Right"; }
+
     std::vector<ModulationTarget> getModulationTargets() const override {
         return {{"Time", 2}, {"Feedback", 3}, {"Mix", 4}};
     }

--- a/Source/Modules/FX/DistortionModule.h
+++ b/Source/Modules/FX/DistortionModule.h
@@ -88,6 +88,12 @@ public:
         }
     }
 
+    juce::String getInputPortLabel(int i) const override {
+        const juce::String labels[] = {"Left", "Right", "Drive", "Mix"};
+        return (i >= 0 && i < 4) ? labels[i] : ModuleBase::getInputPortLabel(i);
+    }
+    juce::String getOutputPortLabel(int i) const override { return i == 0 ? "Left" : "Right"; }
+
     std::vector<ModulationTarget> getModulationTargets() const override { return {{"Drive", 2}, {"Mix", 3}}; }
 
     ModulationCategory getModulationCategory() const override { return ModulationCategory::FX; }

--- a/Source/Modules/FX/FlangerModule.h
+++ b/Source/Modules/FX/FlangerModule.h
@@ -1,0 +1,90 @@
+#pragma once
+
+#include "../ModuleBase.h"
+#include <juce_dsp/juce_dsp.h>
+
+class FlangerModule : public ModuleBase {
+public:
+    FlangerModule()
+        : ModuleBase("Flanger", 4, 2) {
+        addParameter(rateParam = new juce::AudioParameterFloat("rate", "Rate (Hz)", 0.05f, 5.0f, 0.3f));
+        addParameter(depthParam = new juce::AudioParameterFloat("depth", "Depth", 0.0f, 1.0f, 0.7f));
+        addParameter(centreDelayParam =
+                         new juce::AudioParameterFloat("centreDelay", "Centre Delay (ms)", 1.0f, 5.0f, 2.0f));
+        addParameter(feedbackParam = new juce::AudioParameterFloat("feedback", "Feedback", -1.0f, 1.0f, 0.5f));
+        addParameter(mixParam = new juce::AudioParameterFloat("mix", "Mix", 0.0f, 1.0f, 0.5f));
+    }
+
+    void prepareToPlay(double sampleRate, int samplesPerBlock) override {
+        juce::dsp::ProcessSpec spec;
+        spec.sampleRate = sampleRate;
+        spec.maximumBlockSize = (juce::uint32)samplesPerBlock;
+        spec.numChannels = 2;
+        flanger.prepare(spec);
+        flanger.reset();
+
+        smoothedRate.reset(sampleRate, 0.05);
+        smoothedDepth.reset(sampleRate, 0.005);
+        smoothedRate.setCurrentAndTargetValue(*rateParam);
+        smoothedDepth.setCurrentAndTargetValue(*depthParam);
+    }
+
+    void processBlock(juce::AudioBuffer<float>& buffer, juce::MidiBuffer& midiMessages) override {
+        juce::ignoreUnused(midiMessages);
+
+        const int numSamples = buffer.getNumSamples();
+        if (numSamples == 0 || buffer.getNumChannels() < 2)
+            return;
+
+        const float* cvRate = (buffer.getNumChannels() > 2) ? buffer.getReadPointer(2) : nullptr;
+        const float* cvDepth = (buffer.getNumChannels() > 3) ? buffer.getReadPointer(3) : nullptr;
+
+        float cvRateVal = cvRate ? cvRate[0] : 0.0f;
+        float cvDepthVal = cvDepth ? cvDepth[0] : 0.0f;
+
+        smoothedRate.setTargetValue(*rateParam);
+        smoothedDepth.setTargetValue(*depthParam);
+
+        float rate = juce::jlimit(0.05f, 5.0f, smoothedRate.getCurrentValue() + cvRateVal * 2.5f);
+        float depth = juce::jlimit(0.0f, 1.0f, smoothedDepth.getCurrentValue() + cvDepthVal);
+
+        flanger.setRate(rate);
+        flanger.setDepth(depth);
+        flanger.setCentreDelay(std::max(1.0f, (float)*centreDelayParam));
+        flanger.setFeedback(*feedbackParam);
+        flanger.setMix(*mixParam);
+
+        juce::dsp::AudioBlock<float> fullBlock(buffer);
+        juce::dsp::AudioBlock<float> audioBlock = fullBlock.getSubsetChannelBlock(0, 2);
+        juce::dsp::ProcessContextReplacing<float> context(audioBlock);
+        flanger.process(context);
+
+        smoothedRate.skip(numSamples);
+        smoothedDepth.skip(numSamples);
+
+        for (int ch = 2; ch < buffer.getNumChannels(); ++ch)
+            buffer.clear(ch, 0, numSamples);
+    }
+
+    juce::String getInputPortLabel(int i) const override {
+        const juce::String labels[] = {"Left", "Right", "Rate", "Depth"};
+        return (i >= 0 && i < 4) ? labels[i] : ModuleBase::getInputPortLabel(i);
+    }
+    juce::String getOutputPortLabel(int i) const override { return i == 0 ? "Left" : "Right"; }
+
+    std::vector<ModulationTarget> getModulationTargets() const override { return {{"Rate", 2}, {"Depth", 3}}; }
+    ModulationCategory getModulationCategory() const override { return ModulationCategory::FX; }
+    ModuleType getModuleType() const override { return ModuleType::Flanger; }
+
+private:
+    juce::dsp::Chorus<float> flanger;
+
+    juce::SmoothedValue<float, juce::ValueSmoothingTypes::Linear> smoothedRate;
+    juce::SmoothedValue<float, juce::ValueSmoothingTypes::Linear> smoothedDepth;
+
+    juce::AudioParameterFloat* rateParam;
+    juce::AudioParameterFloat* depthParam;
+    juce::AudioParameterFloat* centreDelayParam;
+    juce::AudioParameterFloat* feedbackParam;
+    juce::AudioParameterFloat* mixParam;
+};

--- a/Source/Modules/FX/LimiterModule.h
+++ b/Source/Modules/FX/LimiterModule.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include "../ModuleBase.h"
+#include <juce_dsp/juce_dsp.h>
+
+class LimiterModule : public ModuleBase {
+public:
+    LimiterModule()
+        : ModuleBase("Limiter", 2, 2) {
+        addParameter(thresholdParam =
+                         new juce::AudioParameterFloat("threshold", "Threshold (dB)", -20.0f, 0.0f, -1.0f));
+        addParameter(releaseParam = new juce::AudioParameterFloat("release", "Release (ms)", 1.0f, 500.0f, 100.0f));
+        addParameter(inputGainParam =
+                         new juce::AudioParameterFloat("inputGain", "Input Gain (dB)", -12.0f, 12.0f, 0.0f));
+    }
+
+    void prepareToPlay(double sampleRate, int samplesPerBlock) override {
+        juce::dsp::ProcessSpec spec;
+        spec.sampleRate = sampleRate;
+        spec.maximumBlockSize = (juce::uint32)samplesPerBlock;
+        spec.numChannels = 2;
+        limiter.prepare(spec);
+        limiter.reset();
+
+        smoothedInputGain.reset(sampleRate, 0.005);
+        smoothedInputGain.setCurrentAndTargetValue(*inputGainParam);
+    }
+
+    void processBlock(juce::AudioBuffer<float>& buffer, juce::MidiBuffer& midiMessages) override {
+        juce::ignoreUnused(midiMessages);
+
+        const int numSamples = buffer.getNumSamples();
+        if (numSamples == 0 || buffer.getNumChannels() < 2)
+            return;
+
+        smoothedInputGain.setTargetValue(*inputGainParam);
+        limiter.setThreshold(*thresholdParam);
+        limiter.setRelease(*releaseParam);
+
+        // Apply input gain per-sample (smoothed)
+        for (int i = 0; i < numSamples; ++i) {
+            float gain = juce::Decibels::decibelsToGain(smoothedInputGain.getNextValue());
+            buffer.getWritePointer(0)[i] *= gain;
+            buffer.getWritePointer(1)[i] *= gain;
+        }
+
+        juce::dsp::AudioBlock<float> block(buffer);
+        juce::dsp::ProcessContextReplacing<float> context(block);
+        limiter.process(context);
+    }
+
+    juce::String getInputPortLabel(int i) const override { return i == 0 ? "Left" : "Right"; }
+    juce::String getOutputPortLabel(int i) const override { return i == 0 ? "Left" : "Right"; }
+
+    std::vector<ModulationTarget> getModulationTargets() const override { return {}; }
+    ModulationCategory getModulationCategory() const override { return ModulationCategory::FX; }
+    ModuleType getModuleType() const override { return ModuleType::Limiter; }
+
+private:
+    juce::dsp::Limiter<float> limiter;
+
+    juce::SmoothedValue<float, juce::ValueSmoothingTypes::Linear> smoothedInputGain;
+
+    juce::AudioParameterFloat* thresholdParam;
+    juce::AudioParameterFloat* releaseParam;
+    juce::AudioParameterFloat* inputGainParam;
+};

--- a/Source/Modules/FX/PhaserModule.h
+++ b/Source/Modules/FX/PhaserModule.h
@@ -1,0 +1,90 @@
+#pragma once
+
+#include "../ModuleBase.h"
+#include <juce_dsp/juce_dsp.h>
+
+class PhaserModule : public ModuleBase {
+public:
+    PhaserModule()
+        : ModuleBase("Phaser", 4, 2) {
+        addParameter(rateParam = new juce::AudioParameterFloat("rate", "Rate (Hz)", 0.1f, 20.0f, 1.0f));
+        addParameter(depthParam = new juce::AudioParameterFloat("depth", "Depth", 0.0f, 1.0f, 0.5f));
+        addParameter(centreFreqParam =
+                         new juce::AudioParameterFloat("centreFreq", "Centre Freq (Hz)", 200.0f, 10000.0f, 1300.0f));
+        addParameter(feedbackParam = new juce::AudioParameterFloat("feedback", "Feedback", -1.0f, 1.0f, 0.0f));
+        addParameter(mixParam = new juce::AudioParameterFloat("mix", "Mix", 0.0f, 1.0f, 0.5f));
+    }
+
+    void prepareToPlay(double sampleRate, int samplesPerBlock) override {
+        juce::dsp::ProcessSpec spec;
+        spec.sampleRate = sampleRate;
+        spec.maximumBlockSize = (juce::uint32)samplesPerBlock;
+        spec.numChannels = 2;
+        phaser.prepare(spec);
+        phaser.reset();
+
+        smoothedRate.reset(sampleRate, 0.05);
+        smoothedDepth.reset(sampleRate, 0.005);
+        smoothedRate.setCurrentAndTargetValue(*rateParam);
+        smoothedDepth.setCurrentAndTargetValue(*depthParam);
+    }
+
+    void processBlock(juce::AudioBuffer<float>& buffer, juce::MidiBuffer& midiMessages) override {
+        juce::ignoreUnused(midiMessages);
+
+        const int numSamples = buffer.getNumSamples();
+        if (numSamples == 0 || buffer.getNumChannels() < 2)
+            return;
+
+        const float* cvRate = (buffer.getNumChannels() > 2) ? buffer.getReadPointer(2) : nullptr;
+        const float* cvDepth = (buffer.getNumChannels() > 3) ? buffer.getReadPointer(3) : nullptr;
+
+        float cvRateVal = cvRate ? cvRate[0] : 0.0f;
+        float cvDepthVal = cvDepth ? cvDepth[0] : 0.0f;
+
+        smoothedRate.setTargetValue(*rateParam);
+        smoothedDepth.setTargetValue(*depthParam);
+
+        float rate = juce::jlimit(0.1f, 20.0f, smoothedRate.getCurrentValue() + cvRateVal * 10.0f);
+        float depth = juce::jlimit(0.0f, 1.0f, smoothedDepth.getCurrentValue() + cvDepthVal);
+
+        phaser.setRate(rate);
+        phaser.setDepth(depth);
+        phaser.setCentreFrequency(*centreFreqParam);
+        phaser.setFeedback(*feedbackParam);
+        phaser.setMix(*mixParam);
+
+        juce::dsp::AudioBlock<float> fullBlock(buffer);
+        juce::dsp::AudioBlock<float> audioBlock = fullBlock.getSubsetChannelBlock(0, 2);
+        juce::dsp::ProcessContextReplacing<float> context(audioBlock);
+        phaser.process(context);
+
+        smoothedRate.skip(numSamples);
+        smoothedDepth.skip(numSamples);
+
+        for (int ch = 2; ch < buffer.getNumChannels(); ++ch)
+            buffer.clear(ch, 0, numSamples);
+    }
+
+    juce::String getInputPortLabel(int i) const override {
+        const juce::String labels[] = {"Left", "Right", "Rate", "Depth"};
+        return (i >= 0 && i < 4) ? labels[i] : ModuleBase::getInputPortLabel(i);
+    }
+    juce::String getOutputPortLabel(int i) const override { return i == 0 ? "Left" : "Right"; }
+
+    std::vector<ModulationTarget> getModulationTargets() const override { return {{"Rate", 2}, {"Depth", 3}}; }
+    ModulationCategory getModulationCategory() const override { return ModulationCategory::FX; }
+    ModuleType getModuleType() const override { return ModuleType::Phaser; }
+
+private:
+    juce::dsp::Phaser<float> phaser;
+
+    juce::SmoothedValue<float, juce::ValueSmoothingTypes::Linear> smoothedRate;
+    juce::SmoothedValue<float, juce::ValueSmoothingTypes::Linear> smoothedDepth;
+
+    juce::AudioParameterFloat* rateParam;
+    juce::AudioParameterFloat* depthParam;
+    juce::AudioParameterFloat* centreFreqParam;
+    juce::AudioParameterFloat* feedbackParam;
+    juce::AudioParameterFloat* mixParam;
+};

--- a/Source/Modules/FX/ReverbModule.h
+++ b/Source/Modules/FX/ReverbModule.h
@@ -37,6 +37,9 @@ public:
         }
     }
 
+    juce::String getInputPortLabel(int i) const override { return i == 0 ? "Left" : "Right"; }
+    juce::String getOutputPortLabel(int i) const override { return i == 0 ? "Left" : "Right"; }
+
     std::vector<ModulationTarget> getModulationTargets() const override {
         return {{"Size", 2}, {"Damping", 3}, {"Wet", 4}, {"Dry", 5}, {"Width", 6}};
     }

--- a/Source/Modules/FilterModule.h
+++ b/Source/Modules/FilterModule.h
@@ -132,6 +132,11 @@ public:
     std::vector<ModulationTarget> getModulationTargets() const override {
         return {{"Cutoff", 1}, {"Resonance", 2}, {"Drive", 3}};
     }
+    juce::String getInputPortLabel(int i) const override {
+        const juce::String labels[] = {"Audio", "Cutoff", "Resonance", "Drive"};
+        return (i >= 0 && i < 4) ? labels[i] : ModuleBase::getInputPortLabel(i);
+    }
+    juce::String getOutputPortLabel(int) const override { return "Audio"; }
     ModulationCategory getModulationCategory() const override { return ModulationCategory::Filter; }
     ModuleType getModuleType() const override { return ModuleType::Filter; }
 

--- a/Source/Modules/LFOModule.h
+++ b/Source/Modules/LFOModule.h
@@ -184,6 +184,7 @@ public:
     bool producesMidi() const override { return false; }
 
     ModulationCategory getModulationCategory() const override { return ModulationCategory::LFO; }
+    juce::String getOutputPortLabel(int) const override { return "CV"; }
     ModuleType getModuleType() const override { return ModuleType::LFO; }
 
 private:

--- a/Source/Modules/MidiKeyboardModule.h
+++ b/Source/Modules/MidiKeyboardModule.h
@@ -13,7 +13,7 @@ class MidiKeyboardModule : public ModuleBase {
 public:
     MidiKeyboardModule()
         : ModuleBase("MIDI Keyboard", 0, 0) {
-        addParameter(octaveParam = new juce::AudioParameterInt("octave", "Octave", -2, 2, 0));
+        addParameter(octaveParam = new juce::AudioParameterInt(juce::ParameterID("octave", 1), "Octave", -2, 2, 0));
     }
 
     bool producesMidi() const override { return true; }

--- a/Source/Modules/ModuleBase.h
+++ b/Source/Modules/ModuleBase.h
@@ -26,7 +26,12 @@ enum class ModuleType {
     Attenuverter,
     Delay,
     Distortion,
-    Reverb
+    Reverb,
+    Chorus,
+    Phaser,
+    Compressor,
+    Flanger,
+    Limiter
 };
 
 class ModuleBase : public juce::AudioProcessor {
@@ -92,6 +97,8 @@ public:
     void setModuleName(const juce::String& name) { moduleName = name; }
 
     virtual std::vector<ModulationTarget> getModulationTargets() const { return {}; }
+    virtual juce::String getInputPortLabel(int channelIndex) const { return "In " + juce::String(channelIndex); }
+    virtual juce::String getOutputPortLabel(int channelIndex) const { return "Out " + juce::String(channelIndex); }
     virtual ModulationCategory getModulationCategory() const { return ModulationCategory::Other; }
     virtual ModuleType getModuleType() const = 0;
 

--- a/Source/Modules/OscillatorModule.h
+++ b/Source/Modules/OscillatorModule.h
@@ -10,8 +10,8 @@ public:
     {
         addParameter(waveformParam = new juce::AudioParameterChoice("waveform", "Waveform",
                                                                     {"Sine", "Square", "Saw", "Triangle"}, 0));
-        addParameter(octaveParam = new juce::AudioParameterInt("octave", "Octave", -4, 4, 0));
-        addParameter(coarseParam = new juce::AudioParameterInt("coarse", "Coarse", -12, 12, 0));
+        addParameter(octaveParam = new juce::AudioParameterInt(juce::ParameterID("octave", 1), "Octave", -4, 4, 0));
+        addParameter(coarseParam = new juce::AudioParameterInt(juce::ParameterID("coarse", 1), "Coarse", -12, 12, 0));
         addParameter(fineParam = new juce::AudioParameterFloat("fine", "Fine", -100.0f, 100.0f, 0.0f));
         addParameter(levelParam = new juce::AudioParameterFloat("level", "Level", 0.0f, 1.0f, 1.0f));
 
@@ -185,6 +185,11 @@ public:
     std::vector<ModulationTarget> getModulationTargets() const override {
         return {{"Pitch", 0}, {"Waveform", 1}, {"Octave", 2}, {"Coarse", 3}, {"Fine", 4}, {"Level", 5}};
     }
+    juce::String getInputPortLabel(int i) const override {
+        const juce::String labels[] = {"Pitch", "Waveform", "Octave", "Coarse", "Fine", "Level"};
+        return (i >= 0 && i < 6) ? labels[i] : ModuleBase::getInputPortLabel(i);
+    }
+    juce::String getOutputPortLabel(int) const override { return "Audio"; }
     ModulationCategory getModulationCategory() const override { return ModulationCategory::Oscillator; }
     ModuleType getModuleType() const override { return ModuleType::Oscillator; }
 

--- a/Source/Modules/SequencerModule.h
+++ b/Source/Modules/SequencerModule.h
@@ -41,8 +41,12 @@ public:
                 return text.getIntValue();
             };
 
-            addParameter(stepParams[i] = new juce::AudioParameterInt(name, name, 0, 127, defaults[i], "", stringFromInt,
-                                                                     valueFromText));
+            addParameter(
+                stepParams[i] = new juce::AudioParameterInt(
+                    juce::ParameterID(name, 1), name, 0, 127, defaults[i],
+                    juce::AudioParameterIntAttributes()
+                        .withStringFromValueFunction([stringFromInt](int v, int len) { return stringFromInt(v, len); })
+                        .withValueFromStringFunction(valueFromText)));
         }
 
         // Filter Envelope Amounts

--- a/Source/Modules/VCAModule.h
+++ b/Source/Modules/VCAModule.h
@@ -41,6 +41,8 @@ public:
     }
 
     std::vector<ModulationTarget> getModulationTargets() const override { return {{"CV", 1}}; }
+    juce::String getInputPortLabel(int i) const override { return i == 0 ? "Audio" : "CV"; }
+    juce::String getOutputPortLabel(int) const override { return "Audio"; }
     ModuleType getModuleType() const override { return ModuleType::VCA; }
 
 private:

--- a/Source/UI/GraphEditor.cpp
+++ b/Source/UI/GraphEditor.cpp
@@ -2,8 +2,13 @@
 #include "../AI/AIStateMapper.h"
 #include "../Modules/ADSRModule.h"
 #include "../Modules/AttenuverterModule.h"
+#include "../Modules/FX/ChorusModule.h"
+#include "../Modules/FX/CompressorModule.h"
 #include "../Modules/FX/DelayModule.h"
 #include "../Modules/FX/DistortionModule.h"
+#include "../Modules/FX/FlangerModule.h"
+#include "../Modules/FX/LimiterModule.h"
+#include "../Modules/FX/PhaserModule.h"
 #include "../Modules/FX/ReverbModule.h"
 #include "../Modules/FilterModule.h"
 #include "../Modules/LFOModule.h"
@@ -619,6 +624,16 @@ void GraphEditor::itemDropped(const SourceDetails& dragSourceDetails) {
         newProcessor = std::make_unique<MidiKeyboardModule>();
     else if (name == "Attenuverter")
         newProcessor = std::make_unique<AttenuverterModule>();
+    else if (name == "Chorus")
+        newProcessor = std::make_unique<ChorusModule>();
+    else if (name == "Phaser")
+        newProcessor = std::make_unique<PhaserModule>();
+    else if (name == "Compressor")
+        newProcessor = std::make_unique<CompressorModule>();
+    else if (name == "Flanger")
+        newProcessor = std::make_unique<FlangerModule>();
+    else if (name == "Limiter")
+        newProcessor = std::make_unique<LimiterModule>();
 
     if (newProcessor) {
         auto& graph = audioEngine.getGraph();

--- a/Source/UI/ModuleComponent.cpp
+++ b/Source/UI/ModuleComponent.cpp
@@ -265,38 +265,10 @@ void ModuleComponent::paint(juce::Graphics& g) {
         g.fillEllipse(p.x - 5, p.y - 5, 10, 10);
 
         juce::String label = "In " + juce::String(i);
-        // Custom labels for Oscillator
-        if (getType(module) == ModuleType::Oscillator) {
-            if (i == 0)
-                label = "Pitch CV";
-            else if (i == 1)
-                label = "Wave CV";
-            else if (i == 2)
-                label = "Oct CV";
-            else if (i == 3)
-                label = "Crs CV";
-            else if (i == 4)
-                label = "Fine CV";
-            else if (i == 5)
-                label = "Level CV";
-        }
-        // Custom labels for Filter
-        if (getType(module) == ModuleType::Filter) {
-            if (i == 0)
-                label = "Audio";
-            if (i == 1)
-                label = "Cutoff CV";
-            if (i == 2)
-                label = "Res CV";
-            if (i == 3)
-                label = "Drive CV";
-        }
-        if (getType(module) == ModuleType::VCA) {
-            if (i == 0)
-                label = "Audio";
-            if (i == 1)
-                label = "CV";
-        }
+        if (auto* mb = dynamic_cast<ModuleBase*>(module))
+            label = mb->getInputPortLabel(i);
+        else if (dynamic_cast<juce::AudioProcessorGraph::AudioGraphIOProcessor*>(module))
+            label = (i == 0) ? "Left" : (i == 1) ? "Right" : "In " + juce::String(i);
 
         g.drawText(label, p.x + 10, p.y - 10, 60, 20, juce::Justification::left, false);
     }
@@ -312,9 +284,10 @@ void ModuleComponent::paint(juce::Graphics& g) {
         g.fillEllipse(p.x - 5, p.y - 5, 10, 10);
 
         juce::String label = "Out " + juce::String(i);
-        if (getType(module) == ModuleType::LFO) {
-            label = "CV Out " + juce::String(i + 1);
-        }
+        if (auto* mb = dynamic_cast<ModuleBase*>(module))
+            label = mb->getOutputPortLabel(i);
+        else if (dynamic_cast<juce::AudioProcessorGraph::AudioGraphIOProcessor*>(module))
+            label = (i == 0) ? "Left" : (i == 1) ? "Right" : "Out " + juce::String(i);
         g.drawText(label, p.x - 70, p.y - 10, 60, 20, juce::Justification::right, false);
     }
 }

--- a/Source/UI/ModuleLibraryComponent.h
+++ b/Source/UI/ModuleLibraryComponent.h
@@ -6,37 +6,93 @@ class ModuleLibraryComponent
     : public juce::Component
     , public juce::DragAndDropContainer {
 public:
+    struct Entry {
+        juce::String text;
+        bool isHeader;
+    };
+
     ModuleLibraryComponent() {
-        moduleNames = {"Oscillator", "Filter",     "LFO",   "ADSR",   "VCA",
-                       "Sequencer",  "Distortion", "Delay", "Reverb", "MidiKeyboard"};
+        entries = {
+            {"Sources", true},
+            {"Oscillator", false},
+            {"LFO", false},
+            {"Sequencing", true},
+            {"Sequencer", false},
+            {"MidiKeyboard", false},
+            {"Envelopes & Control", true},
+            {"ADSR", false},
+            {"VCA", false},
+            {"Filters", true},
+            {"Filter", false},
+            {"Modulation FX", true},
+            {"Chorus", false},
+            {"Phaser", false},
+            {"Flanger", false},
+            {"Distortion", false},
+            {"Time FX", true},
+            {"Delay", false},
+            {"Reverb", false},
+            {"Dynamics", true},
+            {"Compressor", false},
+            {"Limiter", false},
+        };
     }
 
     void paint(juce::Graphics& g) override {
         g.fillAll(juce::Colours::darkgrey.darker());
-        g.setColour(juce::Colours::white);
-        g.setFont(18.0f);
 
-        int y = 20;
-        for (const auto& name : moduleNames) {
-            g.drawText(name, 20, y, getWidth() - 40, 30, juce::Justification::centredLeft);
-            y += 40;
+        int y = 10;
+        for (const auto& entry : entries) {
+            if (entry.isHeader) {
+                if (y > 10)
+                    y += 5; // extra spacing before headers (except first)
+                g.setColour(juce::Colours::grey);
+                g.setFont(juce::Font(12.0f));
+                g.drawText(entry.text.toUpperCase(), 10, y, getWidth() - 20, 20, juce::Justification::centredLeft);
+                y += 25;
+            } else {
+                g.setColour(juce::Colours::white);
+                g.setFont(juce::Font(16.0f));
+                g.drawText(entry.text, 20, y, getWidth() - 40, 28, juce::Justification::centredLeft);
+                y += 32;
+            }
         }
     }
 
     void mouseDown(const juce::MouseEvent& e) override {
-        int index = (e.y - 20) / 40;
-        if (index >= 0 && index < moduleNames.size()) {
+        int index = getEntryIndexAt(e.y);
+        if (index >= 0 && index < (int)entries.size() && !entries[index].isHeader) {
             juce::Image dragImage(juce::Image::ARGB, 150, 30, true);
             juce::Graphics dg(dragImage);
             dg.setColour(juce::Colours::white);
-            dg.setFont(18.0f);
-            dg.drawText(moduleNames[index], dragImage.getBounds(), juce::Justification::centred, false);
+            dg.setFont(juce::Font(16.0f));
+            dg.drawText(entries[index].text, dragImage.getBounds(), juce::Justification::centred, false);
 
             if (auto* container = juce::DragAndDropContainer::findParentDragContainerFor(this))
-                container->startDragging(moduleNames[index], this, dragImage);
+                container->startDragging(entries[index].text, this, dragImage);
         }
     }
 
 private:
-    std::vector<juce::String> moduleNames;
+    int getEntryIndexAt(int mouseY) const {
+        int y = 10;
+        for (int i = 0; i < (int)entries.size(); ++i) {
+            if (entries[i].isHeader) {
+                if (y > 10)
+                    y += 5;
+                int h = 25;
+                if (mouseY >= y && mouseY < y + h)
+                    return i;
+                y += h;
+            } else {
+                int h = 32;
+                if (mouseY >= y && mouseY < y + h)
+                    return i;
+                y += h;
+            }
+        }
+        return -1;
+    }
+
+    std::vector<Entry> entries;
 };

--- a/Tests/AIStateMapperTests.cpp
+++ b/Tests/AIStateMapperTests.cpp
@@ -256,7 +256,8 @@ TEST(AIStateMapperTest, FactorySupportsAllModuleTypes) {
     juce::StringArray expectedTypes = {"Audio Input", "Audio Output",   "Midi Input",    "Oscillator", "Filter",
                                        "VCA",         "ADSR",           "Sequencer",     "LFO",        "Distortion",
                                        "Delay",       "Reverb",         "MIDI Keyboard", "Amp Env",    "Filter Env",
-                                       "Poly MIDI",   "Poly Sequencer", "Attenuverter"};
+                                       "Poly MIDI",   "Poly Sequencer", "Attenuverter",  "Chorus",     "Phaser",
+                                       "Compressor",  "Flanger",        "Limiter"};
     for (const auto& type : expectedTypes) {
         auto module = gsynth::AIStateMapper::createModule(type);
         EXPECT_NE(module, nullptr) << "Failed to create module: " << type.toStdString();

--- a/Tests/EdgeCaseTests.cpp
+++ b/Tests/EdgeCaseTests.cpp
@@ -1,6 +1,11 @@
 #include "Modules/ADSRModule.h"
+#include "Modules/FX/ChorusModule.h"
+#include "Modules/FX/CompressorModule.h"
 #include "Modules/FX/DelayModule.h"
 #include "Modules/FX/DistortionModule.h"
+#include "Modules/FX/FlangerModule.h"
+#include "Modules/FX/LimiterModule.h"
+#include "Modules/FX/PhaserModule.h"
 #include "Modules/FX/ReverbModule.h"
 #include "Modules/FilterModule.h"
 #include "Modules/LFOModule.h"
@@ -264,4 +269,54 @@ TEST(EdgeCaseTests, OscillatorAllWaveforms) {
         float rms = buffer.getRMSLevel(0, 0, buffer.getNumSamples());
         EXPECT_GT(rms, 0.0f) << "Waveform " << wf << " should produce non-zero output";
     }
+}
+
+TEST(EdgeCaseTests, ChorusZeroLengthBuffer) {
+    ChorusModule chorus;
+    chorus.prepareToPlay(44100.0, 512);
+
+    juce::AudioBuffer<float> buffer(4, 0);
+    juce::MidiBuffer midi;
+
+    EXPECT_NO_THROW(chorus.processBlock(buffer, midi));
+}
+
+TEST(EdgeCaseTests, PhaserZeroLengthBuffer) {
+    PhaserModule phaser;
+    phaser.prepareToPlay(44100.0, 512);
+
+    juce::AudioBuffer<float> buffer(4, 0);
+    juce::MidiBuffer midi;
+
+    EXPECT_NO_THROW(phaser.processBlock(buffer, midi));
+}
+
+TEST(EdgeCaseTests, CompressorZeroLengthBuffer) {
+    CompressorModule compressor;
+    compressor.prepareToPlay(44100.0, 512);
+
+    juce::AudioBuffer<float> buffer(2, 0);
+    juce::MidiBuffer midi;
+
+    EXPECT_NO_THROW(compressor.processBlock(buffer, midi));
+}
+
+TEST(EdgeCaseTests, FlangerZeroLengthBuffer) {
+    FlangerModule flanger;
+    flanger.prepareToPlay(44100.0, 512);
+
+    juce::AudioBuffer<float> buffer(4, 0);
+    juce::MidiBuffer midi;
+
+    EXPECT_NO_THROW(flanger.processBlock(buffer, midi));
+}
+
+TEST(EdgeCaseTests, LimiterZeroLengthBuffer) {
+    LimiterModule limiter;
+    limiter.prepareToPlay(44100.0, 512);
+
+    juce::AudioBuffer<float> buffer(2, 0);
+    juce::MidiBuffer midi;
+
+    EXPECT_NO_THROW(limiter.processBlock(buffer, midi));
 }

--- a/Tests/FXModuleTests.cpp
+++ b/Tests/FXModuleTests.cpp
@@ -1,7 +1,17 @@
+#include "Modules/ADSRModule.h"
 #include "Modules/AttenuverterModule.h"
+#include "Modules/FX/ChorusModule.h"
+#include "Modules/FX/CompressorModule.h"
 #include "Modules/FX/DelayModule.h"
 #include "Modules/FX/DistortionModule.h"
+#include "Modules/FX/FlangerModule.h"
+#include "Modules/FX/LimiterModule.h"
+#include "Modules/FX/PhaserModule.h"
 #include "Modules/FX/ReverbModule.h"
+#include "Modules/FilterModule.h"
+#include "Modules/LFOModule.h"
+#include "Modules/OscillatorModule.h"
+#include "Modules/VCAModule.h"
 #include <gtest/gtest.h>
 #include <juce_audio_basics/juce_audio_basics.h>
 
@@ -331,4 +341,446 @@ TEST_F(ReverbModuleTest, RoomSizeParameterIsApplied) {
 
     juce::MidiBuffer midi;
     EXPECT_NO_THROW(module->processBlock(buffer, midi));
+}
+
+// ---------------------------------------------------------------------------
+// ChorusModule tests
+// ---------------------------------------------------------------------------
+
+class ChorusModuleTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        module = std::make_unique<ChorusModule>();
+        module->prepareToPlay(44100.0, 512);
+    }
+
+    std::unique_ptr<ChorusModule> module;
+};
+
+TEST_F(ChorusModuleTest, ProcessBlockProducesOutput) {
+    juce::AudioBuffer<float> buffer(4, 512);
+    buffer.clear();
+
+    for (int ch = 0; ch < 2; ++ch)
+        for (int i = 0; i < 512; ++i)
+            buffer.setSample(ch, i, 0.5f);
+
+    juce::MidiBuffer midi;
+    module->processBlock(buffer, midi);
+
+    bool anyNonZero = false;
+    for (int i = 0; i < 512; ++i) {
+        if (buffer.getSample(0, i) != 0.0f) {
+            anyNonZero = true;
+            break;
+        }
+    }
+    EXPECT_TRUE(anyNonZero);
+}
+
+TEST_F(ChorusModuleTest, CVChannelsAreClearedAfterProcessing) {
+    juce::AudioBuffer<float> buffer(4, 512);
+    buffer.clear();
+
+    for (int ch = 0; ch < 2; ++ch)
+        for (int i = 0; i < 512; ++i)
+            buffer.setSample(ch, i, 0.5f);
+
+    for (int i = 0; i < 512; ++i) {
+        buffer.setSample(2, i, 0.3f);
+        buffer.setSample(3, i, 0.2f);
+    }
+
+    juce::MidiBuffer midi;
+    module->processBlock(buffer, midi);
+
+    for (int i = 0; i < 512; ++i) {
+        EXPECT_FLOAT_EQ(buffer.getSample(2, i), 0.0f);
+        EXPECT_FLOAT_EQ(buffer.getSample(3, i), 0.0f);
+    }
+}
+
+TEST_F(ChorusModuleTest, PrepareToPlayAndProcessDoNotCrash) {
+    juce::AudioBuffer<float> buffer(4, 512);
+    buffer.clear();
+    for (int ch = 0; ch < 2; ++ch)
+        for (int i = 0; i < 512; ++i)
+            buffer.setSample(ch, i, 0.3f);
+
+    juce::MidiBuffer midi;
+    EXPECT_NO_THROW(module->processBlock(buffer, midi));
+}
+
+TEST_F(ChorusModuleTest, ModuleTypeAndCategoryAreCorrect) {
+    EXPECT_EQ(module->getModuleType(), ModuleType::Chorus);
+    EXPECT_EQ(module->getModulationCategory(), ModulationCategory::FX);
+}
+
+// ---------------------------------------------------------------------------
+// PhaserModule tests
+// ---------------------------------------------------------------------------
+
+class PhaserModuleTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        module = std::make_unique<PhaserModule>();
+        module->prepareToPlay(44100.0, 512);
+    }
+
+    std::unique_ptr<PhaserModule> module;
+};
+
+TEST_F(PhaserModuleTest, ProcessBlockProducesOutput) {
+    juce::AudioBuffer<float> buffer(4, 512);
+    buffer.clear();
+
+    for (int ch = 0; ch < 2; ++ch)
+        for (int i = 0; i < 512; ++i)
+            buffer.setSample(ch, i, 0.5f);
+
+    juce::MidiBuffer midi;
+    module->processBlock(buffer, midi);
+
+    bool anyNonZero = false;
+    for (int i = 0; i < 512; ++i) {
+        if (buffer.getSample(0, i) != 0.0f) {
+            anyNonZero = true;
+            break;
+        }
+    }
+    EXPECT_TRUE(anyNonZero);
+}
+
+TEST_F(PhaserModuleTest, CVChannelsAreClearedAfterProcessing) {
+    juce::AudioBuffer<float> buffer(4, 512);
+    buffer.clear();
+
+    for (int ch = 0; ch < 2; ++ch)
+        for (int i = 0; i < 512; ++i)
+            buffer.setSample(ch, i, 0.5f);
+
+    for (int i = 0; i < 512; ++i) {
+        buffer.setSample(2, i, 0.3f);
+        buffer.setSample(3, i, 0.2f);
+    }
+
+    juce::MidiBuffer midi;
+    module->processBlock(buffer, midi);
+
+    for (int i = 0; i < 512; ++i) {
+        EXPECT_FLOAT_EQ(buffer.getSample(2, i), 0.0f);
+        EXPECT_FLOAT_EQ(buffer.getSample(3, i), 0.0f);
+    }
+}
+
+TEST_F(PhaserModuleTest, PrepareToPlayAndProcessDoNotCrash) {
+    juce::AudioBuffer<float> buffer(4, 512);
+    buffer.clear();
+    for (int ch = 0; ch < 2; ++ch)
+        for (int i = 0; i < 512; ++i)
+            buffer.setSample(ch, i, 0.3f);
+
+    juce::MidiBuffer midi;
+    EXPECT_NO_THROW(module->processBlock(buffer, midi));
+}
+
+TEST_F(PhaserModuleTest, ModuleTypeAndCategoryAreCorrect) {
+    EXPECT_EQ(module->getModuleType(), ModuleType::Phaser);
+    EXPECT_EQ(module->getModulationCategory(), ModulationCategory::FX);
+}
+
+// ---------------------------------------------------------------------------
+// CompressorModule tests
+// ---------------------------------------------------------------------------
+
+class CompressorModuleTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        module = std::make_unique<CompressorModule>();
+        module->prepareToPlay(44100.0, 512);
+    }
+
+    std::unique_ptr<CompressorModule> module;
+};
+
+TEST_F(CompressorModuleTest, ProcessBlockProducesOutput) {
+    juce::AudioBuffer<float> buffer(2, 512);
+    buffer.clear();
+
+    for (int ch = 0; ch < 2; ++ch)
+        for (int i = 0; i < 512; ++i)
+            buffer.setSample(ch, i, 0.5f);
+
+    juce::MidiBuffer midi;
+    module->processBlock(buffer, midi);
+
+    bool anyNonZero = false;
+    for (int i = 0; i < 512; ++i) {
+        if (buffer.getSample(0, i) != 0.0f) {
+            anyNonZero = true;
+            break;
+        }
+    }
+    EXPECT_TRUE(anyNonZero);
+}
+
+TEST_F(CompressorModuleTest, PrepareToPlayAndProcessDoNotCrash) {
+    juce::AudioBuffer<float> buffer(2, 512);
+    buffer.clear();
+    for (int ch = 0; ch < 2; ++ch)
+        for (int i = 0; i < 512; ++i)
+            buffer.setSample(ch, i, 0.3f);
+
+    juce::MidiBuffer midi;
+    EXPECT_NO_THROW(module->processBlock(buffer, midi));
+}
+
+TEST_F(CompressorModuleTest, ModuleTypeAndCategoryAreCorrect) {
+    EXPECT_EQ(module->getModuleType(), ModuleType::Compressor);
+    EXPECT_EQ(module->getModulationCategory(), ModulationCategory::FX);
+}
+
+// ---------------------------------------------------------------------------
+// FlangerModule tests
+// ---------------------------------------------------------------------------
+
+class FlangerModuleTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        module = std::make_unique<FlangerModule>();
+        module->prepareToPlay(44100.0, 512);
+    }
+
+    std::unique_ptr<FlangerModule> module;
+};
+
+TEST_F(FlangerModuleTest, ProcessBlockProducesOutput) {
+    juce::AudioBuffer<float> buffer(4, 512);
+    buffer.clear();
+
+    for (int ch = 0; ch < 2; ++ch)
+        for (int i = 0; i < 512; ++i)
+            buffer.setSample(ch, i, 0.5f);
+
+    juce::MidiBuffer midi;
+    module->processBlock(buffer, midi);
+
+    bool anyNonZero = false;
+    for (int i = 0; i < 512; ++i) {
+        if (buffer.getSample(0, i) != 0.0f) {
+            anyNonZero = true;
+            break;
+        }
+    }
+    EXPECT_TRUE(anyNonZero);
+}
+
+TEST_F(FlangerModuleTest, CVChannelsAreClearedAfterProcessing) {
+    juce::AudioBuffer<float> buffer(4, 512);
+    buffer.clear();
+
+    for (int ch = 0; ch < 2; ++ch)
+        for (int i = 0; i < 512; ++i)
+            buffer.setSample(ch, i, 0.5f);
+
+    for (int i = 0; i < 512; ++i) {
+        buffer.setSample(2, i, 0.3f);
+        buffer.setSample(3, i, 0.2f);
+    }
+
+    juce::MidiBuffer midi;
+    module->processBlock(buffer, midi);
+
+    for (int i = 0; i < 512; ++i) {
+        EXPECT_FLOAT_EQ(buffer.getSample(2, i), 0.0f);
+        EXPECT_FLOAT_EQ(buffer.getSample(3, i), 0.0f);
+    }
+}
+
+TEST_F(FlangerModuleTest, PrepareToPlayAndProcessDoNotCrash) {
+    juce::AudioBuffer<float> buffer(4, 512);
+    buffer.clear();
+    for (int ch = 0; ch < 2; ++ch)
+        for (int i = 0; i < 512; ++i)
+            buffer.setSample(ch, i, 0.3f);
+
+    juce::MidiBuffer midi;
+    EXPECT_NO_THROW(module->processBlock(buffer, midi));
+}
+
+TEST_F(FlangerModuleTest, ModuleTypeAndCategoryAreCorrect) {
+    EXPECT_EQ(module->getModuleType(), ModuleType::Flanger);
+    EXPECT_EQ(module->getModulationCategory(), ModulationCategory::FX);
+}
+
+// ---------------------------------------------------------------------------
+// LimiterModule tests
+// ---------------------------------------------------------------------------
+
+class LimiterModuleTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        module = std::make_unique<LimiterModule>();
+        module->prepareToPlay(44100.0, 512);
+    }
+
+    std::unique_ptr<LimiterModule> module;
+};
+
+TEST_F(LimiterModuleTest, ProcessBlockProducesOutput) {
+    juce::AudioBuffer<float> buffer(2, 512);
+    buffer.clear();
+
+    for (int ch = 0; ch < 2; ++ch)
+        for (int i = 0; i < 512; ++i)
+            buffer.setSample(ch, i, 0.5f);
+
+    juce::MidiBuffer midi;
+    module->processBlock(buffer, midi);
+
+    bool anyNonZero = false;
+    for (int i = 0; i < 512; ++i) {
+        if (buffer.getSample(0, i) != 0.0f) {
+            anyNonZero = true;
+            break;
+        }
+    }
+    EXPECT_TRUE(anyNonZero);
+}
+
+TEST_F(LimiterModuleTest, PrepareToPlayAndProcessDoNotCrash) {
+    juce::AudioBuffer<float> buffer(2, 512);
+    buffer.clear();
+    for (int ch = 0; ch < 2; ++ch)
+        for (int i = 0; i < 512; ++i)
+            buffer.setSample(ch, i, 0.3f);
+
+    juce::MidiBuffer midi;
+    EXPECT_NO_THROW(module->processBlock(buffer, midi));
+}
+
+TEST_F(LimiterModuleTest, ModuleTypeAndCategoryAreCorrect) {
+    EXPECT_EQ(module->getModuleType(), ModuleType::Limiter);
+    EXPECT_EQ(module->getModulationCategory(), ModulationCategory::FX);
+}
+
+// ---------------------------------------------------------------------------
+// Port Label tests
+// ---------------------------------------------------------------------------
+
+TEST(PortLabelTests, OscillatorPortLabels) {
+    OscillatorModule osc;
+    EXPECT_EQ(osc.getInputPortLabel(0), "Pitch");
+    EXPECT_EQ(osc.getInputPortLabel(1), "Waveform");
+    EXPECT_EQ(osc.getInputPortLabel(2), "Octave");
+    EXPECT_EQ(osc.getInputPortLabel(3), "Coarse");
+    EXPECT_EQ(osc.getInputPortLabel(4), "Fine");
+    EXPECT_EQ(osc.getInputPortLabel(5), "Level");
+    EXPECT_EQ(osc.getOutputPortLabel(0), "Audio");
+}
+
+TEST(PortLabelTests, FilterPortLabels) {
+    FilterModule filter;
+    EXPECT_EQ(filter.getInputPortLabel(0), "Audio");
+    EXPECT_EQ(filter.getInputPortLabel(1), "Cutoff");
+    EXPECT_EQ(filter.getInputPortLabel(2), "Resonance");
+    EXPECT_EQ(filter.getInputPortLabel(3), "Drive");
+    EXPECT_EQ(filter.getOutputPortLabel(0), "Audio");
+}
+
+TEST(PortLabelTests, VCAPortLabels) {
+    VCAModule vca;
+    EXPECT_EQ(vca.getInputPortLabel(0), "Audio");
+    EXPECT_EQ(vca.getInputPortLabel(1), "CV");
+    EXPECT_EQ(vca.getOutputPortLabel(0), "Audio");
+}
+
+TEST(PortLabelTests, ADSRPortLabels) {
+    ADSRModule adsr;
+    EXPECT_EQ(adsr.getInputPortLabel(0), "Gate");
+    EXPECT_EQ(adsr.getOutputPortLabel(0), "Env");
+}
+
+TEST(PortLabelTests, LFOPortLabels) {
+    LFOModule lfo;
+    EXPECT_EQ(lfo.getOutputPortLabel(0), "CV");
+}
+
+TEST(PortLabelTests, AttenuverterPortLabels) {
+    AttenuverterModule att;
+    EXPECT_EQ(att.getInputPortLabel(0), "Signal");
+    EXPECT_EQ(att.getInputPortLabel(1), "Amount");
+    EXPECT_EQ(att.getOutputPortLabel(0), "Out");
+}
+
+TEST(PortLabelTests, DelayPortLabels) {
+    DelayModule delay;
+    EXPECT_EQ(delay.getInputPortLabel(0), "Left");
+    EXPECT_EQ(delay.getInputPortLabel(1), "Right");
+    EXPECT_EQ(delay.getOutputPortLabel(0), "Left");
+    EXPECT_EQ(delay.getOutputPortLabel(1), "Right");
+}
+
+TEST(PortLabelTests, DistortionPortLabels) {
+    DistortionModule dist;
+    EXPECT_EQ(dist.getInputPortLabel(0), "Left");
+    EXPECT_EQ(dist.getInputPortLabel(1), "Right");
+    EXPECT_EQ(dist.getInputPortLabel(2), "Drive");
+    EXPECT_EQ(dist.getInputPortLabel(3), "Mix");
+    EXPECT_EQ(dist.getOutputPortLabel(0), "Left");
+    EXPECT_EQ(dist.getOutputPortLabel(1), "Right");
+}
+
+TEST(PortLabelTests, ReverbPortLabels) {
+    ReverbModule reverb;
+    EXPECT_EQ(reverb.getInputPortLabel(0), "Left");
+    EXPECT_EQ(reverb.getInputPortLabel(1), "Right");
+    EXPECT_EQ(reverb.getOutputPortLabel(0), "Left");
+    EXPECT_EQ(reverb.getOutputPortLabel(1), "Right");
+}
+
+TEST(PortLabelTests, ChorusPortLabels) {
+    ChorusModule chorus;
+    EXPECT_EQ(chorus.getInputPortLabel(0), "Left");
+    EXPECT_EQ(chorus.getInputPortLabel(1), "Right");
+    EXPECT_EQ(chorus.getInputPortLabel(2), "Rate");
+    EXPECT_EQ(chorus.getInputPortLabel(3), "Depth");
+    EXPECT_EQ(chorus.getOutputPortLabel(0), "Left");
+    EXPECT_EQ(chorus.getOutputPortLabel(1), "Right");
+}
+
+TEST(PortLabelTests, PhaserPortLabels) {
+    PhaserModule phaser;
+    EXPECT_EQ(phaser.getInputPortLabel(0), "Left");
+    EXPECT_EQ(phaser.getInputPortLabel(1), "Right");
+    EXPECT_EQ(phaser.getInputPortLabel(2), "Rate");
+    EXPECT_EQ(phaser.getInputPortLabel(3), "Depth");
+    EXPECT_EQ(phaser.getOutputPortLabel(0), "Left");
+    EXPECT_EQ(phaser.getOutputPortLabel(1), "Right");
+}
+
+TEST(PortLabelTests, CompressorPortLabels) {
+    CompressorModule comp;
+    EXPECT_EQ(comp.getInputPortLabel(0), "Left");
+    EXPECT_EQ(comp.getInputPortLabel(1), "Right");
+    EXPECT_EQ(comp.getOutputPortLabel(0), "Left");
+    EXPECT_EQ(comp.getOutputPortLabel(1), "Right");
+}
+
+TEST(PortLabelTests, FlangerPortLabels) {
+    FlangerModule flanger;
+    EXPECT_EQ(flanger.getInputPortLabel(0), "Left");
+    EXPECT_EQ(flanger.getInputPortLabel(1), "Right");
+    EXPECT_EQ(flanger.getInputPortLabel(2), "Rate");
+    EXPECT_EQ(flanger.getInputPortLabel(3), "Depth");
+    EXPECT_EQ(flanger.getOutputPortLabel(0), "Left");
+    EXPECT_EQ(flanger.getOutputPortLabel(1), "Right");
+}
+
+TEST(PortLabelTests, LimiterPortLabels) {
+    LimiterModule limiter;
+    EXPECT_EQ(limiter.getInputPortLabel(0), "Left");
+    EXPECT_EQ(limiter.getInputPortLabel(1), "Right");
+    EXPECT_EQ(limiter.getOutputPortLabel(0), "Left");
+    EXPECT_EQ(limiter.getOutputPortLabel(1), "Right");
 }


### PR DESCRIPTION
## Summary

Add 5 new FX modules (Chorus, Phaser, Compressor, Flanger, Limiter) using built-in JUCE DSP classes. Also adds descriptive port labels for all modules, a categorized sidebar, and fixes the integer parameter auto-correction bug that caused oscillator octave to default to -4.

Closes #39

## Changes

- **New FX modules**: ChorusModule, PhaserModule, FlangerModule (all with CV modulation on Rate/Depth), CompressorModule (with makeup gain), LimiterModule (with input gain drive)
- **Port labels**: Added virtual `getInputPortLabel()`/`getOutputPortLabel()` to ModuleBase, overridden in all modules for descriptive port names. Fixed AudioGraphIOProcessor showing wrong labels
- **Categorized sidebar**: ModuleLibraryComponent now has section headers (Sources, Sequencing, Envelopes & Control, Filters, Modulation FX, Time FX, Dynamics)
- **Bug fix**: AIStateMapper no longer auto-corrects `AudioParameterInt` values in [0,1] range as normalized, fixing the octave defaulting to -4
- **Deprecated API cleanup**: Updated `AudioParameterInt` constructors to use `ParameterID` API (OscillatorModule, MidiKeyboardModule, SequencerModule)
- **Registered in all systems**: ModuleType enum, CMakeLists, AIStateMapper factory/switch/schema/audioNodeTypes, GraphEditor drag-drop

## Test Plan

- [x] All existing tests pass
- [x] New tests added for new functionality (~33 new tests: FX module tests, edge cases, port label tests, factory support)
- [x] Tested locally (build + run)
- [x] New modules visible in sidebar and draggable onto graph
- [x] Port labels display correctly for all modules including Audio Output
- [x] Oscillator octave defaults to 0 (not -4)