### PR TITLE
feat: visual signal flow, modulation feedback, and oscillator CV fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,5 +37,6 @@ coverage/
 .claude/settings.local.json
 worktrees/
 build-asan/
+build-app/
 build-release/
 build-test/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ The project follows a modular architecture with:
 - **AudioEngine**: Manages audio device I/O, the audio processor graph, and modulation matrix routing
 - **GraphEditor**: Visual editor for connecting modules with zoom/pan and drag-to-connect
 - **ModuleComponent**: Auto-UI generation from module parameters with type-safe layout switching via `ModuleType` enum
-- **AttenuverterModule**: Intermediary module for modulation routing with bypass and CV amount control
+- **AttenuverterModule**: Intermediary module for modulation routing with bypass and CV amount control; exposes `lastOutputPeak`/`lastModValue` atomics for UI visualization
 - **Port Labels**: Virtual `getInputPortLabel()`/`getOutputPortLabel()` on ModuleBase, overridden per-module for descriptive port names in the UI
 - **GravisynthUndoManager**: Snapshot-based undo/redo system wrapping `juce::UndoManager`, captures full graph state on every change
 - **AI Integration** (`Source/AI/`): AIIntegrationService orchestrates LLM-powered features via OllamaProvider; AIStateMapper translates graph state for AI context
@@ -110,7 +110,7 @@ Post-merge, `.github/workflows/build-artifacts.yml` runs on push to main (4 jobs
 
 ## Testing Strategy
 
-~284 tests across 37 suites, all headless (no audio device, no GUI window). Five test layers: audio rendering (DSP verification), integration (signal chains, mod routing), component workflow (UI interactions), state management (presets, undo/redo, serialization), and E2E workflow (full application paths). Code coverage threshold: 80%. See [`docs/testing.md`](docs/testing.md) for the full breakdown, patterns, and how to add tests for new modules.
+~295 tests across 38 suites, all headless (no audio device, no GUI window). Five test layers: audio rendering (DSP verification), integration (signal chains, mod routing), component workflow (UI interactions), state management (presets, undo/redo, serialization), and E2E workflow (full application paths). Code coverage threshold: 85%. See [`docs/testing.md`](docs/testing.md) for the full breakdown, patterns, and how to add tests for new modules.
 
 ## Key Files to Understand
 
@@ -127,6 +127,7 @@ Post-merge, `.github/workflows/build-artifacts.yml` runs on push to main (4 jobs
 - `Source/UI/GraphEditor.cpp`: Graph editor with attenuverter knob rendering, modulation routing, and undo integration
 - `Source/UI/ModuleLibraryComponent.h`: Categorized sidebar with section headers for module drag-and-drop
 - `Source/UI/ModMatrixComponent.cpp`: Modulation matrix with undo tracking for routing and parameter changes
+- **Visual Signal Flow**: GraphEditor draws animated dots on connections (white for audio, cyan for modulation), pulsing modulation lines, and activity glow on modules. ModuleComponent renders Serum-style modulation rings on knobs. Driven by `AudioEngine::getModulationDisplayInfo()` cached at 30fps.
 - `Source/Modules/FX/ChorusModule.h`: Chorus effect using `juce::dsp::Chorus`, CV modulation on Rate/Depth
 - `Source/Modules/FX/PhaserModule.h`: Phaser effect using `juce::dsp::Phaser`, CV modulation on Rate/Depth
 - `Source/Modules/FX/CompressorModule.h`: Compressor with manual makeup gain
@@ -135,4 +136,4 @@ Post-merge, `.github/workflows/build-artifacts.yml` runs on push to main (4 jobs
 - `Source/UI/AIChatComponent.cpp/.h`: Chat interface for AI-assisted patching
 - `Source/UI/ScopeComponent.h`: Oscilloscope/waveform display component
 - `Tests/E2EWorkflowTests.cpp`: 24 E2E workflow tests — preset loading, module drop/delete/replace, connection drag, mod matrix, undo/redo sequences, and stress tests
-- `Tests/`: ~284 tests across 37 suites (audio rendering, integration, component workflow, state management, E2E workflow)
+- `Tests/`: ~295 tests across 38 suites (audio rendering, integration, component workflow, state management, E2E workflow)

--- a/Source/AudioEngine.cpp
+++ b/Source/AudioEngine.cpp
@@ -64,6 +64,34 @@ std::vector<AudioEngine::ModRoutingInfo> AudioEngine::getActiveModRoutings() con
     return routings;
 }
 
+std::vector<AudioEngine::ModulationDisplayInfo> AudioEngine::getModulationDisplayInfo() const {
+    std::vector<ModulationDisplayInfo> result;
+    for (auto* node : mainProcessorGraph.getNodes()) {
+        if (auto* atten = dynamic_cast<AttenuverterModule*>(node->getProcessor())) {
+            ModulationDisplayInfo info;
+            info.attenuverterNodeID = node->nodeID;
+            info.modSignalValue = atten->getLastModValue();
+            info.modSignalPeak = atten->getLastOutputPeak();
+            info.isBypassed = false;
+            if (auto* bp = dynamic_cast<juce::AudioParameterBool*>(node->getProcessor()->getParameters()[2]))
+                info.isBypassed = bp->get();
+
+            bool foundDest = false;
+            for (auto& conn : mainProcessorGraph.getConnections()) {
+                if (conn.source.nodeID == node->nodeID && conn.source.channelIndex == 0) {
+                    info.destNodeID = conn.destination.nodeID;
+                    info.destChannelIndex = conn.destination.channelIndex;
+                    foundDest = true;
+                    break;
+                }
+            }
+            if (foundDest)
+                result.push_back(info);
+        }
+    }
+    return result;
+}
+
 void AudioEngine::addModRouting(juce::AudioProcessorGraph::NodeID sourceNodeID, int sourceChannelIndex,
                                 juce::AudioProcessorGraph::NodeID destNodeID, int destChannelIndex) {
     auto attenuverterNode = mainProcessorGraph.addNode(std::make_unique<AttenuverterModule>());

--- a/Source/AudioEngine.h
+++ b/Source/AudioEngine.h
@@ -33,7 +33,17 @@ public:
         bool isBypassed;
     };
 
+    struct ModulationDisplayInfo {
+        juce::AudioProcessorGraph::NodeID attenuverterNodeID;
+        juce::AudioProcessorGraph::NodeID destNodeID;
+        int destChannelIndex;
+        float modSignalValue;
+        float modSignalPeak;
+        bool isBypassed;
+    };
+
     std::vector<ModRoutingInfo> getActiveModRoutings() const;
+    std::vector<ModulationDisplayInfo> getModulationDisplayInfo() const;
     void addModRouting(juce::AudioProcessorGraph::NodeID sourceNodeID, int sourceChannelIndex,
                        juce::AudioProcessorGraph::NodeID destNodeID, int destChannelIndex);
     void addEmptyModRouting();

--- a/Source/Modules/ADSRModule.h
+++ b/Source/Modules/ADSRModule.h
@@ -13,6 +13,7 @@ public:
         addParameter(sustainParam = new juce::AudioParameterFloat("sustain", "Sustain", 0.0f, 1.0f, 0.0f));
         addParameter(releaseParam = new juce::AudioParameterFloat("release", "Release", 0.01f, 5.0f, 0.1f));
         addParameter(polyParam = new juce::AudioParameterBool("poly", "Poly", false));
+        enableVisualBuffer(true);
     }
 
     void prepareToPlay(double sampleRate, int samplesPerBlock) override {
@@ -61,6 +62,9 @@ public:
             }
 
             adsrs[0].applyEnvelopeToBuffer(buffer, 0, buffer.getNumSamples());
+            if (auto* vb = getVisualBuffer())
+                for (int s = 0; s < buffer.getNumSamples(); ++s)
+                    vb->pushSample(buffer.getSample(0, s));
         } else {
             // Poly mode: gate CV per voice
             for (int v = 0; v < MAX_VOICES; ++v)
@@ -87,6 +91,9 @@ public:
                 for (int smp = 0; smp < numSamples; ++smp)
                     out[smp] = adsrs[v].getNextSample();
             }
