### PR TITLE
feat: visual signal flow — animated modulation dots and rings

### DIFF
--- a/Source/AudioEngine.cpp
+++ b/Source/AudioEngine.cpp
@@ -64,6 +64,34 @@ std::vector<AudioEngine::ModRoutingInfo> AudioEngine::getActiveModRoutings() con
     return routings;
 }
 
+std::vector<AudioEngine::ModulationDisplayInfo> AudioEngine::getModulationDisplayInfo() const {
+    std::vector<ModulationDisplayInfo> result;
+    for (auto* node : mainProcessorGraph.getNodes()) {
+        if (auto* atten = dynamic_cast<AttenuverterModule*>(node->getProcessor())) {
+            ModulationDisplayInfo info;
+            info.attenuverterNodeID = node->nodeID;
+            info.modSignalValue = atten->getLastModValue();
+            info.modSignalPeak = atten->getLastOutputPeak();
+            info.isBypassed = false;
+            if (auto* bp = dynamic_cast<juce::AudioParameterBool*>(node->getProcessor()->getParameters()[2]))
+                info.isBypassed = bp->get();
+
+            bool foundDest = false;
+            for (auto& conn : mainProcessorGraph.getConnections()) {
+                if (conn.source.nodeID == node->nodeID && conn.source.channelIndex == 0) {
+                    info.destNodeID = conn.destination.nodeID;
+                    info.destChannelIndex = conn.destination.channelIndex;
+                    foundDest = true;
+                    break;
+                }
+            }
+            if (foundDest)
+                result.push_back(info);
+        }
+    }
+    return result;
+}
+
 void AudioEngine::addModRouting(juce::AudioProcessorGraph::NodeID sourceNodeID, int sourceChannelIndex,
                                 juce::AudioProcessorGraph::NodeID destNodeID, int destChannelIndex) {
     auto attenuverterNode = mainProcessorGraph.addNode(std::make_unique<AttenuverterModule>());

--- a/Source/AudioEngine.h
+++ b/Source/AudioEngine.h
@@ -33,7 +33,17 @@ public:
         bool isBypassed;
     };
 
+    struct ModulationDisplayInfo {
+        juce::AudioProcessorGraph::NodeID attenuverterNodeID;
+        juce::AudioProcessorGraph::NodeID destNodeID;
+        int destChannelIndex;
+        float modSignalValue;
+        float modSignalPeak;
+        bool isBypassed;
+    };
+
     std::vector<ModRoutingInfo> getActiveModRoutings() const;
+    std::vector<ModulationDisplayInfo> getModulationDisplayInfo() const;
     void addModRouting(juce::AudioProcessorGraph::NodeID sourceNodeID, int sourceChannelIndex,
                        juce::AudioProcessorGraph::NodeID destNodeID, int destChannelIndex);
     void addEmptyModRouting();

--- a/Source/Modules/ADSRModule.h
+++ b/Source/Modules/ADSRModule.h
@@ -13,6 +13,7 @@ public:
         addParameter(sustainParam = new juce::AudioParameterFloat("sustain", "Sustain", 0.0f, 1.0f, 0.0f));
         addParameter(releaseParam = new juce::AudioParameterFloat("release", "Release", 0.01f, 5.0f, 0.1f));
         addParameter(polyParam = new juce::AudioParameterBool("poly", "Poly", false));
+        enableVisualBuffer(true);
     }
 
     void prepareToPlay(double sampleRate, int samplesPerBlock) override {
@@ -61,6 +62,9 @@ public:
             }
 
             adsrs[0].applyEnvelopeToBuffer(buffer, 0, buffer.getNumSamples());
+            if (auto* vb = getVisualBuffer())
+                for (int s = 0; s < buffer.getNumSamples(); ++s)
+                    vb->pushSample(buffer.getSample(0, s));
         } else {
             // Poly mode: gate CV per voice
             for (int v = 0; v < MAX_VOICES; ++v)
@@ -87,6 +91,9 @@ public:
                 for (int smp = 0; smp < numSamples; ++smp)
                     out[smp] = adsrs[v].getNextSample();
             }
+            if (auto* vb = getVisualBuffer())
+                for (int s = 0; s < numSamples; ++s)
+                    vb->pushSample(buffer.getSample(0, s));
         }
     }
 

