### PR TITLE
rebrand: rename Gravisynth to Agent Synth

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -22,19 +22,19 @@ jobs:
           - os: ubuntu-latest
             platform: Linux
             arch: x64
-            artifact_name: Gravisynth-Linux-x64
+            artifact_name: AgentSynth-Linux-x64
 
           # macOS arm64 (Apple Silicon)
           - os: macos-latest
             platform: macOS
             arch: arm64
-            artifact_name: Gravisynth-macOS-arm64
+            artifact_name: AgentSynth-macOS-arm64
 
           # Windows x64
           - os: windows-latest
             platform: Windows
             arch: x64
-            artifact_name: Gravisynth-Windows-x64
+            artifact_name: AgentSynth-Windows-x64
 
     steps:
     - uses: actions/checkout@v4
@@ -81,20 +81,20 @@ jobs:
       if: runner.os == 'Linux'
       run: |
         mkdir -p artifact
-        find build -name Gravisynth -type f -perm /111 -exec cp {} artifact/ \; || true
-        if [ ! -f artifact/Gravisynth ]; then
-            find build -name Gravisynth -type f -exec cp {} artifact/ \;
+        find build -name AgentSynth -type f -perm /111 -exec cp {} artifact/ \; || true
+        if [ ! -f artifact/AgentSynth ]; then
+            find build -name AgentSynth -type f -exec cp {} artifact/ \;
         fi
-        chmod +x artifact/Gravisynth
+        chmod +x artifact/AgentSynth
 
     # Package macOS
     - name: Package macOS Artifact
       if: runner.os == 'macOS'
       run: |
         mkdir -p artifact
-        APP_PATH=$(find build -name Gravisynth.app -type d -maxdepth 3 | head -n 1)
+        APP_PATH=$(find build -name AgentSynth.app -type d -maxdepth 3 | head -n 1)
         if [ -z "$APP_PATH" ]; then
-          echo "Gravisynth.app not found!"
+          echo "AgentSynth.app not found!"
           exit 1
         fi
         echo "Found app at: $APP_PATH"
@@ -111,7 +111,7 @@ jobs:
       shell: pwsh
       run: |
         New-Item -ItemType Directory -Force -Path artifact
-        Get-ChildItem -Path build -Recurse -Filter Gravisynth.exe | Copy-Item -Destination artifact\
+        Get-ChildItem -Path build -Recurse -Filter AgentSynth.exe | Copy-Item -Destination artifact\
 
     # Upload Artifact
     - name: Upload Artifact

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Gravisynth CI
+name: AgentSynth CI
 
 on:
   pull_request:
@@ -80,7 +80,7 @@ jobs:
         export LLVM_PROFILE_FILE="default.profraw"
         # Run without xvfb — tests are headless and xvfb's X11 event loop
         # adds ~44s overhead per pumpMessages() call on slow CI runners
-        ./build/Tests/GravisynthTests
+        ./build/Tests/AgentSynthTests
 
     - name: Check Coverage
       run: xvfb-run bash scripts/coverage.sh --report-only
@@ -127,10 +127,10 @@ jobs:
           -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address"
 
     - name: Build
-      run: cmake --build build --target GravisynthTests
+      run: cmake --build build --target AgentSynthTests
 
     - name: Run Tests
-      run: xvfb-run ./build/Tests/GravisynthTests
+      run: xvfb-run ./build/Tests/AgentSynthTests
       env:
         ASAN_OPTIONS: detect_leaks=0
 
@@ -180,7 +180,7 @@ jobs:
 
     - name: Run Tests
       working-directory: ./build/Tests
-      run: ./GravisynthTests
+      run: ./AgentSynthTests
 
   build-and-test-windows:
     name: Build and Test (Windows)
@@ -204,5 +204,5 @@ jobs:
       run: cmake --build build --config Release
 
     - name: Run Tests
-      run: ./build/Tests/Release/GravisynthTests.exe
+      run: ./build/Tests/Release/AgentSynthTests.exe
       shell: bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,8 +10,8 @@ This is a **modular synthesizer** application built with JUCE and C++20, featuri
 
 The project follows a modular architecture with:
 
-1. **Core Library (`GravisynthCore`)**: Contains all audio processing modules and core logic
-2. **Application Layer (`Gravisynth`)**: GUI application built on JUCE that uses the core library
+1. **Core Library (`AgentSynthCore`)**: Contains all audio processing modules and core logic
+2. **Application Layer (`AgentSynth`)**: GUI application built on JUCE that uses the core library
 3. **UI Components**: Graph editor and module components for visual patching
 
 ### Key Components
@@ -22,7 +22,7 @@ The project follows a modular architecture with:
 - **ModuleComponent**: Auto-UI generation from module parameters with type-safe layout switching via `ModuleType` enum
 - **AttenuverterModule**: Intermediary module for modulation routing with bypass and CV amount control; exposes `lastOutputPeak`/`lastModValue` atomics for UI visualization
 - **Port Labels**: Virtual `getInputPortLabel()`/`getOutputPortLabel()` on ModuleBase, overridden per-module for descriptive port names in the UI
-- **GravisynthUndoManager**: Snapshot-based undo/redo system wrapping `juce::UndoManager`, captures full graph state on every change
+- **UndoManager**: Snapshot-based undo/redo system wrapping `juce::UndoManager`, captures full graph state on every change
 - **AI Integration** (`Source/AI/`): AIIntegrationService orchestrates LLM-powered features via OllamaProvider; AIStateMapper translates graph state for AI context
 
 ### Audio Modules
@@ -63,10 +63,10 @@ cmake --build build
 
 ### Run Tests
 ```bash
-cmake --build build --target GravisynthTests
-./build/Tests/GravisynthTests
+cmake --build build --target AgentSynthTests
+./build/Tests/AgentSynthTests
 # Run only E2E workflow tests:
-./build/Tests/GravisynthTests --gtest_filter="E2EWorkflow*"
+./build/Tests/AgentSynthTests --gtest_filter="E2EWorkflow*"
 ```
 
 ### Build and Test (Release)