+            if (auto* vb = getVisualBuffer())
+                for (int s = 0; s < numSamples; ++s)
+                    vb->pushSample(buffer.getSample(0, s));
         }
     }
 

--- a/Source/Modules/AttenuverterModule.h
+++ b/Source/Modules/AttenuverterModule.h
@@ -25,6 +25,8 @@ public:
 
         if (bypassParam->get()) {
             buffer.clear();
+            lastOutputPeak.store(0.0f, std::memory_order_relaxed);
+            lastModValue.store(0.0f, std::memory_order_relaxed);
             return;
         }
 
@@ -40,6 +42,13 @@ public:
             audioData[sample] *= amount;
         }
 
+        // Track output for UI visualization
+        float peak = 0.0f;
+        for (int s = 0; s < numSamples; ++s)
+            peak = std::max(peak, std::abs(audioData[s]));
+        lastOutputPeak.store(peak, std::memory_order_relaxed);
+        lastModValue.store(numSamples > 0 ? audioData[numSamples / 2] : 0.0f, std::memory_order_relaxed);
+
         // Clear CV channel and copy audio to remaining channels
         for (int ch = 1; ch < buffer.getNumChannels(); ++ch) {
             buffer.copyFrom(ch, 0, buffer, 0, 0, numSamples);
@@ -52,8 +61,13 @@ public:
 
     ModuleType getModuleType() const override { return ModuleType::Attenuverter; }
 
+    float getLastOutputPeak() const { return lastOutputPeak.load(std::memory_order_relaxed); }
+    float getLastModValue() const { return lastModValue.load(std::memory_order_relaxed); }
+
 private:
     juce::AudioParameterFloat* amountParam;
     juce::AudioParameterBool* bypassParam;
     juce::SmoothedValue<float, juce::ValueSmoothingTypes::Linear> smoothedAmount;
+    std::atomic<float> lastOutputPeak{0.0f};
+    std::atomic<float> lastModValue{0.0f};
 };

--- a/Source/Modules/OscillatorModule.h
+++ b/Source/Modules/OscillatorModule.h
@@ -114,11 +114,28 @@ private:
 
         int numSamples = buffer.getNumSamples();
 