--- a/Source/Modules/VCAModule.h
+++ b/Source/Modules/VCAModule.h
@@ -11,6 +11,7 @@ public:
     {
         addParameter(gainParam = new juce::AudioParameterFloat("gain", "Gain", 0.0f, 1.0f, 0.5f));
         addParameter(polyParam = new juce::AudioParameterBool("poly", "Poly", false));
+        enableVisualBuffer(true);
     }
 
     void prepareToPlay(double sampleRate, int samplesPerBlock) override {
@@ -54,6 +55,9 @@ public:
             if (numChannels > 1) {
                 buffer.copyFrom(1, 0, buffer, 0, 0, numSamples);
             }
+            if (auto* vb = getVisualBuffer())
+                for (int s = 0; s < numSamples; ++s)
+                    vb->pushSample(buffer.getSample(0, s));
         } else {
             // --- Poly mode: 8 voices summed to stereo (ch0/ch1) ---
             // Each voice is multiplied by its envelope CV and the master gain,
@@ -83,6 +87,9 @@ public:
                 for (int v = 2; v < MAX_VOICES && v < numChannels; ++v)
                     buffer.clear(v, 0, numSamples);
             }
+            if (auto* vb = getVisualBuffer())
+                for (int s = 0; s < numSamples; ++s)
+                    vb->pushSample(buffer.getSample(0, s));
         }
     }
 

--- a/Source/UI/GraphEditor.cpp
+++ b/Source/UI/GraphEditor.cpp
@@ -95,8 +95,18 @@ void GraphEditor::GraphContentComponent::paint(juce::Graphics& g) {
                 }
 
                 if (found1 && found2) {
-                    g.setColour(juce::Colours::yellow);
-                    g.drawLine(p1.toFloat().x, p1.toFloat().y, p2.toFloat().x, p2.toFloat().y, 2.0f);
+                    // Pulse modulation line based on signal activity
+                    float modPeak = 0.0f;
+                    for (auto& info : editor.cachedModDisplayInfo) {
+                        if (info.attenuverterNodeID == node2->nodeID) {
+                            modPeak = info.modSignalPeak;
+                            break;
+                        }
+                    }
+                    float lineWidth = 2.0f + modPeak * 2.0f;
+                    float brightness = juce::jlimit(0.5f, 1.0f, 0.5f + modPeak * 0.5f);
+                    g.setColour(juce::Colours::yellow.withMultipliedBrightness(brightness));
+                    g.drawLine(p1.toFloat().x, p1.toFloat().y, p2.toFloat().x, p2.toFloat().y, lineWidth);
 
                     float amt = 0.0f;
                     if (auto* p = node2->getProcessor()->getParameters()[1]) {
@@ -116,6 +126,15 @@ void GraphEditor::GraphContentComponent::paint(juce::Graphics& g) {
                     float dx = std::sin(angle) * 8.0f;
                     float dy = -std::cos(angle) * 8.0f;
                     g.drawLine(mid.toFloat().x, mid.toFloat().y, mid.toFloat().x + dx, mid.toFloat().y + dy, 2.0f);
+
+                    // Animated dots along modulation connection
+                    for (int d = 0; d < 3; ++d) {
+                        float t = std::fmod(connectionAnimPhase + (float)d / 3.0f, 1.0f);
+                        float dotX = p1.toFloat().x + (p2.toFloat().x - p1.toFloat().x) * t;
+                        float dotY = p1.toFloat().y + (p2.toFloat().y - p1.toFloat().y) * t;
+                        g.setColour(juce::Colours::cyan.withAlpha(0.7f));
+                        g.fillEllipse(dotX - 2.5f, dotY - 2.5f, 5.0f, 5.0f);
+                    }
                 }
             }
             continue;
@@ -150,8 +169,18 @@ void GraphEditor::GraphContentComponent::paint(juce::Graphics& g) {
             }
         }
 
-        if (found1 && found2)
+        if (found1 && found2) {
             g.drawLine(p1.toFloat().x, p1.toFloat().y, p2.toFloat().x, p2.toFloat().y, 2.0f);
+
+            // Animated dots along audio connection
+            for (int d = 0; d < 3; ++d) {
+                float t = std::fmod(connectionAnimPhase + (float)d / 3.0f, 1.0f);
+                float dotX = p1.toFloat().x + (p2.toFloat().x - p1.toFloat().x) * t;
+                float dotY = p1.toFloat().y + (p2.toFloat().y - p1.toFloat().y) * t;
+                g.setColour(juce::Colours::white.withAlpha(0.7f));
+                g.fillEllipse(dotX - 2.5f, dotY - 2.5f, 5.0f, 5.0f);
+            }
+        }
     }
 
     // Draw Line being dragged