@@ -134,7 +134,7 @@ Shortcuts are configurable in Settings → General tab (click a binding to rebin
 
 - `CMakeLists.txt`: Main build configuration (version 0.13.2)
 - `Source/AudioEngine.h/cpp`: Audio processing engine, device management, and modulation matrix
-- `Source/GravisynthUndoManager.h/cpp`: Snapshot-based undo/redo with `SnapshotAction`, safe detach/reattach lifecycle
+- `Source/UndoManager.h/cpp`: Snapshot-based undo/redo with `SnapshotAction`, safe detach/reattach lifecycle
 - `Source/Modules/ModuleBase.h`: Base class with `ModuleType` enum, `ModulationTarget`, `ModulationCategory`
 - `Source/Modules/OscillatorModule.h`: Oscillator with PolyBLEP/PolyBLAMP anti-aliasing, waveform crossfade, and CV feedback fix (channel 0 shared between CV input and audio output, saved before overwrite)
 - `Source/Modules/FilterModule.h`: Multi-mode filter (LadderFilter for LPF/HPF/BPF + SVF for notch), atomic modulated params for visualizer, type parameter

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,7 +108,7 @@ endif()
 juce_add_gui_app(AgentSynth
     PRODUCT_NAME "AgentSynth"
     VERSION "0.13.2"
-    BUNDLE_ID "com.gravisynth.app"
+    BUNDLE_ID "com.agentsynth.app"
     BLUETOOTH_PERMISSION_ENABLED TRUE
     BLUETOOTH_PERMISSION_TEXT "We need Bluetooth access to connect to your external MIDI devices."
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.22)
 
-project(Gravisynth VERSION 0.13.2)
+project(AgentSynth VERSION 0.13.2)
 
 # Set C++ standard
 set(CMAKE_CXX_STANDARD 20)
@@ -29,11 +29,11 @@ if(ENABLE_COVERAGE)
 endif()
 
 # Create the core library
-add_library(GravisynthCore STATIC
+add_library(AgentSynthCore STATIC
     Source/AudioEngine.cpp
     Source/AudioEngine.h
-    Source/GravisynthUndoManager.cpp
-    Source/GravisynthUndoManager.h
+    Source/UndoManager.cpp
+    Source/UndoManager.h
     Source/PresetManager.cpp
     Source/PresetManager.h
     # Modules
@@ -67,7 +67,7 @@ add_library(GravisynthCore STATIC
 )
 
 # Link Core against JUCE
-target_link_libraries(GravisynthCore PUBLIC
+target_link_libraries(AgentSynthCore PUBLIC
     juce::juce_core
     juce::juce_events
     juce::juce_graphics
@@ -81,7 +81,7 @@ target_link_libraries(GravisynthCore PUBLIC
     juce::juce_dsp
 )
 
-target_compile_definitions(GravisynthCore PUBLIC JUCE_WEB_BROWSER=0)
+target_compile_definitions(AgentSynthCore PUBLIC JUCE_WEB_BROWSER=0)
 
 if(UNIX AND NOT APPLE)
     find_package(PkgConfig REQUIRED)
@@ -90,33 +90,33 @@ if(UNIX AND NOT APPLE)
     find_package(CURL REQUIRED)
 
     # Link to Core so JUCE modules compiled within it find the headers
-    target_link_libraries(GravisynthCore PUBLIC ${GTK3_LIBRARIES} CURL::libcurl)
-    target_include_directories(GravisynthCore PUBLIC ${GTK3_INCLUDE_DIRS})
+    target_link_libraries(AgentSynthCore PUBLIC ${GTK3_LIBRARIES} CURL::libcurl)
+    target_include_directories(AgentSynthCore PUBLIC ${GTK3_INCLUDE_DIRS})
 endif()
 
-target_include_directories(GravisynthCore PUBLIC
+target_include_directories(AgentSynthCore PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/Source
 )
 
 if(MSVC)
-    target_compile_options(GravisynthCore PRIVATE /W4)
+    target_compile_options(AgentSynthCore PRIVATE /W4)
 else()
-    target_compile_options(GravisynthCore PRIVATE -Wall -Wextra)
+    target_compile_options(AgentSynthCore PRIVATE -Wall -Wextra)
 endif()
 
 # Create the application target
-juce_add_gui_app(Gravisynth
-    PRODUCT_NAME "Gravisynth"
+juce_add_gui_app(AgentSynth
+    PRODUCT_NAME "AgentSynth"
     VERSION "0.13.2"
     BUNDLE_ID "com.gravisynth.app"
     BLUETOOTH_PERMISSION_ENABLED TRUE
     BLUETOOTH_PERMISSION_TEXT "We need Bluetooth access to connect to your external MIDI devices."
 )
 
-juce_generate_juce_header(Gravisynth)
+juce_generate_juce_header(AgentSynth)
 
 # Add source files
-target_sources(Gravisynth PRIVATE
+target_sources(AgentSynth PRIVATE
     Source/Main.cpp
     Source/MainComponent.cpp
     Source/MainComponent.h
@@ -135,8 +135,8 @@ target_sources(Gravisynth PRIVATE
 )
 
 # Link against JUCE modules
-target_link_libraries(Gravisynth PRIVATE
-    GravisynthCore # Link to our core library
+target_link_libraries(AgentSynth PRIVATE
+    AgentSynthCore # Link to our core library
     juce::juce_core
     juce::juce_events
     juce::juce_graphics
@@ -151,18 +151,18 @@ target_link_libraries(Gravisynth PRIVATE
     juce::juce_dsp
 )
 
-target_compile_definitions(Gravisynth PRIVATE JUCE_WEB_BROWSER=0)
+target_compile_definitions(AgentSynth PRIVATE JUCE_WEB_BROWSER=0)
 
 if(UNIX AND NOT APPLE)
-    target_link_libraries(Gravisynth PRIVATE ${GTK3_LIBRARIES})
-    target_include_directories(Gravisynth PRIVATE ${GTK3_INCLUDE_DIRS})
+    target_link_libraries(AgentSynth PRIVATE ${GTK3_LIBRARIES})
+    target_include_directories(AgentSynth PRIVATE ${GTK3_INCLUDE_DIRS})
 endif()
 
 # Enable strict warnings to catch issues early
 if(MSVC)
-    target_compile_options(Gravisynth PRIVATE /W4)
+    target_compile_options(AgentSynth PRIVATE /W4)
 else()
-    target_compile_options(Gravisynth PRIVATE -Wall -Wextra)
+    target_compile_options(AgentSynth PRIVATE -Wall -Wextra)
 endif()
 
 add_subdirectory(Tests)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to Gravisynth
+# Contributing to AgentSynth
 
 ## Development Setup
 
@@ -10,7 +10,7 @@
    ```
 3. Run tests:
    ```bash
-   ./build/Tests/GravisynthTests
+   ./build/Tests/AgentSynthTests
    ```
 
 ## Pull Request Workflow

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -10,8 +10,8 @@ This is a **modular synthesizer** application built with JUCE and C++20, featuri
 
 The project follows a modular architecture with:
 
-1. **Core Library (`GravisynthCore`)**: Contains all audio processing modules and core logic
-2. **Application Layer (`Gravisynth`)**: GUI application built on JUCE that uses the core library
+1. **Core Library (`AgentSynthCore`)**: Contains all audio processing modules and core logic
+2. **Application Layer (`AgentSynth`)**: GUI application built on JUCE that uses the core library
 3. **UI Components**: Graph editor and module components for visual patching
 
 ### Key Components
@@ -22,7 +22,7 @@ The project follows a modular architecture with:
 - **ModuleComponent**: Auto-UI generation from module parameters with type-safe layout switching via `ModuleType` enum
 - **AttenuverterModule**: Intermediary module for modulation routing with bypass and CV amount control; exposes `lastOutputPeak`/`lastModValue` atomics for UI visualization
 - **Port Labels**: Virtual `getInputPortLabel()`/`getOutputPortLabel()` on ModuleBase, overridden per-module for descriptive port names in the UI
-- **GravisynthUndoManager**: Snapshot-based undo/redo system wrapping `juce::UndoManager`, captures full graph state on every change
+- **UndoManager**: Snapshot-based undo/redo system wrapping `juce::UndoManager`, captures full graph state on every change
 - **AI Integration** (`Source/AI/`): AIIntegrationService orchestrates LLM-powered features via OllamaProvider; AIStateMapper translates graph state for AI context
 
 ### Audio Modules
@@ -63,10 +63,10 @@ cmake --build build
 
 ### Run Tests
 ```bash
-cmake --build build --target GravisynthTests
-./build/Tests/GravisynthTests
+cmake --build build --target AgentSynthTests
+./build/Tests/AgentSynthTests
 # Run only E2E workflow tests:
-./build/Tests/GravisynthTests --gtest_filter="E2EWorkflow*"
+./build/Tests/AgentSynthTests --gtest_filter="E2EWorkflow*"
 ```
 
 ### Build and Test (Release)
@@ -134,7 +134,7 @@ Shortcuts are configurable in Settings → General tab (click a binding to rebin
 
 - `CMakeLists.txt`: Main build configuration (version 0.13.2)
 - `Source/AudioEngine.h/cpp`: Audio processing engine, device management, and modulation matrix
-- `Source/GravisynthUndoManager.h/cpp`: Snapshot-based undo/redo with `SnapshotAction`, safe detach/reattach lifecycle
+- `Source/UndoManager.h/cpp`: Snapshot-based undo/redo with `SnapshotAction`, safe detach/reattach lifecycle
 - `Source/Modules/ModuleBase.h`: Base class with `ModuleType` enum, `ModulationTarget`, `ModulationCategory`
 - `Source/Modules/OscillatorModule.h`: Oscillator with PolyBLEP/PolyBLAMP anti-aliasing, waveform crossfade, and CV feedback fix (channel 0 shared between CV input and audio output, saved before overwrite)
 - `Source/Modules/FilterModule.h`: Multi-mode filter (LadderFilter for LPF/HPF/BPF + SVF for notch), atomic modulated params for visualizer, type parameter

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Gravisynth
+# AgentSynth
 
 A **modular synthesizer** application built with JUCE and C++20, featuring a node-based graph editor for sound design.
 
 ## Overview
 
-Gravisynth provides a visual patching environment where audio modules can be freely connected to create complex sounds. Each module processes audio and/or control signals, enabling everything from simple subtractive synthesis to elaborate modulation chains.
+AgentSynth provides a visual patching environment where audio modules can be freely connected to create complex sounds. Each module processes audio and/or control signals, enabling everything from simple subtractive synthesis to elaborate modulation chains.
 
 ### Module Graph
 Modules connect via inputs and outputs:
@@ -33,20 +33,20 @@ Modules connect via inputs and outputs:
 - **Poly Sequencer**: Multi-voice pattern sequencing.
 
 ### Modulation System
-Gravisynth uses a hidden **Attenuverter** node architecture for modulation routing:
+AgentSynth uses a hidden **Attenuverter** node architecture for modulation routing:
 - **Smart Cables**: CV connections display an interactive depth knob at the cable midpoint. Drag to adjust depth (bipolar ±100%), double-click to delete.
 - **Mod Matrix Panel**: A panel listing all active CV connections with labelled sliders. Fully synced with the smart cable knobs in real time.
 - **Panel Toggles**: Top-bar **Hide AI** and **Hide Matrix** buttons collapse panels to give the graph more space.
 
 ### AI Integration
-> **Note**: The AI integration is currently in an experimental state and may not function as expected. There are plans to migrate the AI harness into a separate, closed-source project in the future. The core Gravisynth engine and modular synth will remain open-source forever.
+> **Note**: The AI integration is currently in an experimental state and may not function as expected. There are plans to migrate the AI harness into a separate, closed-source project in the future. The core AgentSynth engine and modular synth will remain open-source forever.
 
 - **AI Sound Designer**: Describe a sound in natural language and the AI generates the complete patch (modules, parameters, and connections).
 - **One-Click Apply**: Instantly apply AI-generated patches to the graph editor.
 
 ## Building
 
-Gravisynth uses CMake for its build system.
+AgentSynth uses CMake for its build system.
 
 ### Prerequisites
 -   A C++20 compatible compiler (e.g., Clang, GCC, MSVC)
@@ -75,20 +75,20 @@ Gravisynth uses CMake for its build system.
 
 3.  **Build the application:**
     ```bash
-    cmake --build build --target Gravisynth
+    cmake --build build --target AgentSynth
     ```
-    This will compile the application. On macOS, the executable will be found at `build/Gravisynth_artefacts/<BuildType>/Gravisynth.app`. On other platforms, the path might vary (e.g., `build/<BuildType>/Gravisynth`).
+    This will compile the application. On macOS, the executable will be found at `build/AgentSynth_artefacts/<BuildType>/AgentSynth.app`. On other platforms, the path might vary (e.g., `build/<BuildType>/AgentSynth`).
 
 4.  **Run the application:**
     *   **macOS:**
         ```bash
-        open build/Gravisynth_artefacts/Release/Gravisynth.app
+        open build/AgentSynth_artefacts/Release/AgentSynth.app
         # or
-        open build/Gravisynth_artefacts/Debug/Gravisynth.app
+        open build/AgentSynth_artefacts/Debug/AgentSynth.app
         ```
     *   **Linux/Windows (example for Release):**
         ```bash
-        ./build/Release/Gravisynth
+        ./build/Release/AgentSynth
         ```
 
 ## Development
@@ -103,18 +103,18 @@ Gravisynth uses CMake for its build system.
 
 ## Testing
 
-Gravisynth uses GoogleTest for unit testing.
+AgentSynth uses GoogleTest for unit testing.
 
 ### Running Unit Tests
 
 1.  **Build the test suite:**
     ```bash
-    cmake --build build --target GravisynthTests
+    cmake --build build --target AgentSynthTests
     ```
 
 2.  **Execute the tests:**
     ```bash
-    ./build/Tests/GravisynthTests
+    ./build/Tests/AgentSynthTests
     ```
 
 ### Code Coverage
@@ -141,7 +141,7 @@ This script will build the project with coverage flags, run the tests, and gener
 - **Polyphonic Modulation**: Route LFOs/envelopes per voice.
 
 ### Vision: AI-Powered Sound Design
-*Note: This roadmap for AI features will be fulfilled by a separate closed-source project in the future. Gravisynth itself remains the open-source foundation.*
+*Note: This roadmap for AI features will be fulfilled by a separate closed-source project in the future. AgentSynth itself remains the open-source foundation.*
 
 - [x] **Local AI Integration**: Support for Ollama and local models.
 - [x] **Natural Language Patching**: Text-to-patch generation.

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ AgentSynth uses CMake for its build system.
 
 1.  **Clone the repository:**
     ```bash
-    git clone https://github.com/Diabl0269/gravisynth.git
-    cd gravisynth
+    git clone https://github.com/Diabl0269/agentsynth.git
+    cd agentsynth
     ```
 
 2.  **Configure CMake:**

--- a/Source/AI/AIIntegrationService.cpp
+++ b/Source/AI/AIIntegrationService.cpp
@@ -107,9 +107,9 @@ void AIIntegrationService::initSystemPrompt() {
     juce::String schema = AIStateMapper::getModuleSchema();
 
     juce::String systemMsg =
-        "You are Gravisynth AI, an expert sound designer for the Gravisynth modular synthesizer. "
+        "You are AgentSynth AI, an expert sound designer for the AgentSynth modular synthesizer. "
         "Your goal is to help users create and modify patches. "
-        "Gravisynth uses a nodes-and-connections model. "
+        "AgentSynth uses a nodes-and-connections model. "
         "\n\n" +
         schema +
         "\n"

--- a/Source/Main.cpp
+++ b/Source/Main.cpp
@@ -2,9 +2,9 @@
 #include "ShortcutManager.h"
 #include <JuceHeader.h>
 
-class GravisynthApplication : public juce::JUCEApplication {
+class AgentSynthApplication : public juce::JUCEApplication {
 public:
-    GravisynthApplication() {}
+    AgentSynthApplication() {}
 
     const juce::String getApplicationName() override { return ProjectInfo::projectName; }
     const juce::String getApplicationVersion() override { return ProjectInfo::versionString; }
@@ -65,13 +65,13 @@ public:
             if (auto* mc = dynamic_cast<MainComponent*>(getContentComponent())) {
                 auto& cm = mc->getCommandManager();
                 if (menuIndex == 0) {
-                    menu.addCommandItem(&cm, GravisynthCommands::savePreset);
-                    menu.addCommandItem(&cm, GravisynthCommands::openPreset);
+                    menu.addCommandItem(&cm, AgentSynthCommands::savePreset);
+                    menu.addCommandItem(&cm, AgentSynthCommands::openPreset);
                     menu.addSeparator();
-                    menu.addCommandItem(&cm, GravisynthCommands::openSettings);
+                    menu.addCommandItem(&cm, AgentSynthCommands::openSettings);
                 } else if (menuIndex == 1) {
-                    menu.addCommandItem(&cm, GravisynthCommands::undo);
-                    menu.addCommandItem(&cm, GravisynthCommands::redo);
+                    menu.addCommandItem(&cm, AgentSynthCommands::undo);
+                    menu.addCommandItem(&cm, AgentSynthCommands::redo);
                 }
             }
             return menu;
@@ -88,4 +88,4 @@ private:
 };
 
 //==============================================================================
-START_JUCE_APPLICATION(GravisynthApplication)
+START_JUCE_APPLICATION(AgentSynthApplication)

--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -7,8 +7,8 @@ MainComponent::MainComponent(std::unique_ptr<gsynth::AIProvider> provider)
     , aiService(audioEngine.getGraph())
     , aiChatComponent(aiService) {
     // Setup ApplicationProperties
-    propertiesOptions.applicationName = "Gravisynth";
-    propertiesOptions.folderName = "Gravisynth";
+    propertiesOptions.applicationName = "AgentSynth";
+    propertiesOptions.folderName = "AgentSynth";
     propertiesOptions.filenameSuffix = "settings";
     propertiesOptions.osxLibrarySubFolder = "Application Support";
     propertiesOptions.storageFormat = juce::PropertiesFile::storeAsXML;
@@ -199,37 +199,37 @@ void MainComponent::paint(juce::Graphics& g) {
 }
 
 void MainComponent::getAllCommands(juce::Array<juce::CommandID>& commands) {
-    commands.addArray({GravisynthCommands::openSettings, GravisynthCommands::savePreset, GravisynthCommands::openPreset,
-                       GravisynthCommands::undo, GravisynthCommands::redo});
+    commands.addArray({AgentSynthCommands::openSettings, AgentSynthCommands::savePreset, AgentSynthCommands::openPreset,
+                       AgentSynthCommands::undo, AgentSynthCommands::redo});
 }
 
 void MainComponent::getCommandInfo(juce::CommandID commandID, juce::ApplicationCommandInfo& result) {
     switch (commandID) {
-    case GravisynthCommands::openSettings: {
+    case AgentSynthCommands::openSettings: {
         result.setInfo("Open Settings", "Open the settings window", "General", 0);
         auto kp = shortcutManager.getBinding("openSettings");
         result.addDefaultKeypress(kp.getKeyCode(), kp.getModifiers());
         break;
     }
-    case GravisynthCommands::savePreset: {
+    case AgentSynthCommands::savePreset: {
         result.setInfo("Save Preset", "Save the current preset", "General", 0);
         auto kp = shortcutManager.getBinding("savePreset");
         result.addDefaultKeypress(kp.getKeyCode(), kp.getModifiers());
         break;
     }
-    case GravisynthCommands::openPreset: {
+    case AgentSynthCommands::openPreset: {
         result.setInfo("Open Preset", "Open a preset file", "General", 0);
         auto kp = shortcutManager.getBinding("openPreset");
         result.addDefaultKeypress(kp.getKeyCode(), kp.getModifiers());
         break;
     }
-    case GravisynthCommands::undo: {
+    case AgentSynthCommands::undo: {
         result.setInfo("Undo", "Undo the last action", "Edit", 0);
         auto kp = shortcutManager.getBinding("undo");
         result.addDefaultKeypress(kp.getKeyCode(), kp.getModifiers());
         break;
     }
-    case GravisynthCommands::redo: {
+    case AgentSynthCommands::redo: {
         result.setInfo("Redo", "Redo the last undone action", "Edit", 0);
         auto kp = shortcutManager.getBinding("redo");
         result.addDefaultKeypress(kp.getKeyCode(), kp.getModifiers());
@@ -242,22 +242,22 @@ void MainComponent::getCommandInfo(juce::CommandID commandID, juce::ApplicationC
 
 bool MainComponent::perform(const InvocationInfo& info) {
     switch (info.commandID) {
-    case GravisynthCommands::openSettings:
+    case AgentSynthCommands::openSettings:
         if (settingsButton.onClick)
             settingsButton.onClick();
         return true;
-    case GravisynthCommands::savePreset:
+    case AgentSynthCommands::savePreset:
         if (saveButton.onClick)
             saveButton.onClick();
         return true;
-    case GravisynthCommands::openPreset:
+    case AgentSynthCommands::openPreset:
         openPresetFromFile();
         return true;
-    case GravisynthCommands::undo:
+    case AgentSynthCommands::undo:
         if (undoManager.canUndo())
             undoManager.undo();
         return true;
-    case GravisynthCommands::redo:
+    case AgentSynthCommands::redo:
         if (undoManager.canRedo())
             undoManager.redo();
         return true;
@@ -272,7 +272,7 @@ bool MainComponent::keyPressed(const juce::KeyPress& key) {
     auto action = shortcutManager.getActionForKeyPress(key);
     if (action.isEmpty())
         return false;
-    auto cmdId = GravisynthCommands::getCommandForAction(action);
+    auto cmdId = AgentSynthCommands::getCommandForAction(action);
     if (cmdId == 0)
         return false;
     return commandManager.invokeDirectly(cmdId, true);

--- a/Source/MainComponent.h
+++ b/Source/MainComponent.h
@@ -2,12 +2,12 @@
 
 #include "AI/AIIntegrationService.h"
 #include "AudioEngine.h"
-#include "GravisynthUndoManager.h"
 #include "PresetManager.h"
 #include "ShortcutManager.h"
 #include "UI/AIChatComponent.h"
 #include "UI/GraphEditor.h"
 #include "UI/ModuleLibraryComponent.h"
+#include "UndoManager.h"
 #include <juce_audio_utils/juce_audio_utils.h>
 #include <juce_gui_basics/juce_gui_basics.h>
 
@@ -56,7 +56,7 @@ public:
         if (redoButton.onClick)
             redoButton.onClick();
     }
-    GravisynthUndoManager& getUndoManager() { return undoManager; }
+    UndoManager& getUndoManager() { return undoManager; }
     AudioEngine& getAudioEngine() { return audioEngine; }
     void openPresetFromFile();
 
@@ -64,7 +64,7 @@ private:
     // AIIntegrationService::Listener
     void aiPatchApplied() override;
 
-    GravisynthUndoManager undoManager;
+    UndoManager undoManager;
     AudioEngine audioEngine;
     GraphEditor graphEditor;
     ModuleLibraryComponent moduleLibrary;

--- a/Source/ShortcutManager.h
+++ b/Source/ShortcutManager.h
@@ -2,7 +2,7 @@
 
 #include <juce_gui_basics/juce_gui_basics.h>
 
-namespace GravisynthCommands {
+namespace AgentSynthCommands {
 enum CommandIDs { openSettings = 0x100, savePreset, openPreset, undo, redo };
 
 inline juce::CommandID getCommandForAction(const juce::String& actionId) {
@@ -18,7 +18,7 @@ inline juce::CommandID getCommandForAction(const juce::String& actionId) {
         return redo;
     return 0;
 }
-} // namespace GravisynthCommands
+} // namespace AgentSynthCommands
 
 class ShortcutManager {
 public:

--- a/Source/UI/GraphEditor.cpp
+++ b/Source/UI/GraphEditor.cpp
@@ -21,7 +21,7 @@
 #include "../Modules/VoiceMixerModule.h"
 #include "ModuleComponent.h"
 
-GraphEditor::GraphEditor(AudioEngine& engine, GravisynthUndoManager* undoMgr)
+GraphEditor::GraphEditor(AudioEngine& engine, UndoManager* undoMgr)
     : audioEngine(engine)
     , content(*this)
     , modMatrix(engine, undoMgr)
@@ -213,7 +213,7 @@ void GraphEditor::GraphContentComponent::paint(juce::Graphics& g) {
     }
 
     g.setColour(juce::Colours::white);
-    g.drawText("Gravisynth (Double click to refresh)", getLocalBounds().removeFromTop(20), juce::Justification::centred,
+    g.drawText("AgentSynth (Double click to refresh)", getLocalBounds().removeFromTop(20), juce::Justification::centred,
                true);
 }
 

--- a/Source/UI/GraphEditor.h
+++ b/Source/UI/GraphEditor.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "../AudioEngine.h"
-#include "../GravisynthUndoManager.h"
+#include "../UndoManager.h"
 #include <juce_gui_basics/juce_gui_basics.h>
 
 class ModuleComponent;
@@ -12,7 +12,7 @@ class GraphEditor
     , public juce::Timer
     , public juce::DragAndDropTarget {
 public:
-    GraphEditor(AudioEngine& engine, GravisynthUndoManager* undoMgr = nullptr);
+    GraphEditor(AudioEngine& engine, UndoManager* undoMgr = nullptr);
     ~GraphEditor() override;
 
     AudioEngine& getAudioEngine() { return audioEngine; }
@@ -92,7 +92,7 @@ private:
     juce::AudioProcessorGraph::NodeID draggingAttenuverterNodeId;
     float attenDragStartValue = 0.0f;
 
-    GravisynthUndoManager* undoManager = nullptr;
+    UndoManager* undoManager = nullptr;
     std::vector<AudioEngine::ModulationDisplayInfo> cachedModDisplayInfo;
 
     void updateTransform();

--- a/Source/UI/ModMatrixComponent.cpp
+++ b/Source/UI/ModMatrixComponent.cpp
@@ -3,7 +3,7 @@
 #include <algorithm>
 #include <map>
 
-ModMatrixComponent::ModMatrixComponent(AudioEngine& engine, GravisynthUndoManager* undoMgr)
+ModMatrixComponent::ModMatrixComponent(AudioEngine& engine, UndoManager* undoMgr)
     : audioEngine(engine)
     , undoManager(undoMgr) {
     addAndMakeVisible(viewport);

--- a/Source/UI/ModMatrixComponent.h
+++ b/Source/UI/ModMatrixComponent.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "../AudioEngine.h"
-#include "../GravisynthUndoManager.h"
+#include "../UndoManager.h"
 #include <juce_gui_basics/juce_gui_basics.h>
 #include <map>
 
@@ -9,7 +9,7 @@ class ModMatrixComponent
     : public juce::Component
     , public juce::Timer {
 public:
-    ModMatrixComponent(AudioEngine& engine, GravisynthUndoManager* undoMgr = nullptr);
+    ModMatrixComponent(AudioEngine& engine, UndoManager* undoMgr = nullptr);
     ~ModMatrixComponent() override;
 
     void paint(juce::Graphics& g) override;
@@ -28,7 +28,7 @@ public:
 
 private:
     AudioEngine& audioEngine;
-    GravisynthUndoManager* undoManager = nullptr;
+    UndoManager* undoManager = nullptr;
     bool isSourceMenuFlat = false;
 
     juce::TextButton addButton{"Add Modulation"};

--- a/Source/UI/ModuleComponent.cpp
+++ b/Source/UI/ModuleComponent.cpp
@@ -11,7 +11,7 @@ static ModuleType getType(juce::AudioProcessor* module) {
 }
 
 ModuleComponent::ModuleComponent(juce::AudioProcessor* m, juce::AudioProcessorGraph::NodeID nId, GraphEditor& owner,
-                                 GravisynthUndoManager* undoMgr)
+                                 UndoManager* undoMgr)
     : module(m)
     , nodeId(nId)
     , owner(owner)

--- a/Source/UI/ModuleComponent.h
+++ b/Source/UI/ModuleComponent.h
@@ -1,9 +1,9 @@
 #pragma once
 
 #include "../AudioEngine.h"
-#include "../GravisynthUndoManager.h"
 #include "../Modules/FilterModule.h"
 #include "../Modules/MidiKeyboardModule.h"
+#include "../UndoManager.h"
 #include "FrequencyResponseComponent.h"
 #include "ScopeComponent.h"
 #include <juce_audio_processors/juce_audio_processors.h>
@@ -19,7 +19,7 @@ class ModuleComponent
     , public juce::AudioProcessorParameter::Listener {
 public:
     ModuleComponent(juce::AudioProcessor* module, juce::AudioProcessorGraph::NodeID nodeId, GraphEditor& owner,
-                    GravisynthUndoManager* undoMgr = nullptr);
+                    UndoManager* undoMgr = nullptr);
 
     void parameterValueChanged(int parameterIndex, float newValue) override;
     void parameterGestureChanged(int parameterIndex, bool gestureIsStarting) override;
@@ -80,7 +80,7 @@ private:
     std::unique_ptr<juce::TextButton> bypassButton;
     std::unique_ptr<juce::ButtonParameterAttachment> bypassAttachment;
 
-    GravisynthUndoManager* undoManager = nullptr;
+    UndoManager* undoManager = nullptr;
     std::map<int, float> gestureStartValues;
     juce::Point<int> dragStartPosition;
 

--- a/Source/UndoManager.cpp
+++ b/Source/UndoManager.cpp
@@ -1,4 +1,4 @@
-#include "GravisynthUndoManager.h"
+#include "UndoManager.h"
 #include "AI/AIStateMapper.h"
 #include "UI/GraphEditor.h"
 
@@ -181,9 +181,9 @@ private:
 
 // =============================================================================
 
-GravisynthUndoManager::GravisynthUndoManager() {}
+UndoManager::UndoManager() {}
 
-void GravisynthUndoManager::recordStructuralChange(juce::AudioProcessorGraph& graph, std::function<void()> mutation) {
+void UndoManager::recordStructuralChange(juce::AudioProcessorGraph& graph, std::function<void()> mutation) {
     auto beforeState = gsynth::AIStateMapper::graphToJSON(graph);
 
     undoManager.beginNewTransaction();
@@ -205,17 +205,15 @@ void GravisynthUndoManager::recordStructuralChange(juce::AudioProcessorGraph& gr
         }));
 }
 
-void GravisynthUndoManager::recordParameterChange(juce::AudioProcessorGraph& graph,
-                                                  juce::AudioProcessorGraph::NodeID nodeId, const juce::String& paramId,
-                                                  float oldValue, float newValue) {
+void UndoManager::recordParameterChange(juce::AudioProcessorGraph& graph, juce::AudioProcessorGraph::NodeID nodeId,
+                                        const juce::String& paramId, float oldValue, float newValue) {
     // The firstPerform flag will skip the first perform() since the parameter
     // was already changed by the user.
     undoManager.perform(new ParameterChangeAction(graph, nodeId, paramId, oldValue, newValue));
 }
 
-void GravisynthUndoManager::recordPositionChange(juce::AudioProcessorGraph& graph,
-                                                 juce::AudioProcessorGraph::NodeID nodeId, int oldX, int oldY, int newX,
-                                                 int newY, std::function<void()> postRestore) {
+void UndoManager::recordPositionChange(juce::AudioProcessorGraph& graph, juce::AudioProcessorGraph::NodeID nodeId,
+                                       int oldX, int oldY, int newX, int newY, std::function<void()> postRestore) {
     undoManager.beginNewTransaction();
 
     // The firstPerform flag will skip the first perform() since the position
@@ -223,11 +221,11 @@ void GravisynthUndoManager::recordPositionChange(juce::AudioProcessorGraph& grap
     undoManager.perform(new PositionChangeAction(graph, nodeId, oldX, oldY, newX, newY, postRestore));
 }
 
-void GravisynthUndoManager::captureBeforeState(juce::AudioProcessorGraph& graph) {
+void UndoManager::captureBeforeState(juce::AudioProcessorGraph& graph) {
     capturedBeforeState = gsynth::AIStateMapper::graphToJSON(graph);
 }
 
-void GravisynthUndoManager::pushSnapshotFromCapture(juce::AudioProcessorGraph& graph) {
+void UndoManager::pushSnapshotFromCapture(juce::AudioProcessorGraph& graph) {
     if (capturedBeforeState.isVoid())
         return;
 

--- a/Source/UndoManager.h
+++ b/Source/UndoManager.h
@@ -5,15 +5,15 @@
 #include <juce_data_structures/juce_data_structures.h>
 
 /**
- * @class GravisynthUndoManager
+ * @class UndoManager
  * @brief Thin wrapper around juce::UndoManager with convenience methods for
  *        structural changes, parameter edits, and module repositioning.
  */
 class GraphEditor; // Forward declaration
 
-class GravisynthUndoManager {
+class UndoManager {
 public:
-    GravisynthUndoManager();
+    UndoManager();
 
     void setGraphEditor(GraphEditor* ge) { graphEditor = ge; }
 
@@ -81,5 +81,5 @@ private:
     juce::UndoManager undoManager{30000000, 50}; // 30MB limit, 50 min transactions
     juce::var capturedBeforeState;
 
-    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(GravisynthUndoManager)
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(UndoManager)
 };

--- a/Tests/ADSRTests.cpp
+++ b/Tests/ADSRTests.cpp
@@ -18,7 +18,7 @@ TEST_F(ADSRTest, StartsIdle) {
     // Initially should output 0
     adsr.processBlock(buffer, midiMessages);
     // Since ADSR modifies buffer in place (multiplying?), typically ADSR is a
-    // control signal or VCA? In Gravisynth, ADSRModule might just generate an
+    // control signal or VCA? In AgentSynth, ADSRModule might just generate an
     // envelope or apply it. Checking code... wait, I need to check ADSRModule
     // implementation to know if it's a generator or processor. Assuming standard
     // VCA-like behavior or just check "getNextSample" if exposed? "ModuleBase"

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -9,7 +9,7 @@ FetchContent_Declare(
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)
 
-add_executable(GravisynthTests
+add_executable(AgentSynthTests
     TestMain.cpp
     OscillatorTests.cpp
     FilterTests.cpp
@@ -54,22 +54,22 @@ add_executable(GravisynthTests
     ../Source/UI/SettingsWindow.cpp
 )
 
-target_link_libraries(GravisynthTests PRIVATE
+target_link_libraries(AgentSynthTests PRIVATE
     GTest::gtest
-    GravisynthCore
+    AgentSynthCore
 )
 
-# Sources are now in GravisynthCore, so we don't need to add them here manually
+# Sources are now in AgentSynthCore, so we don't need to add them here manually
 # except for the test files themselves.
 
-target_include_directories(GravisynthTests PRIVATE
+target_include_directories(AgentSynthTests PRIVATE
     ${CMAKE_SOURCE_DIR}/Source
 )
 
-target_compile_definitions(GravisynthTests PRIVATE JUCE_MODAL_LOOPS_PERMITTED=1)
+target_compile_definitions(AgentSynthTests PRIVATE JUCE_MODAL_LOOPS_PERMITTED=1)
 
 # Link JUCE specifics if needed
-target_link_libraries(GravisynthTests PRIVATE
+target_link_libraries(AgentSynthTests PRIVATE
     juce::juce_core
     juce::juce_events
     juce::juce_audio_basics
@@ -77,4 +77,4 @@ target_link_libraries(GravisynthTests PRIVATE
 )
 
 include(GoogleTest)
-gtest_discover_tests(GravisynthTests)
+gtest_discover_tests(AgentSynthTests)

--- a/Tests/E2EWorkflowTests.cpp
+++ b/Tests/E2EWorkflowTests.cpp
@@ -1,5 +1,4 @@
 #include "../Source/AI/AIProvider.h"
-#include "../Source/GravisynthUndoManager.h"
 #include "../Source/Modules/ADSRModule.h"
 #include "../Source/Modules/FX/ChorusModule.h"
 #include "../Source/Modules/FX/CompressorModule.h"
@@ -20,6 +19,7 @@
 #include "../Source/PresetManager.h"
 #include "../Source/UI/GraphEditor.h"
 #include "../Source/UI/ModuleComponent.h"
+#include "../Source/UndoManager.h"
 #include "MainComponent.h"
 #include <gtest/gtest.h>
 #include <juce_gui_basics/juce_gui_basics.h>
@@ -59,10 +59,10 @@ protected:
     GraphEditor& editor() { return mainComp->getGraphEditor(); }
     AudioEngine& engine() { return mainComp->getAudioEngine(); }
     juce::AudioProcessorGraph& graph() { return engine().getGraph(); }
-    GravisynthUndoManager& undoMgr() { return *undoMgrPtr(); }
+    UndoManager& undoMgr() { return *undoMgrPtr(); }
 
     // Access undo manager - note: MainComponent doesn't expose it yet, so we'll need a workaround
-    GravisynthUndoManager* undoMgrPtr() {
+    UndoManager* undoMgrPtr() {
         // For now, we'll use the GraphEditor's undoManager indirectly
         // This is a limitation of current testing hooks
         return nullptr; // Will be addressed with new hooks

--- a/Tests/GraphEditorTests.cpp
+++ b/Tests/GraphEditorTests.cpp
@@ -1,4 +1,3 @@
-#include "../Source/GravisynthUndoManager.h"
 #include "../Source/Modules/ADSRModule.h"
 #include "../Source/Modules/FilterModule.h"
 #include "../Source/Modules/LFOModule.h"
@@ -7,6 +6,7 @@
 #include "../Source/Modules/VCAModule.h"
 #include "../Source/UI/GraphEditor.h"
 #include "../Source/UI/ModuleComponent.h"
+#include "../Source/UndoManager.h"
 #include <gtest/gtest.h>
 #include <juce_gui_basics/juce_gui_basics.h>
 
@@ -307,7 +307,7 @@ TEST_F(GraphEditorTest, ReplaceModulePreservesMidiConnections) {
 
 TEST_F(GraphEditorTest, ReplaceModuleIsUndoable) {
     AudioEngine engine;
-    GravisynthUndoManager undoMgr;
+    UndoManager undoMgr;
     GraphEditor editor(engine, &undoMgr);
     editor.setSize(800, 600);
 

--- a/Tests/SettingsWindowTests.cpp
+++ b/Tests/SettingsWindowTests.cpp
@@ -33,8 +33,8 @@ protected:
     void SetUp() override {
         // Set up ApplicationProperties with temporary storage for testing
         juce::PropertiesFile::Options options;
-        options.applicationName = "GravisynthSettingsTest";
-        options.folderName = "GravisynthSettingsTest";
+        options.applicationName = "AgentSynthSettingsTest";
+        options.folderName = "AgentSynthSettingsTest";
         options.osxLibrarySubFolder = "Application Support";
 
         appProperties.setStorageParameters(options);

--- a/Tests/ShortcutManagerTests.cpp
+++ b/Tests/ShortcutManagerTests.cpp
@@ -42,8 +42,8 @@ TEST_F(ShortcutManagerTest, SetBinding_Updates) {
 TEST_F(ShortcutManagerTest, SaveAndLoad_RoundTrips) {
     juce::ApplicationProperties props;
     juce::PropertiesFile::Options opts;
-    opts.applicationName = "GravisynthShortcutTest";
-    opts.folderName = "GravisynthShortcutTest";
+    opts.applicationName = "AgentSynthShortcutTest";
+    opts.folderName = "AgentSynthShortcutTest";
     opts.filenameSuffix = "settings";
     opts.osxLibrarySubFolder = "Application Support";
     opts.storageFormat = juce::PropertiesFile::storeAsXML;

--- a/Tests/UndoRedoTests.cpp
+++ b/Tests/UndoRedoTests.cpp
@@ -1,15 +1,15 @@
 #include "../Source/AI/AIStateMapper.h"
-#include "../Source/GravisynthUndoManager.h"
 #include "../Source/Modules/FilterModule.h"
 #include "../Source/Modules/OscillatorModule.h"
 #include "../Source/Modules/VCAModule.h"
+#include "../Source/UndoManager.h"
 #include <gtest/gtest.h>
 #include <juce_audio_processors/juce_audio_processors.h>
 
 class UndoRedoTest : public ::testing::Test {
 protected:
     juce::AudioProcessorGraph graph;
-    GravisynthUndoManager undoManager;
+    UndoManager undoManager;
 
     void SetUp() override { graph.clear(); }
 };

--- a/conductor/add-distortion-types.md
+++ b/conductor/add-distortion-types.md
@@ -9,13 +9,13 @@ Implement additional distortion algorithms (e.g., Hard Clip, Foldback) in `Disto
     *   Update `applyWaveshaper` to accept the selected type and implement the new algorithms.
     *   Update parameter list registration.
 2.  **UI Update**:
-    *   The `ModuleComponent` should auto-detect the new `ChoiceParameter` and update the UI (Gravisynth's auto-UI should handle this automatically based on existing parameter handling).
+    *   The `ModuleComponent` should auto-detect the new `ChoiceParameter` and update the UI (Agent Synth's auto-UI should handle this automatically based on existing parameter handling).
 3.  **Testing**:
     *   Update `Tests/DistortionSweepTests.cpp` to verify all distortion types.
     *   Add a test case to ensure modulation still works correctly with new types.
 
 ## Verification
-*   Build and run `GravisynthTests`.
+*   Build and run `Agent SynthTests`.
 *   Verify UI displays the new "Type" parameter.
 *   Verify distortion sounds different for different types (via `DistortionSweepTests`).
 

--- a/conductor/rebrand_plan.md
+++ b/conductor/rebrand_plan.md
@@ -1,0 +1,30 @@
+# Implementation Plan: Rebrand AgentSynth to Agent Synth
+
+## Objective
+Rebrand the project from "AgentSynth" to "Agent Synth". This involves renaming classes, files, namespaces, and build targets systematically.
+
+## Key Files & Context
+- `Source/`: Contains core logic, namespaces, and JUCE application files.
+- `CMakeLists.txt`: Defines build targets and module sources.
+- `docs/`: All documentation files require updates.
+- `scripts/`: Build/Test scripts reference old names.
+- `Tests/`: Test files include old headers and class references.
+- `.github/`: Workflow files.
+
+## Implementation Steps
+1. **Pass 1: Namespace & String Replacement**
+   - Replace "AgentSynth" with "AgentSynth" across all source and text files, prioritizing namespacing and code identifiers.
+2. **Pass 2: Filename Simplification**
+   - Rename files (e.g., `UndoManager.h` -> `UndoManager.h`, `AgentSynthApplication.cpp` -> `Application.cpp` where applicable) to remove unnecessary brand prefixes.
+3. **Pass 3: Build System & Scripts**
+   - Update `CMakeLists.txt`, `scripts/`, and `.github/` to reflect new targets, file paths, and names.
+4. **Pass 4: Documentation**
+   - Update all files in `docs/`, `README.md`, `CONTRIBUTING.md`, `CLAUDE.md`, and `GEMINI.md`.
+
+## Verification & Testing
+- Build the project using `cmake`.
+- Run existing test suites.
+- Verify CI/CD workflows match new naming.
+
+## Docs Updates
+- All files in `docs/`, `README.md`, `CONTRIBUTING.md`, `CLAUDE.md`, `GEMINI.md`.

--- a/docs/AI_Engine.md
+++ b/docs/AI_Engine.md
@@ -1,9 +1,9 @@
-# Gravisynth AI Engine Documentation
+# AgentSynth AI Engine Documentation
 
-This document provides a comprehensive overview of the AI Engine integrated into Gravisynth, detailing its architecture, components, communication patterns, and key functionalities.
+This document provides a comprehensive overview of the AI Engine integrated into AgentSynth, detailing its architecture, components, communication patterns, and key functionalities.
 
 ## 1. Overview
-The Gravisynth AI Engine serves as an intelligent sound design assistant, enabling users to generate and modify synthesizer patches using natural language commands. Its primary goal is to bridge the gap between intuitive textual instructions and the complex, modular architecture of the Gravisynth synthesizer. This allows for a more accessible and creative sound design workflow.
+The AgentSynth AI Engine serves as an intelligent sound design assistant, enabling users to generate and modify synthesizer patches using natural language commands. Its primary goal is to bridge the gap between intuitive textual instructions and the complex, modular architecture of the AgentSynth synthesizer. This allows for a more accessible and creative sound design workflow.
 
 ## 2. Architecture
 
@@ -11,7 +11,7 @@ The AI Engine's architecture is designed for modularity and extensibility, prima
 
 ### Core Components:
 
--   **`AIProvider`**: An abstract interface defining the contract for any AI backend integration. This allows Gravisynth to support various large language models (LLMs) or AI services (e.g., Ollama, OpenAI) by implementing this interface. It specifies methods for sending prompts, retrieving responses, and managing available models.
+-   **`AIProvider`**: An abstract interface defining the contract for any AI backend integration. This allows AgentSynth to support various large language models (LLMs) or AI services (e.g., Ollama, OpenAI) by implementing this interface. It specifies methods for sending prompts, retrieving responses, and managing available models.
 
 -   **`OllamaProvider`**: A concrete implementation of the `AIProvider` interface specifically designed to interact with local Ollama instances. It handles the HTTP communication with the Ollama API, including fetching available models and managing chat completions.
 
@@ -23,7 +23,7 @@ The AI Engine's architecture is designed for modularity and extensibility, prima
     *   Managing the selection and fetching of available AI models.
     *   Notifying listeners of AI-driven changes to the synthesizer state.
 
--   **`AIStateMapper`**: A utility component responsible for translating between the AI-friendly JSON representation of a synthesizer patch and Gravisynth's internal `juce::AudioProcessorGraph` structure. It handles both `graphToJSON` (for providing context to the AI) and `applyJSONToGraph` (for applying AI suggestions).
+-   **`AIStateMapper`**: A utility component responsible for translating between the AI-friendly JSON representation of a synthesizer patch and AgentSynth's internal `juce::AudioProcessorGraph` structure. It handles both `graphToJSON` (for providing context to the AI) and `applyJSONToGraph` (for applying AI suggestions).
 
 ### Interaction Flow:
 
@@ -37,7 +37,7 @@ The AI Engine's architecture is designed for modularity and extensibility, prima
 
 ## 3. Communication Pattern
 
-The AI communicates with Gravisynth using a simplified JSON schema to describe synthesizer patches. This schema defines nodes (representing modules) and connections between them.
+The AI communicates with AgentSynth using a simplified JSON schema to describe synthesizer patches. This schema defines nodes (representing modules) and connections between them.
 
 ### Example JSON Patch Format:
 

--- a/docs/AI_Usage_Guide.md
+++ b/docs/AI_Usage_Guide.md
@@ -1,10 +1,10 @@
-# Gravisynth AI Sound Designer: Usage Guide
+# AgentSynth AI Sound Designer: Usage Guide
 
-This guide provides practical instructions and tips for effectively using the AI Sound Designer in Gravisynth to create and modify synthesizer patches with natural language.
+This guide provides practical instructions and tips for effectively using the AI Sound Designer in AgentSynth to create and modify synthesizer patches with natural language.
 
 ## 1. Getting Started with the AI Sound Designer
 
-1.  **Open the AI Chat Panel**: In the Gravisynth application, locate and open the AI chat panel. This is typically accessible via a dedicated button or menu option.
+1.  **Open the AI Chat Panel**: In the AgentSynth application, locate and open the AI chat panel. This is typically accessible via a dedicated button or menu option.
 2.  **Select an AI Model**: Use the model picker dropdown to choose an available AI model (e.g., `qwen3-coder-next:latest`). Ensure your Ollama server (or other AI backend) is running and accessible if using local models.
 3.  **Start Chatting**: Type your requests or descriptions in the input field and press "Send" or Enter.
 
@@ -35,7 +35,7 @@ The AI responds best to clear, concise, and specific prompts. Think about the ch
 
 *   **Be Specific**: Vague prompts lead to vague results.
 *   **Iterate**: If the first attempt isn't perfect, refine your request. You can say things like "Make it brighter," or "Reduce the sustain on the last sound."
-*   **Use Gravisynth Terminology**: While natural language is understood, using module names (e.g., Oscillator, Filter, ADSR) and parameter names (e.g., Cutoff, Frequency) from Gravisynth can yield more precise results.
+*   **Use AgentSynth Terminology**: While natural language is understood, using module names (e.g., Oscillator, Filter, ADSR) and parameter names (e.g., Cutoff, Frequency) from AgentSynth can yield more precise results.
 *   **Review JSON**: If the AI provides a JSON patch, expanding and reviewing it can help you understand how the AI interpreted your request.
 
 ## 3. Example Prompts
@@ -53,7 +53,7 @@ Here are some examples of effective prompts you can use:
 ## 4. Troubleshooting
 
 *   **"Error: No AI provider selected."**: Ensure you have selected an AI model from the dropdown. If no models appear, check if your Ollama server is running and accessible at `http://localhost:11434`.
-*   **"Error fetching models"**: Your Gravisynth application might not be able to connect to the Ollama server. Verify the server is running and there are no firewall issues. Check the application logs for "AI Discovery Error" messages.
+*   **"Error fetching models"**: Your AgentSynth application might not be able to connect to the Ollama server. Verify the server is running and there are no firewall issues. Check the application logs for "AI Discovery Error" messages.
 *   **AI provides text, but no patch is applied**: The AI's response might not contain a valid JSON patch in the expected ````json` block format, or the JSON might be malformed. Try rephrasing your prompt to explicitly ask for a JSON patch (e.g., "Provide the patch as a JSON block").
 *   **Unexpected Patch Behavior**: The AI might generate a patch that doesn't sound as expected. Review the generated JSON (by expanding the patch card) to understand the AI's interpretation and refine your prompt accordingly.
 

--- a/docs/Module_Development_Guide.md
+++ b/docs/Module_Development_Guide.md
@@ -1,10 +1,10 @@
-# Gravisynth Module Development Guide
+# AgentSynth Module Development Guide
 
-This guide provides comprehensive instructions for developers looking to create new audio processing modules for the Gravisynth modular synthesizer. It covers the essential steps, coding standards, and best practices to ensure seamless integration and high-quality results.
+This guide provides comprehensive instructions for developers looking to create new audio processing modules for the AgentSynth modular synthesizer. It covers the essential steps, coding standards, and best practices to ensure seamless integration and high-quality results.
 
 ## 1. Module Structure and Setup
 
-All audio modules in Gravisynth inherit from `ModuleBase`, which in turn extends `juce::AudioProcessor`. This provides a consistent foundation for all modules.
+All audio modules in AgentSynth inherit from `ModuleBase`, which in turn extends `juce::AudioProcessor`. This provides a consistent foundation for all modules.
 
 ### Basic Steps:
 
@@ -66,10 +66,10 @@ All audio modules in Gravisynth inherit from `ModuleBase`, which in turn extends
     } // namespace gsynth
     ```
 
-3.  **Add to `GravisynthCore` in `CMakeLists.txt`:**
-    Ensure your new module's `.cpp` file is included in the `GravisynthCore` target.
+3.  **Add to `AgentSynthCore` in `CMakeLists.txt`:**
+    Ensure your new module's `.cpp` file is included in the `AgentSynthCore` target.
     ```cmake
-    target_sources(GravisynthCore PUBLIC
+    target_sources(AgentSynthCore PUBLIC
         # ... other source files
         Source/Modules/MyNewModule.cpp
     )
@@ -94,9 +94,9 @@ All audio modules in Gravisynth inherit from `ModuleBase`, which in turn extends
 
 All module parameters should be defined in the constructor using `addParameter()`. Use `juce::AudioParameterFloat`, `juce::AudioParameterInt`, `juce::AudioParameterChoice`, etc.
 
-**Fully Modular Architecture Rule:** To ensure Gravisynth remains a truly modular environment, *every relevant continuous parameter in a module MUST expose a dedicated CV Input Port. However, modules MUST NOT explicitly define internal "Modulation Depth" or "Modulation Amount" parameters.* 
+**Fully Modular Architecture Rule:** To ensure AgentSynth remains a truly modular environment, *every relevant continuous parameter in a module MUST expose a dedicated CV Input Port. However, modules MUST NOT explicitly define internal "Modulation Depth" or "Modulation Amount" parameters.* 
 
-Instead of hardcoding internal modulation amounts or matrices, Gravisynth delegates all CV scaling to the host environment. The Graph automatically instantiates `Attenuverter` nodes on every CV connection cable. Modulation sources should provide raw normalized signals (e.g. [-1.0, 1.0] or [0.0, 1.0]), and the receiving node should map this raw incoming CV directly to its full native modulation range (e.g. +/- 4 octaves, or +/- 12 semitones). Users control depth dynamically via the smart cables. Do not crowd the module UI with redundant "Mod Amount" knobs!
+Instead of hardcoding internal modulation amounts or matrices, AgentSynth delegates all CV scaling to the host environment. The Graph automatically instantiates `Attenuverter` nodes on every CV connection cable. Modulation sources should provide raw normalized signals (e.g. [-1.0, 1.0] or [0.0, 1.0]), and the receiving node should map this raw incoming CV directly to its full native modulation range (e.g. +/- 4 octaves, or +/- 12 semitones). Users control depth dynamically via the smart cables. Do not crowd the module UI with redundant "Mod Amount" knobs!
 
 ```cpp
 MyNewModule::MyNewModule()
@@ -117,7 +117,7 @@ MyNewModule::MyNewModule()
 
 ## 4. DSP Standards for Professional Sound Quality
 
-Adhering to these standards ensures the highest audio quality for Gravisynth modules:
+Adhering to these standards ensures the highest audio quality for AgentSynth modules:
 
 *   **Parameter Smoothing**: For any continuous parameters (e.g., gain, cutoff, frequency), use `juce::SmoothedValue<float>` to avoid clicks and zipper noise when parameters are automated or changed rapidly.
     ```cpp
@@ -148,7 +148,7 @@ Adhering to these standards ensures the highest audio quality for Gravisynth mod
 
 ## 5. State Management (Preset Save/Load)
 
-Override `getStateInformation()` and `setStateInformation()` to allow your module's parameters and internal state to be saved and loaded as part of a Gravisynth patch.
+Override `getStateInformation()` and `setStateInformation()` to allow your module's parameters and internal state to be saved and loaded as part of a AgentSynth patch.
 
 ```cpp
 void MyNewModule::getStateInformation(juce::MemoryBlock& destData) override {
@@ -203,7 +203,7 @@ All new modules **must** have unit tests in the `Tests/` directory.
 2.  **Add to `Tests/CMakeLists.txt`:**
     Ensure your test file is compiled as part of the test suite.
     ```cmake
-    target_sources(GravisynthTests PUBLIC
+    target_sources(AgentSynthTests PUBLIC
         # ... other test files
         Tests/MyNewModuleTests.cpp
     )
@@ -211,12 +211,12 @@ All new modules **must** have unit tests in the `Tests/` directory.
 
 3.  **Run Tests:**
     ```bash
-    cmake --build build --target GravisynthTests
-    ./build/Tests/GravisynthTests
+    cmake --build build --target AgentSynthTests
+    ./build/Tests/AgentSynthTests
     ```
 
 ### E2E Coverage
 
 New modules are automatically covered by E2E workflow tests in `Tests/E2EWorkflowTests.cpp`. The `DropAllModuleTypes_NoCrash` test drops every registered module type and verifies it creates a graph node without crashing. If you add a new module type, add its name string to the `moduleTypes` array in that test.
 
-By following this guide, you can contribute robust and high-quality audio modules to Gravisynth.
+By following this guide, you can contribute robust and high-quality audio modules to AgentSynth.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture Overview
 
-Gravisynth is built on a modular graph architecture using JUCE's `AudioProcessorGraph` (implicitly managed by `AudioEngine`).
+AgentSynth is built on a modular graph architecture using JUCE's `AudioProcessorGraph` (implicitly managed by `AudioEngine`).
 
 ## Core Components
 

--- a/docs/fx_modules.md
+++ b/docs/fx_modules.md
@@ -1,6 +1,6 @@
 # FX Modules Reference
 
-Technical documentation for the Gravisynth effects suite.
+Technical documentation for the AgentSynth effects suite.
 
 ## Distortion Module
 - **Algorithm**: Nonlinear soft-clipping using a `tanh`-based curve: `f(x) = x / (1 + |x|)`.

--- a/docs/midi_input.md
+++ b/docs/midi_input.md
@@ -1,6 +1,6 @@
 # MIDI Input Support
 
-Gravisynth now supports external MIDI input devices, allowing you to connect hardware controllers for more expressive playability, including polyphonic support.
+Agent Synth now supports external MIDI input devices, allowing you to connect hardware controllers for more expressive playability, including polyphonic support.
 
 ## Usage
 1. Open the application.

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -1,6 +1,6 @@
 # Core Modules Reference
 
-Detailed specifications for Gravisynth's primary synthesis modules.
+Detailed specifications for AgentSynth's primary synthesis modules.
 
 ## Oscillator Module
 - **Waveforms**: Sine, Square, Saw, Triangle.
@@ -47,7 +47,7 @@ Detailed specifications for Gravisynth's primary synthesis modules.
 
 ## Modulation System
 
-Gravisynth uses a **hidden Attenuverter architecture** for modulation depth control, inspired by Serum's mod matrix.
+AgentSynth uses a **hidden Attenuverter architecture** for modulation depth control, inspired by Serum's mod matrix.
 
 ### Smart Cables
 - Every CV cable renders a circular knob at the midpoint of the bezier curve.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -4,11 +4,11 @@ All tests use GoogleTest and run headless (no audio device, no GUI window). ~310
 
 ```bash
 # Run all tests
-cmake --build build --target GravisynthTests
-./build/Tests/GravisynthTests
+cmake --build build --target AgentSynthTests
+./build/Tests/AgentSynthTests
 
 # Run a specific suite
-./build/Tests/GravisynthTests --gtest_filter="E2EWorkflow*"
+./build/Tests/AgentSynthTests --gtest_filter="E2EWorkflow*"
 
 # Check coverage (threshold: 80%)
 bash scripts/coverage.sh

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -104,7 +104,7 @@ When adding a new audio module:
 
 The `AudioRenderingTests` suite compares rendered audio against "golden" reference files stored in `Tests/reference/`.
 
-- **To run**: `./build/Tests/GravisynthTests --gtest_filter="AudioRenderingTest.Snapshot*"`
+- **To run**: `./build/Tests/AgentSynthTests --gtest_filter="AudioRenderingTest.Snapshot*"`
 - **To update references**: If you intentionally change DSP logic (e.g., a better filter algorithm) and want to update the baseline:
   ```bash
   bash scripts/update-reference.sh

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -13,11 +13,11 @@ if [ "$REPORT_ONLY" = false ]; then
   cmake -B build -DCMAKE_BUILD_TYPE=Debug -DENABLE_COVERAGE=ON
 
   # Build the tests
-  cmake --build build --target GravisynthTests
+  cmake --build build --target AgentSynthTests
 
   # Run the tests
   export LLVM_PROFILE_FILE="default.profraw"
-  ./build/Tests/GravisynthTests
+  ./build/Tests/AgentSynthTests
 fi
 
 # Generate coverage report
@@ -37,7 +37,7 @@ $PROFDATA merge -sparse default.profraw -o default.profdata
 echo "Generating coverage report..."
 # Capture the report output
 REPORT=$($COV report \
-    ./build/Tests/GravisynthTests \
+    ./build/Tests/AgentSynthTests \
     -instr-profile=default.profdata \
     -ignore-filename-regex="JuceLibraryCode|build/_deps|Tests|Source/UI|Source/Main\.cpp|Source/MainComponent")
 

--- a/scripts/pre-push-release-test.sh
+++ b/scripts/pre-push-release-test.sh
@@ -19,9 +19,9 @@ if [ ! -f "$BUILD_DIR/CMakeCache.txt" ]; then
 fi
 
 # Incremental build
-cmake --build "$BUILD_DIR" --target GravisynthTests -- -j$(sysctl -n hw.ncpu 2>/dev/null || nproc)
+cmake --build "$BUILD_DIR" --target AgentSynthTests -- -j$(sysctl -n hw.ncpu 2>/dev/null || nproc)
 
 # Run tests
-"$BUILD_DIR/Tests/GravisynthTests"
+"$BUILD_DIR/Tests/AgentSynthTests"
 
 echo "Pre-push: All tests passed in Release mode."

--- a/scripts/update-reference.sh
+++ b/scripts/update-reference.sh
@@ -15,10 +15,10 @@ echo "==> Removing old reference files..."
 rm -f "$REF_DIR"/*.raw
 
 echo "==> Building tests..."
-cmake --build "$REPO_ROOT/build" --target GravisynthTests -j"$(sysctl -n hw.logicalcpu 2>/dev/null || nproc)"
+cmake --build "$REPO_ROOT/build" --target AgentSynthTests -j"$(sysctl -n hw.logicalcpu 2>/dev/null || nproc)"
 
 echo "==> Running snapshot tests to generate new references..."
-"$REPO_ROOT/build/Tests/GravisynthTests" --gtest_filter="AudioRenderingTest.Snapshot*"
+"$REPO_ROOT/build/Tests/AgentSynthTests" --gtest_filter="AudioRenderingTest.Snapshot*"
 
 echo "==> Done. New reference files:"
 ls -la "$REF_DIR"/*.raw 2>/dev/null || echo "(none generated — check test output)"


### PR DESCRIPTION
This PR rebrands the application from 'Gravisynth' to 'Agent Synth', including renaming classes, namespaces, files, and updating all documentation and build scripts. Resolves #70.