-        // Clear input-only CV channels (1+) to prevent JUCE buffer pool garbage
-        // being misread as CV modulation. Connected sources refill before processBlock.
-        for (int ch = 1; ch < buffer.getNumChannels(); ++ch) {
-            buffer.clear(ch, 0, numSamples);
-        }
+        // Save CV channel data before clearing the buffer.
+        // Channel 0 is shared between CV pitch input and audio output;
+        // in mono mode we ignore pitch CV (it may contain Hz from PolyMidi).
+        int numCh = buffer.getNumChannels();
+        juce::HeapBlock<float> cvWaveformSaved(numSamples);
+        juce::HeapBlock<float> cvOctaveSaved(numSamples);
+        juce::HeapBlock<float> cvCoarseSaved(numSamples);
+        juce::HeapBlock<float> cvFineSaved(numSamples);
+        juce::HeapBlock<float> cvLevelSaved(numSamples);
+
+        if (numCh > 1)
+            juce::FloatVectorOperations::copy(cvWaveformSaved, buffer.getReadPointer(1), numSamples);
+        if (numCh > 2)
+            juce::FloatVectorOperations::copy(cvOctaveSaved, buffer.getReadPointer(2), numSamples);
+        if (numCh > 3)
+            juce::FloatVectorOperations::copy(cvCoarseSaved, buffer.getReadPointer(3), numSamples);
+        if (numCh > 4)
+            juce::FloatVectorOperations::copy(cvFineSaved, buffer.getReadPointer(4), numSamples);
+        if (numCh > 5)
+            juce::FloatVectorOperations::copy(cvLevelSaved, buffer.getReadPointer(5), numSamples);
+
+        buffer.clear();
 
         float totalPitch = voices[0].lastMidiNote + (octaveParam->get() * 12.0f) + (float)coarseParam->get() +
                            (fineParam->get() / 100.0f);
@@ -127,26 +144,12 @@ private:
 
         int baseWaveform = waveformParam->getIndex();
 
-        // Channel 0 is shared between CV pitch input and audio output.
-        // In mono mode, ignore ch0 pitch CV (it may contain Hz values from PolyMidi
-        // which would be misinterpreted as octave-shift CV).
-        juce::HeapBlock<float> cvPitchSaved(numSamples);
-        juce::HeapBlock<float> cvWaveformSaved(numSamples);
-        juce::FloatVectorOperations::clear(cvPitchSaved, numSamples);
-        // Mono mode: read CV from original channels 1-5 (backward compatible)
-        if (buffer.getNumChannels() > 1)
-            juce::FloatVectorOperations::copy(cvWaveformSaved, buffer.getReadPointer(1), numSamples);
-        else
-            juce::FloatVectorOperations::clear(cvWaveformSaved, numSamples);
-
-        const float* cvPitchCh = cvPitchSaved;
-        const float* cvWaveformCh = (buffer.getNumChannels() > 1) ? cvWaveformSaved.get() : nullptr;
-        const float* cvOctaveCh = (buffer.getNumChannels() > 2) ? buffer.getReadPointer(2) : nullptr;
-        const float* cvCoarseCh = (buffer.getNumChannels() > 3) ? buffer.getReadPointer(3) : nullptr;
-        const float* cvFineCh = (buffer.getNumChannels() > 4) ? buffer.getReadPointer(4) : nullptr;
-        const float* cvLevelCh = (buffer.getNumChannels() > 5) ? buffer.getReadPointer(5) : nullptr;
-
-        buffer.clear();
+        const float* cvPitchCh = nullptr; // Mono mode ignores pitch CV
+        const float* cvWaveformCh = (numCh > 1) ? cvWaveformSaved.get() : nullptr;
+        const float* cvOctaveCh = (numCh > 2) ? cvOctaveSaved.get() : nullptr;
+        const float* cvCoarseCh = (numCh > 3) ? cvCoarseSaved.get() : nullptr;
+        const float* cvFineCh = (numCh > 4) ? cvFineSaved.get() : nullptr;
+        const float* cvLevelCh = (numCh > 5) ? cvLevelSaved.get() : nullptr;
         auto* ch0 = buffer.getWritePointer(0);
 
         int unisonCount = unisonParam->get();

--- a/Source/Modules/VCAModule.h
+++ b/Source/Modules/VCAModule.h
@@ -11,6 +11,7 @@ public:
     {
         addParameter(gainParam = new juce::AudioParameterFloat("gain", "Gain", 0.0f, 1.0f, 0.5f));
         addParameter(polyParam = new juce::AudioParameterBool("poly", "Poly", false));
+        enableVisualBuffer(true);
     }
 
     void prepareToPlay(double sampleRate, int samplesPerBlock) override {
@@ -54,6 +55,9 @@ public:
             if (numChannels > 1) {
                 buffer.copyFrom(1, 0, buffer, 0, 0, numSamples);
             }
+            if (auto* vb = getVisualBuffer())
+                for (int s = 0; s < numSamples; ++s)
+                    vb->pushSample(buffer.getSample(0, s));
         } else {
             // --- Poly mode: 8 voices summed to stereo (ch0/ch1) ---
             // Each voice is multiplied by its envelope CV and the master gain,
@@ -83,6 +87,9 @@ public:
                 for (int v = 2; v < MAX_VOICES && v < numChannels; ++v)
                     buffer.clear(v, 0, numSamples);
             }
+            if (auto* vb = getVisualBuffer())
+                for (int s = 0; s < numSamples; ++s)
+                    vb->pushSample(buffer.getSample(0, s));
         }
     }
 