@@ -792,7 +821,10 @@ void GraphEditor::disconnectPort(ModuleComponent* module, int portIndex, bool is
 }
 
 void GraphEditor::timerCallback() {
-    // No longer aggressive GCing attenuverters to allow empty slots in ModMatrix
+    cachedModDisplayInfo = audioEngine.getModulationDisplayInfo();
+    content.connectionAnimPhase += 0.02f;
+    if (content.connectionAnimPhase >= 1.0f)
+        content.connectionAnimPhase -= 1.0f;
     content.repaint();
 }
 

--- a/Source/UI/GraphEditor.h
+++ b/Source/UI/GraphEditor.h
@@ -64,6 +64,8 @@ private:
 
         juce::OwnedArray<ModuleComponent>& getModules() { return moduleComponents; }
 
+        float connectionAnimPhase = 0.0f;
+
     private:
         GraphEditor& editor;
         juce::OwnedArray<ModuleComponent> moduleComponents;
@@ -91,8 +93,13 @@ private:
     float attenDragStartValue = 0.0f;
 
     GravisynthUndoManager* undoManager = nullptr;
+    std::vector<AudioEngine::ModulationDisplayInfo> cachedModDisplayInfo;
 
     void updateTransform();
 
+public:
+    const std::vector<AudioEngine::ModulationDisplayInfo>& getCachedModDisplayInfo() const { return cachedModDisplayInfo; }
+
+private:
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(GraphEditor)
 };

