### PR TITLE
Fix: Modulation Matrix Bypass Sync

### DIFF
--- a/Source/AudioEngine.cpp
+++ b/Source/AudioEngine.cpp
@@ -119,7 +119,8 @@ std::vector<AudioEngine::ModulationDisplayInfo> AudioEngine::getModulationDispla
             info.modSignalValue = atten->getLastModValue();
             info.modSignalPeak = atten->getLastOutputPeak();
             info.isBypassed = false;
-            if (auto* bp = dynamic_cast<juce::AudioParameterBool*>(node->getProcessor()->getParameters()[2]))
+            // Parameter 0 is bypassed, Parameter 1 is amount
+            if (auto* bp = dynamic_cast<juce::AudioParameterBool*>(node->getProcessor()->getParameters()[0]))
                 info.isBypassed = bp->get();
 
             bool foundDest = false;

--- a/Source/UI/ModMatrixComponent.cpp
+++ b/Source/UI/ModMatrixComponent.cpp
@@ -214,14 +214,14 @@ ModMatrixComponent::ModRow::ModRow(ModMatrixComponent& o, juce::AudioProcessorGr
     // Attach to attenuverter params
     if (auto* node = owner.audioEngine.getGraph().getNodeForId(attenuverterId)) {
         const auto& params = node->getProcessor()->getParameters();
+        if (params.size() > 0) {
+            if (auto* bParam = dynamic_cast<juce::AudioParameterBool*>(params[0])) {
+                bypassAttachment = std::make_unique<juce::ButtonParameterAttachment>(*bParam, bypassToggle);
+            }
+        }
         if (params.size() > 1) {
             if (auto* param = dynamic_cast<juce::AudioParameterFloat*>(params[1])) {
                 amountAttachment = std::make_unique<juce::SliderParameterAttachment>(*param, amountSlider);
-            }
-        }
-        if (params.size() > 2) {
-            if (auto* bParam = dynamic_cast<juce::AudioParameterBool*>(params[2])) {
-                bypassAttachment = std::make_unique<juce::ButtonParameterAttachment>(*bParam, bypassToggle);
             }
         }
 

--- a/Tests/BypassTests.cpp
+++ b/Tests/BypassTests.cpp
@@ -1,0 +1,23 @@
+#include "Modules/AttenuverterModule.h"
+#include <gtest/gtest.h>
+
+TEST(AttenuverterBypassTest, BypassClearsBuffer) {
+    auto module = std::make_unique<AttenuverterModule>();
+    module->prepareToPlay(44100.0, 512);
+
+    juce::AudioBuffer<float> buffer(1, 128);
+    for (int i = 0; i < buffer.getNumSamples(); ++i) {
+        buffer.setSample(0, i, 1.0f); // Set to 1.0
+    }
+    juce::MidiBuffer midi;
+
+    // Enable bypass
+    module->setBypassed(true);
+
+    module->processBlock(buffer, midi);
+
+    // Verify buffer is cleared
+    for (int i = 0; i < buffer.getNumSamples(); ++i) {
+        EXPECT_EQ(buffer.getSample(0, i), 0.0f) << "Sample " << i << " was not cleared by bypass";
+    }
+}

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -40,6 +40,7 @@ add_executable(GravisynthTests
     ExternalMidiModuleTests.cpp
     PresetManagerTests.cpp
     ModuleBypassTests.cpp
+    BypassTests.cpp
     VisualSignalFlowTests.cpp
     DistortionSweepTests.cpp
     OscillatorCVModulationTests.cpp


### PR DESCRIPTION
Resolves an issue where the modulation matrix bypass toggle was incorrectly bound to the wrong parameter index. This fix ensures the UI correctly communicates the bypass state to the engine and includes a new verification test.