--- a/Source/UI/GraphEditor.cpp
+++ b/Source/UI/GraphEditor.cpp
@@ -95,8 +95,18 @@ void GraphEditor::GraphContentComponent::paint(juce::Graphics& g) {
                 }
 
                 if (found1 && found2) {
-                    g.setColour(juce::Colours::yellow);
-                    g.drawLine(p1.toFloat().x, p1.toFloat().y, p2.toFloat().x, p2.toFloat().y, 2.0f);
+                    // Pulse modulation line based on signal activity
+                    float modPeak = 0.0f;
+                    for (auto& info : editor.cachedModDisplayInfo) {
+                        if (info.attenuverterNodeID == node2->nodeID) {
+                            modPeak = info.modSignalPeak;
+                            break;
+                        }
+                    }
+                    float lineWidth = 2.0f + modPeak * 2.0f;
+                    float brightness = juce::jlimit(0.5f, 1.0f, 0.5f + modPeak * 0.5f);
+                    g.setColour(juce::Colours::yellow.withMultipliedBrightness(brightness));
+                    g.drawLine(p1.toFloat().x, p1.toFloat().y, p2.toFloat().x, p2.toFloat().y, lineWidth);
 
                     float amt = 0.0f;
                     if (auto* p = node2->getProcessor()->getParameters()[1]) {
@@ -116,6 +126,15 @@ void GraphEditor::GraphContentComponent::paint(juce::Graphics& g) {
                     float dx = std::sin(angle) * 8.0f;
                     float dy = -std::cos(angle) * 8.0f;
                     g.drawLine(mid.toFloat().x, mid.toFloat().y, mid.toFloat().x + dx, mid.toFloat().y + dy, 2.0f);
+
+                    // Animated dots along modulation connection
+                    for (int d = 0; d < 3; ++d) {
+                        float t = std::fmod(connectionAnimPhase + (float)d / 3.0f, 1.0f);
+                        float dotX = p1.toFloat().x + (p2.toFloat().x - p1.toFloat().x) * t;
+                        float dotY = p1.toFloat().y + (p2.toFloat().y - p1.toFloat().y) * t;
+                        g.setColour(juce::Colours::cyan.withAlpha(0.7f));
+                        g.fillEllipse(dotX - 2.5f, dotY - 2.5f, 5.0f, 5.0f);
+                    }
                 }
             }
             continue;
@@ -150,8 +169,18 @@ void GraphEditor::GraphContentComponent::paint(juce::Graphics& g) {
             }
         }
 
-        if (found1 && found2)
+        if (found1 && found2) {
             g.drawLine(p1.toFloat().x, p1.toFloat().y, p2.toFloat().x, p2.toFloat().y, 2.0f);
+
+            // Animated dots along audio connection
+            for (int d = 0; d < 3; ++d) {
+                float t = std::fmod(connectionAnimPhase + (float)d / 3.0f, 1.0f);
+                float dotX = p1.toFloat().x + (p2.toFloat().x - p1.toFloat().x) * t;
+                float dotY = p1.toFloat().y + (p2.toFloat().y - p1.toFloat().y) * t;
+                g.setColour(juce::Colours::white.withAlpha(0.7f));
+                g.fillEllipse(dotX - 2.5f, dotY - 2.5f, 5.0f, 5.0f);
+            }
+        }
     }
 
     // Draw Line being dragged
@@ -792,7 +821,10 @@ void GraphEditor::disconnectPort(ModuleComponent* module, int portIndex, bool is
 }
 
 void GraphEditor::timerCallback() {
-    // No longer aggressive GCing attenuverters to allow empty slots in ModMatrix
+    cachedModDisplayInfo = audioEngine.getModulationDisplayInfo();
+    content.connectionAnimPhase += 0.02f;
+    if (content.connectionAnimPhase >= 1.0f)
+        content.connectionAnimPhase -= 1.0f;
     content.repaint();
 }
 

--- a/Source/UI/GraphEditor.h
+++ b/Source/UI/GraphEditor.h
@@ -64,6 +64,8 @@ private:
 
         juce::OwnedArray<ModuleComponent>& getModules() { return moduleComponents; }
 
+        float connectionAnimPhase = 0.0f;
+
     private:
         GraphEditor& editor;
         juce::OwnedArray<ModuleComponent> moduleComponents;
@@ -91,8 +93,14 @@ private:
     float attenDragStartValue = 0.0f;
 
     GravisynthUndoManager* undoManager = nullptr;
+    std::vector<AudioEngine::ModulationDisplayInfo> cachedModDisplayInfo;
 
     void updateTransform();
+
+public:
+    const std::vector<AudioEngine::ModulationDisplayInfo>& getCachedModDisplayInfo() const {
+        return cachedModDisplayInfo;
+    }
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(GraphEditor)
 };