--- a/Source/UI/ModuleComponent.cpp
+++ b/Source/UI/ModuleComponent.cpp
@@ -112,8 +112,22 @@ void ModuleComponent::detachFromProcessor() {
     module = nullptr;
 }
 void ModuleComponent::timerCallback() {
-    if (module != nullptr)
-        repaint();
+    if (module == nullptr)
+        return;
+
+    if (auto* modBase = dynamic_cast<ModuleBase*>(module)) {
+        if (auto* vb = modBase->getVisualBuffer()) {
+            if (rmsReadBuffer.empty())
+                rmsReadBuffer.resize(vb->getSize(), 0.0f);
+            vb->copyTo(rmsReadBuffer);
+            float sum = 0.0f;
+            for (float s : rmsReadBuffer)
+                sum += s * s;
+            cachedRMS = std::sqrt(sum / (float)rmsReadBuffer.size());
+        }
+    }
+
+    repaint();
 }
 
 void ModuleComponent::createControls() {
@@ -273,6 +287,13 @@ void ModuleComponent::paint(juce::Graphics& g) {
 
     g.fillAll(isBypassed ? juce::Colours::lightgrey.withAlpha(0.4f) : juce::Colours::lightgrey);
 
+    // Activity glow indicator
+    if (cachedRMS > 0.01f && !isBypassed) {
+        float glowAlpha = juce::jlimit(0.0f, 0.3f, cachedRMS * 0.5f);
+        g.setColour(juce::Colours::limegreen.withAlpha(glowAlpha));
+        g.drawRoundedRectangle(getLocalBounds().toFloat().reduced(1.0f), 4.0f, 3.0f);
+    }
+
     // Highlight Active Step (Sequencer only)
     if (getType(module) == ModuleType::Sequencer) {
         if (auto* seq = dynamic_cast<SequencerModule*>(module)) {
@@ -295,6 +316,13 @@ void ModuleComponent::paint(juce::Graphics& g) {
     g.fillRect(0, 0, getWidth(), 24);
     g.setColour(juce::Colours::white);
     g.drawText(module->getName(), 0, 0, getWidth(), 24, juce::Justification::centred, true);
+
+    // Activity LED in header
+    if (cachedRMS > 0.01f && !isBypassed) {
+        float ledAlpha = juce::jlimit(0.3f, 1.0f, cachedRMS * 2.0f);
+        g.setColour(juce::Colours::limegreen.withAlpha(ledAlpha));
+        g.fillEllipse(6.0f, 8.0f, 8.0f, 8.0f);
+    }
 
     // --- PORTS ---
     int numIns = module->getTotalNumInputChannels();
@@ -350,6 +378,69 @@ void ModuleComponent::paint(juce::Graphics& g) {
         else if (dynamic_cast<juce::AudioProcessorGraph::AudioGraphIOProcessor*>(module))
             label = (i == 0) ? "Left" : (i == 1) ? "Right" : "Out " + juce::String(i);
         g.drawText(label, p.x - 70, p.y - 10, 60, 20, juce::Justification::right, false);
+    }
+
+    // Serum-style modulation rings on knobs
+    if (mod != nullptr) {
+        auto targets = mod->getModulationTargets();
+        const auto& modInfo = owner.getCachedModDisplayInfo();
+
+        for (const auto& info : modInfo) {
+            if (info.destNodeID != nodeId || info.isBypassed)
+                continue;
+
+            // Find the modulation target matching this channel
+            juce::String targetParamName;
+            for (const auto& t : targets) {
+                if (t.channelIndex == info.destChannelIndex) {
+                    targetParamName = t.name;
+                    break;
+                }
+            }
+            if (targetParamName.isEmpty())
+                continue;
+
+            // Find the matching slider
+            for (int si = 0; si < sliders.size(); ++si) {
+                if (sliders[si]->getComponentID() != targetParamName)
+                    continue;
+                if (sliders[si]->getSliderStyle() != juce::Slider::RotaryHorizontalVerticalDrag)
+                    continue;
+
+                auto sliderBounds = sliders[si]->getBounds().toFloat();
+                float cx = sliderBounds.getCentreX();
+                float cy = sliderBounds.getCentreY() - 10.0f;
+                float radius = std::min(sliderBounds.getWidth(), sliderBounds.getHeight()) / 2.0f - 2.0f;
+
+                // Find matching parameter for base value
+                float baseNorm = 0.5f;
+                for (auto* param : module->getParameters()) {
+                    if (param->getName(100) == targetParamName) {
+                        baseNorm = param->getValue();
+                        break;
+                    }
+                }
+
+                float modNorm = juce::jlimit(0.0f, 1.0f, baseNorm + info.modSignalValue);
+
+                constexpr float startAngle = -juce::MathConstants<float>::pi * 0.75f;
+                constexpr float endAngle = juce::MathConstants<float>::pi * 0.75f;
+                float baseAngle = juce::jmap(baseNorm, 0.0f, 1.0f, startAngle, endAngle);
+                float modAngle = juce::jmap(modNorm, 0.0f, 1.0f, startAngle, endAngle);
+
+                if (std::abs(modAngle - baseAngle) > 0.01f) {
+                    juce::Path arc;
+                    arc.addCentredArc(cx, cy, radius, radius, 0.0f,
+                                      std::min(baseAngle, modAngle),
+                                      std::max(baseAngle, modAngle), true);
+                    bool isPositive = info.modSignalValue >= 0.0f;
+                    g.setColour(isPositive ? juce::Colours::cyan.withAlpha(0.6f)
+                                           : juce::Colours::orange.withAlpha(0.6f));
+                    g.strokePath(arc, juce::PathStrokeType(3.0f));
+                }
+                break;
+            }
+        }
     }
 }
 

--- a/Source/UI/ModuleComponent.h
+++ b/Source/UI/ModuleComponent.h
@@ -35,6 +35,7 @@ public:
     void moved() override;
 
     juce::AudioProcessor* getModule() const { return module; }
+    juce::AudioProcessorGraph::NodeID getNodeId() const { return nodeId; }
 
     // Safely detach from the processor before graph rebuild.
     // Removes listeners, destroys attachments, stops timer, nulls module pointer.
@@ -82,6 +83,9 @@ private:
     GravisynthUndoManager* undoManager = nullptr;
     std::map<int, float> gestureStartValues;
     juce::Point<int> dragStartPosition;
+
+    float cachedRMS = 0.0f;
+    std::vector<float> rmsReadBuffer;
 
     void createControls();
     void updateLayout();


### PR DESCRIPTION
## Summary

Preserves a WIP branch (originally stashed locally) that adds real-time visual feedback for signal and modulation flow in the graph editor.

## Changes

- `AudioEngine::getModulationDisplayInfo()` — aggregates attenuverter state (mod value, peak, bypass) for each active modulation routing. Intended to be polled at ~30fps by the UI.
- `ADSRModule` and `VCAModule` — enable `VisualBuffer` and push their output into it each block for scope-style display.
- `GraphEditor` — draws animated traveling dots on connections (white for audio, cyan for modulation) and pulses modulation lines based on activity.
- `ModuleComponent` — renders Serum-style modulation rings around parameter knobs to show live modulation depth on each parameter.

## Test Plan

- [ ] All existing tests pass
- [ ] New tests added for new functionality
- [ ] Tested locally (build + run)
- [ ] Documentation updated (CLAUDE.md, docs/) to reflect any new files, architecture changes, or conventions

## Screenshots

N/A — draft. Visual verification required before un-drafting.

---
_Draft: recovered from a local stash before project cleanup. Has not been built or tested locally in this form; CLAUDE.md / docs/testing.md had stale conflicts and kept main's version — reconcile docs (test counts, architecture blurb) when picking this back up. A stray `Tests/CMakeLists.txt` edit that belonged to #79 was dropped._