--- a/Source/UI/ModuleComponent.cpp
+++ b/Source/UI/ModuleComponent.cpp
@@ -112,8 +112,22 @@ void ModuleComponent::detachFromProcessor() {
     module = nullptr;
 }
 void ModuleComponent::timerCallback() {
-    if (module != nullptr)
-        repaint();
+    if (module == nullptr)
+        return;
+
+    if (auto* modBase = dynamic_cast<ModuleBase*>(module)) {
+        if (auto* vb = modBase->getVisualBuffer()) {
+            if (rmsReadBuffer.empty())
+                rmsReadBuffer.resize(vb->getSize(), 0.0f);
+            vb->copyTo(rmsReadBuffer);
+            float sum = 0.0f;
+            for (float s : rmsReadBuffer)
+                sum += s * s;
+            cachedRMS = std::sqrt(sum / (float)rmsReadBuffer.size());
+        }
+    }
+
+    repaint();
 }
 
 void ModuleComponent::createControls() {
@@ -273,6 +287,13 @@ void ModuleComponent::paint(juce::Graphics& g) {
 
     g.fillAll(isBypassed ? juce::Colours::lightgrey.withAlpha(0.4f) : juce::Colours::lightgrey);
 
+    // Activity glow indicator
+    if (cachedRMS > 0.01f && !isBypassed) {
+        float glowAlpha = juce::jlimit(0.0f, 0.3f, cachedRMS * 0.5f);
+        g.setColour(juce::Colours::limegreen.withAlpha(glowAlpha));
+        g.drawRoundedRectangle(getLocalBounds().toFloat().reduced(1.0f), 4.0f, 3.0f);
+    }
+
     // Highlight Active Step (Sequencer only)
     if (getType(module) == ModuleType::Sequencer) {
         if (auto* seq = dynamic_cast<SequencerModule*>(module)) {
@@ -295,6 +316,13 @@ void ModuleComponent::paint(juce::Graphics& g) {
     g.fillRect(0, 0, getWidth(), 24);
     g.setColour(juce::Colours::white);
     g.drawText(module->getName(), 0, 0, getWidth(), 24, juce::Justification::centred, true);
+
+    // Activity LED in header
+    if (cachedRMS > 0.01f && !isBypassed) {
+        float ledAlpha = juce::jlimit(0.3f, 1.0f, cachedRMS * 2.0f);
+        g.setColour(juce::Colours::limegreen.withAlpha(ledAlpha));
+        g.fillEllipse(6.0f, 8.0f, 8.0f, 8.0f);
+    }
 
     // --- PORTS ---
     int numIns = module->getTotalNumInputChannels();
@@ -350,6 +378,65 @@ void ModuleComponent::paint(juce::Graphics& g) {
         else if (dynamic_cast<juce::AudioProcessorGraph::AudioGraphIOProcessor*>(module))
             label = (i == 0) ? "Left" : (i == 1) ? "Right" : "Out " + juce::String(i);
         g.drawText(label, p.x - 70, p.y - 10, 60, 20, juce::Justification::right, false);
+    }
+
+    // Serum-style modulation rings on knobs
+    if (mod != nullptr) {
+        auto targets = mod->getModulationTargets();
+        const auto& modInfo = owner.getCachedModDisplayInfo();
+
+        for (const auto& info : modInfo) {
+            if (info.destNodeID != nodeId || info.isBypassed)
+                continue;
+
+            juce::String targetParamName;
+            for (const auto& t : targets) {
+                if (t.channelIndex == info.destChannelIndex) {
+                    targetParamName = t.name;
+                    break;
+                }
+            }
+            if (targetParamName.isEmpty())
+                continue;
+
+            for (int si = 0; si < sliders.size(); ++si) {
+                if (sliders[si]->getComponentID() != targetParamName)
+                    continue;
+                if (sliders[si]->getSliderStyle() != juce::Slider::RotaryHorizontalVerticalDrag)
+                    continue;
+
+                auto sliderBounds = sliders[si]->getBounds().toFloat();
+                float cx = sliderBounds.getCentreX();
+                float cy = sliderBounds.getCentreY() - 10.0f;
+                float radius = std::min(sliderBounds.getWidth(), sliderBounds.getHeight()) / 2.0f - 11.0f;
+
+                float baseNorm = 0.5f;
+                for (auto* param : module->getParameters()) {
+                    if (param->getName(100) == targetParamName) {
+                        baseNorm = param->getValue();
+                        break;
+                    }
+                }
+
+                float modNorm = juce::jlimit(0.0f, 1.0f, baseNorm + info.modSignalValue);
+
+                constexpr float startAngle = -juce::MathConstants<float>::pi * 0.75f;
+                constexpr float endAngle = juce::MathConstants<float>::pi * 0.75f;
+                float baseAngle = juce::jmap(baseNorm, 0.0f, 1.0f, startAngle, endAngle);
+                float modAngle = juce::jmap(modNorm, 0.0f, 1.0f, startAngle, endAngle);
+
+                if (std::abs(modAngle - baseAngle) > 0.01f) {
+                    juce::Path arc;
+                    arc.addCentredArc(cx, cy, radius, radius, 0.0f, std::min(baseAngle, modAngle),
+                                      std::max(baseAngle, modAngle), true);
+                    bool isPositive = info.modSignalValue >= 0.0f;
+                    auto ringColour = isPositive ? juce::Colour(0xff00e5ff) : juce::Colour(0xffff6e00);
+                    g.setColour(ringColour);
+                    g.strokePath(arc, juce::PathStrokeType(3.5f));
+                }
+                break;
+            }
+        }
     }
 }
 

--- a/Source/UI/ModuleComponent.h
+++ b/Source/UI/ModuleComponent.h
@@ -35,6 +35,7 @@ public:
     void moved() override;
 
     juce::AudioProcessor* getModule() const { return module; }
+    juce::AudioProcessorGraph::NodeID getNodeId() const { return nodeId; }
 
     // Safely detach from the processor before graph rebuild.
     // Removes listeners, destroys attachments, stops timer, nulls module pointer.
@@ -82,6 +83,9 @@ private:
     GravisynthUndoManager* undoManager = nullptr;
     std::map<int, float> gestureStartValues;
     juce::Point<int> dragStartPosition;
+
+    float cachedRMS = 0.0f;
+    std::vector<float> rmsReadBuffer;
 
     void createControls();
     void updateLayout();

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -39,6 +39,8 @@ add_executable(GravisynthTests
     E2EWorkflowTests.cpp
     PresetManagerTests.cpp
     ModuleBypassTests.cpp
+    VisualSignalFlowTests.cpp
+    OscillatorCVModulationTests.cpp
     ../Source/MainComponent.cpp
     ../Source/UI/GraphEditor.cpp
     ../Source/UI/ModMatrixComponent.cpp

--- a/Tests/OscillatorCVModulationTests.cpp
+++ b/Tests/OscillatorCVModulationTests.cpp
@@ -1,0 +1,115 @@
+#include "Modules/OscillatorModule.h"
+#include <cmath>
+#include <gtest/gtest.h>
+
+class OscillatorCVModulationTest : public ::testing::Test {
+protected:
+    std::unique_ptr<OscillatorModule> osc;
+    static constexpr double sampleRate = 44100.0;
+    static constexpr int blockSize = 512;
+
+    void SetUp() override {
+        osc = std::make_unique<OscillatorModule>();
+        osc->prepareToPlay(sampleRate, blockSize);
+
+        // Send noteOn A4 (440Hz) to set voice 0's lastMidiNote
+        juce::AudioBuffer<float> initBuf(14, blockSize);
+        initBuf.clear();
+        juce::MidiBuffer midi;
+        midi.addEvent(juce::MidiMessage::noteOn(1, 69, (juce::uint8)100), 0);
+        osc->processBlock(initBuf, midi);
+    }
+
+    static float computeRMS(const juce::AudioBuffer<float>& buf, int channel) {
+        float sum = 0.0f;
+        for (int i = 0; i < buf.getNumSamples(); ++i) {
+            float s = buf.getSample(channel, i);
+            sum += s * s;
+        }
+        return std::sqrt(sum / (float)buf.getNumSamples());
+    }
+
+    static float estimateFreqByZeroCrossings(const juce::AudioBuffer<float>& buf, int channel, double sr) {
+        int crossings = 0;
+        for (int i = 1; i < buf.getNumSamples(); ++i) {
+            if ((buf.getSample(channel, i - 1) >= 0.0f) != (buf.getSample(channel, i) >= 0.0f))
+                ++crossings;
+        }
+        return (float)(crossings * sr / (2.0 * buf.getNumSamples()));
+    }
+};
+
+TEST_F(OscillatorCVModulationTest, OctaveCVShiftsFrequency) {
+    // Reference block with no CV
+    juce::AudioBuffer<float> refBuf(14, blockSize);
+    refBuf.clear();
+    juce::MidiBuffer emptyMidi;
+    osc->processBlock(refBuf, emptyMidi);
+    float refFreq = estimateFreqByZeroCrossings(refBuf, 0, sampleRate);
+
+    // Reset oscillator
+    osc->prepareToPlay(sampleRate, blockSize);
+    juce::AudioBuffer<float> initBuf(14, blockSize);
+    initBuf.clear();
+    juce::MidiBuffer midi;
+    midi.addEvent(juce::MidiMessage::noteOn(1, 69, (juce::uint8)100), 0);
+    osc->processBlock(initBuf, midi);
+
+    // Octave CV = 0.5 on channel 2 -> octShift = round(0.5 * 4) = 2 octaves up
+    juce::AudioBuffer<float> modBuf(14, blockSize);
+    modBuf.clear();
+    for (int i = 0; i < blockSize; ++i)
+        modBuf.setSample(2, i, 0.5f);
+    osc->processBlock(modBuf, emptyMidi);
+    float modFreq = estimateFreqByZeroCrossings(modBuf, 0, sampleRate);
+
+    // 2 octaves up = ~4x frequency
+    EXPECT_GT(modFreq, refFreq * 2.5f) << "Octave CV should shift frequency up significantly";
+}
+
+TEST_F(OscillatorCVModulationTest, LevelCVReducesAmplitude) {
+    // Reference with default level (1.0)
+    juce::AudioBuffer<float> refBuf(14, blockSize);
+    refBuf.clear();
+    juce::MidiBuffer emptyMidi;
+    osc->processBlock(refBuf, emptyMidi);
+    float refRMS = computeRMS(refBuf, 0);
+
+    // Level CV = -0.5 on channel 5 -> level = clamp(1.0 + (-0.5)) = 0.5
+    juce::AudioBuffer<float> modBuf(14, blockSize);
+    modBuf.clear();
+    for (int i = 0; i < blockSize; ++i)
+        modBuf.setSample(5, i, -0.5f);
+    osc->processBlock(modBuf, emptyMidi);
+    float modRMS = computeRMS(modBuf, 0);
+
+    EXPECT_LT(modRMS, refRMS * 0.75f) << "Level CV should reduce output amplitude";
+    EXPECT_GT(modRMS, 0.01f) << "Output should still have signal";
+}
+
+TEST_F(OscillatorCVModulationTest, CoarseCVShiftsFrequency) {
+    // Reference
+    juce::AudioBuffer<float> refBuf(14, blockSize);
+    refBuf.clear();
+    juce::MidiBuffer emptyMidi;
+    osc->processBlock(refBuf, emptyMidi);
+    float refFreq = estimateFreqByZeroCrossings(refBuf, 0, sampleRate);
+
+    // Reset
+    osc->prepareToPlay(sampleRate, blockSize);
+    juce::AudioBuffer<float> initBuf(14, blockSize);
+    initBuf.clear();
+    juce::MidiBuffer midi;
+    midi.addEvent(juce::MidiMessage::noteOn(1, 69, (juce::uint8)100), 0);
+    osc->processBlock(initBuf, midi);
+
+    // Coarse CV = 1.0 on channel 3 -> coarseShift = round(1.0 * 12) = 12 semitones = 1 octave
+    juce::AudioBuffer<float> modBuf(14, blockSize);
+    modBuf.clear();
+    for (int i = 0; i < blockSize; ++i)
+        modBuf.setSample(3, i, 1.0f);
+    osc->processBlock(modBuf, emptyMidi);
+    float modFreq = estimateFreqByZeroCrossings(modBuf, 0, sampleRate);
+
+    EXPECT_GT(modFreq, refFreq * 1.5f) << "Coarse CV should shift frequency up";
+}

--- a/Tests/VisualSignalFlowTests.cpp
+++ b/Tests/VisualSignalFlowTests.cpp
@@ -1,0 +1,162 @@
+#include "AudioEngine.h"
+#include "Modules/AttenuverterModule.h"
+#include "Modules/LFOModule.h"
+#include "Modules/VCAModule.h"
+#include "Modules/VisualBuffer.h"
+#include <cmath>
+#include <gtest/gtest.h>
+
+// --- AttenuverterModule Peak/Mod Tracking Tests ---
+
+class AttenuverterVisualTests : public ::testing::Test {
+protected:
+    std::unique_ptr<AttenuverterModule> module;
+
+    void SetUp() override {
+        module = std::make_unique<AttenuverterModule>();
+        module->prepareToPlay(44100.0, 512);
+    }
+};
+
+TEST_F(AttenuverterVisualTests, PeakTrackingWithSignal) {
+    // Set amount to 1.0 (full pass-through)
+    if (auto* amt = dynamic_cast<juce::AudioParameterFloat*>(module->getParameters()[1]))
+        amt->setValueNotifyingHost(amt->convertTo0to1(1.0f));
+
+    juce::MidiBuffer midi;
+    // Process multiple blocks to let SmoothedValue ramp to target
+    for (int block = 0; block < 5; ++block) {
+        juce::AudioBuffer<float> buffer(2, 512);
+        buffer.clear();
+        for (int i = 0; i < 512; ++i)
+            buffer.setSample(0, i, 0.5f);
+        module->processBlock(buffer, midi);
+    }
+
+    EXPECT_NEAR(module->getLastOutputPeak(), 0.5f, 0.05f);
+}
+
+TEST_F(AttenuverterVisualTests, ModValueTrackingReturnsMidBlockSample) {
+    if (auto* amt = dynamic_cast<juce::AudioParameterFloat*>(module->getParameters()[1]))
+        amt->setValueNotifyingHost(amt->convertTo0to1(1.0f));
+
+    juce::MidiBuffer midi;
+    // Process multiple blocks to let SmoothedValue ramp to target
+    for (int block = 0; block < 5; ++block) {
+        juce::AudioBuffer<float> buffer(2, 512);
+        buffer.clear();
+        for (int i = 0; i < 512; ++i)
+            buffer.setSample(0, i, 0.75f);
+        module->processBlock(buffer, midi);
+    }
+
+    EXPECT_NEAR(module->getLastModValue(), 0.75f, 0.1f);
+}
+
+TEST_F(AttenuverterVisualTests, BypassedReturnsZeroPeakAndMod) {
+    // Set bypass (parameter index 2)
+    if (auto* bp = dynamic_cast<juce::AudioParameterBool*>(module->getParameters()[2]))
+        bp->setValueNotifyingHost(1.0f);
+
+    juce::AudioBuffer<float> buffer(2, 128);
+    for (int i = 0; i < 128; ++i)
+        buffer.setSample(0, i, 1.0f);
+    juce::MidiBuffer midi;
+
+    module->processBlock(buffer, midi);
+
+    EXPECT_FLOAT_EQ(module->getLastOutputPeak(), 0.0f);
+    EXPECT_FLOAT_EQ(module->getLastModValue(), 0.0f);
+}
+
+TEST_F(AttenuverterVisualTests, ZeroAmountProducesZeroPeak) {
+    // Default amount is 0.0
+    juce::AudioBuffer<float> buffer(2, 128);
+    for (int i = 0; i < 128; ++i)
+        buffer.setSample(0, i, 1.0f);
+    juce::MidiBuffer midi;
+
+    module->processBlock(buffer, midi);
+
+    EXPECT_NEAR(module->getLastOutputPeak(), 0.0f, 0.05f);
+}
+
+// --- VisualBuffer RMS Computation Test ---
+
+TEST(VisualBufferRMSTest, ComputeRMSFromBuffer) {
+    VisualBuffer vb;
+    // Push a known signal: 1024 samples of 0.5
+    for (int i = 0; i < 1024; ++i)
+        vb.pushSample(0.5f);
+
+    std::vector<float> data(vb.getSize(), 0.0f);
+    vb.copyTo(data);
+
+    float sum = 0.0f;
+    for (float s : data)
+        sum += s * s;
+    float rms = std::sqrt(sum / (float)data.size());
+
+    EXPECT_NEAR(rms, 0.5f, 0.01f);
+}
+
+TEST(VisualBufferRMSTest, SilentBufferHasZeroRMS) {
+    VisualBuffer vb;
+    for (int i = 0; i < 1024; ++i)
+        vb.pushSample(0.0f);
+
+    std::vector<float> data(vb.getSize(), 0.0f);
+    vb.copyTo(data);
+
+    float sum = 0.0f;
+    for (float s : data)
+        sum += s * s;
+    float rms = std::sqrt(sum / (float)data.size());
+
+    EXPECT_FLOAT_EQ(rms, 0.0f);
+}
+
+// --- AudioEngine ModulationDisplayInfo Tests ---
+
+class ModulationDisplayInfoTests : public ::testing::Test {
+protected:
+    std::unique_ptr<AudioEngine> engine;
+
+    void SetUp() override { engine = std::make_unique<AudioEngine>(); }
+
+    void TearDown() override {
+        engine->shutdown();
+        engine.reset();
+    }
+};
+
+TEST_F(ModulationDisplayInfoTests, EmptyGraphReturnsEmptyInfo) {
+    auto info = engine->getModulationDisplayInfo();
+    EXPECT_TRUE(info.empty());
+}
+
+TEST_F(ModulationDisplayInfoTests, UnconnectedAttenuverterIsExcluded) {
+    // Add an empty mod routing (attenuverter with no connections)
+    engine->addEmptyModRouting();
+
+    auto info = engine->getModulationDisplayInfo();
+    EXPECT_TRUE(info.empty());
+}
+
+TEST_F(ModulationDisplayInfoTests, ConnectedRoutingAppearsInInfo) {
+    auto& graph = engine->getGraph();
+
+    // Use non-attenuverter modules as src/dst to avoid false matches
+    auto srcNode = graph.addNode(std::make_unique<LFOModule>());
+    auto dstNode = graph.addNode(std::make_unique<VCAModule>());
+    ASSERT_NE(srcNode, nullptr);
+    ASSERT_NE(dstNode, nullptr);
+
+    // Add mod routing from src to dst channel 1 (VCA CV input)
+    engine->addModRouting(srcNode->nodeID, 0, dstNode->nodeID, 1);
+
+    auto info = engine->getModulationDisplayInfo();
+    ASSERT_EQ(info.size(), 1u);
+    EXPECT_EQ(info[0].destNodeID, dstNode->nodeID);
+    EXPECT_EQ(info[0].destChannelIndex, 1);
+}

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -56,6 +56,7 @@ Test UI component interactions using in-process construction (no window, no disp
 | VisualBufferTest | 3 | Scope visualization buffer management, read/write, ringbuffer behavior |
 | ModuleBaseTest | 4 | Parameter getters, port labels, bypass functionality |
 | ModuleBypassTest | 5 | Default state, toggle, signal passing when bypassed |
+| VisualSignalFlowTests | 8 | AttenuverterModule peak/mod value tracking, VisualBuffer RMS computation, AudioEngine::getModulationDisplayInfo() population |
 
 ### State Management Tests (~44 tests)
 

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -50,12 +50,12 @@ TOTAL_COVERAGE=$(echo "$REPORT" | grep "TOTAL" | awk '{print $10}' | sed 's/%//'
 echo "Total Line Coverage: $TOTAL_COVERAGE%"
 
 # Threshold check (awk for float comparison to avoid installing bc)
-PASS=$(awk -v cov="$TOTAL_COVERAGE" 'BEGIN {print (cov >= 80.0) ? 1 : 0}')
+PASS=$(awk -v cov="$TOTAL_COVERAGE" 'BEGIN {print (cov >= 85.0) ? 1 : 0}')
 
 if [ "$PASS" -eq 1 ]; then
   echo "Coverage check passed."
   exit 0
 else
-  echo "Error: Coverage ($TOTAL_COVERAGE%) is below threshold (80.0%)"
+  echo "Error: Coverage ($TOTAL_COVERAGE%) is below threshold (85.0%)"
   exit 1
 fi


### PR DESCRIPTION
## Summary

Add visual signal flow animations and modulation feedback to the graph editor, plus fix a pre-existing bug where Oscillator CV modulation was non-functional in mono mode.

## Changes

- **Connection animation**: Moving dots along all connection lines (white for audio, cyan for modulation) showing signal direction
- **Module activity indicators**: Green glow border and LED on modules producing audio signal, driven by VisualBuffer RMS
- **Modulation line pulsing**: Modulation connection lines pulse in width/brightness based on signal activity
- **Serum-style modulation rings**: Bright cyan/orange arc around rotary knobs showing modulated value range without moving the knob
- **Modulation display infrastructure**: `AudioEngine::getModulationDisplayInfo()` exposes AttenuverterModule signal values via atomics, cached at 30fps in GraphEditor
- **VisualBuffer on ADSR/VCA**: Enable activity glow for these modules
- **Oscillator CV fix**: Fix mono mode clearing CV channels (Octave, Coarse, Fine, Level, Waveform) before reading them — save to HeapBlock before buffer.clear()
- **Coverage threshold**: Bump from 80% to 85% (currently at ~89.5%)

## Test Plan

- [x] All 314 existing tests pass (including 18 new from main merge)
- [x] New tests added:
  - VisualSignalFlowTests (9 tests): AttenuverterModule peak/mod tracking, VisualBuffer RMS, ModulationDisplayInfo
  - OscillatorCVModulationTests (3 tests): Octave/Coarse/Level CV modulation verification
- [x] Tested locally (build + run app, verified visual feedback)
- [x] Documentation updated (CLAUDE.md, docs/testing.md)
- [x] Merged with main, conflicts resolved

Closes #43