### PR TITLE
feat: visualize poly modulation routing + fix preset-load UI freeze

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,28 +16,29 @@ The project follows a modular architecture with:
 
 ### Key Components
 
-- **ModuleBase**: Abstract base class for all audio modules with `ModuleType` enum, `ModulationTarget` metadata, and `VisualBuffer` support
-- **AudioEngine**: Manages audio device I/O, the audio processor graph, and modulation matrix routing
-- **GraphEditor**: Visual editor for connecting modules with zoom/pan and drag-to-connect
-- **ModuleComponent**: Auto-UI generation from module parameters with type-safe layout switching via `ModuleType` enum
-- **AttenuverterModule**: Intermediary module for modulation routing with bypass and CV amount control; exposes `lastOutputPeak`/`lastModValue` atomics for UI visualization
+- **ModuleBase**: Abstract base class for all audio modules with `ModuleType` enum, `ModulationTarget` metadata, `VisualBuffer` support, logical-port API (`mapInputChannel`/`mapOutputChannel`, `PortRole`, `LogicalPort`), and `isAutoPromotableModTarget` guard that prevents poly-mode CV inputs from being auto-wrapped in attenuverters
+- **AudioEngine**: Manages audio device I/O, the audio processor graph, and modulation matrix routing; exposes `getModulationRoutings()` — a read-only derived view (`RoutingKind`: AttenuverterChain / DirectCV / PolyBus) that is never serialized; `getActiveModRoutings()` and `getModulationDisplayInfo()` are thin adapters over it
+- **GraphEditor**: Visual editor with zoom/pan and drag-to-connect; draws poly-bus wires (collapsed N-voice `DirectCV` connections) with an "xN" badge and anchors all wires to visible jacks via the logical-port API
+- **ModuleComponent**: Auto-UI generation from module parameters with type-safe layout switching via `ModuleType` enum; modulation rings read `getModulationRoutings()`
+- **AttenuverterModule**: Intermediary module for modulation routing with bypass and CV amount control; exposes `lastOutputPeak`/`lastModValue` atomics for UI visualization; constructor default Amount = 0.0 (set to 1.0 by `addModRouting`, left at 0.0 by `addEmptyModRouting`)
 - **Port Labels**: Virtual `getInputPortLabel()`/`getOutputPortLabel()` on ModuleBase, overridden per-module for descriptive port names in the UI
 - **GravisynthUndoManager**: Snapshot-based undo/redo system wrapping `juce::UndoManager`, captures full graph state on every change
 - **AI Integration** (`Source/AI/`): AIIntegrationService orchestrates LLM-powered features via OllamaProvider; AIStateMapper translates graph state for AI context
 
 ### Audio Modules
 
-- Oscillator: Waveform generator (Sine, Saw, Square, Triangle)
+- Oscillator: Waveform generator (Sine, Saw, Square, Triangle); poly mode consumes shared mod-CV on ch8=Waveform, 9=Octave, 10=Coarse, 11=Fine, 12=Level; declared with 14 outputs to prevent JUCE graph buffer aliasing
 - Filter: Multi-mode filter with 7 types (LPF24, LPF12, HPF24, HPF12, BPF24, BPF12, Notch), cutoff/resonance control, and frequency response visualizer
-- VCA: Voltage Controlled Amplifier for dynamic control
-- ADSR: Envelope generator for amplitude/filter modulation
+- VCA: Voltage Controlled Amplifier; poly mode sums 8 voices with per-voice envelope CV
+- ADSR: Envelope generator for amplitude/filter modulation; poly mode drives 8 per-voice ADSRs from gate CV
 - LFO: Low Frequency Oscillator for modulation
 - Sequencer: Step sequencer with per-step pitch control
 - MIDI Keyboard: Interactive on-screen keyboard for MIDI input
 - FX Modules: Delay, Distortion, Reverb, Chorus, Phaser, Compressor, Flanger, Limiter
 - Preset System: Factory presets with categorized organization
-- Poly MIDI: Polyphonic MIDI input handling
+- Poly MIDI: Polyphonic MIDI input handling (ch0-7=pitch Hz, ch8-15=gate)
 - Poly Sequencer: Polyphonic step sequencer
+- Voice Mixer: 8-to-stereo mixer with tanh soft saturation and Level control; alternative to VCA's internal poly summing
 
 ## Build System
 
@@ -63,6 +64,8 @@ cmake --build build
 
 ### Run Tests
 ```bash
+# ENABLE_TESTS defaults OFF — must configure with it explicitly
+cmake -S . -B build -DENABLE_TESTS=ON
 cmake --build build --target GravisynthTests
 ./build/Tests/GravisynthTests
 # Run only E2E workflow tests:
@@ -95,7 +98,7 @@ bash scripts/install-hooks.sh    # Install pre-push hook (runs lint + Release bu
 
 CI runs via `.github/workflows/ci.yml` on PRs only (4 parallel jobs):
 - **Lint** (Ubuntu, ~30s) — clang-format check
-- **Build, Test, and Coverage** (Ubuntu Debug) — coverage threshold 80%
+- **Build, Test, and Coverage** (Ubuntu Debug) — coverage threshold 85%
 - **Build and Test** (macOS) — Release build, catches UB/segfaults + cross-platform
 - **Build and Test** (Windows) — Release build, catches UB/segfaults + cross-platform
 
@@ -116,7 +119,7 @@ Post-merge, `.github/workflows/build-artifacts.yml` runs on push to main (4 jobs
 
 ## Testing Strategy
 
-~314 tests across 41 suites, all headless (no audio device, no GUI window). Five test layers: audio rendering (DSP verification), integration (signal chains, mod routing), component workflow (UI interactions), state management (presets, undo/redo, serialization), and E2E workflow (full application paths). Code coverage threshold: 85%. See [`docs/testing.md`](docs/testing.md) for the full breakdown, patterns, and how to add tests for new modules.
+~371 tests across ~53 suites, all headless (no audio device, no GUI window). Five test layers: audio rendering (DSP verification), integration (signal chains, mod routing), component workflow (UI interactions), state management (presets, undo/redo, serialization), and E2E workflow (full application paths). Code coverage threshold: 85%. See [`docs/testing.md`](docs/testing.md) for the full breakdown, patterns, and how to add tests for new modules.
 
 ## Keyboard Shortcuts
 
@@ -126,16 +129,16 @@ Refer to [docs/shortcuts.md](docs/shortcuts.md) for the full list of configurabl
 ## Key Files to Understand
 
 - `CMakeLists.txt`: Main build configuration (version 0.13.2)
-- `Source/AudioEngine.h/cpp`: Audio processing engine, device management, and modulation matrix
+- `Source/AudioEngine.h/cpp`: Audio processing engine, device management; `getModulationRoutings()` returns read-only `ModulationRouting` structs (`RoutingKind`: AttenuverterChain / DirectCV / PolyBus) derived from the live graph; `getActiveModRoutings()` / `getModulationDisplayInfo()` are adapters over it
 - `Source/GravisynthUndoManager.h/cpp`: Snapshot-based undo/redo with `SnapshotAction`, safe detach/reattach lifecycle
-- `Source/Modules/ModuleBase.h`: Base class with `ModuleType` enum, `ModulationTarget`, `ModulationCategory`
-- `Source/Modules/OscillatorModule.h`: Oscillator with PolyBLEP/PolyBLAMP anti-aliasing, waveform crossfade, and CV feedback fix (channel 0 shared between CV input and audio output, saved before overwrite)
+- `Source/Modules/ModuleBase.h`: Base class with `ModuleType` enum, `ModulationTarget`, `ModulationCategory`; logical-port API (`PortRole`, `LogicalPort`, `mapInputChannel`, `mapOutputChannel`); `isAutoPromotableModTarget` guard for poly-mode connections
+- `Source/Modules/OscillatorModule.h`: Oscillator with PolyBLEP/PolyBLAMP anti-aliasing, waveform crossfade; poly mode reads shared mod-CV on ch8-12 and saves them before clearing the buffer; declared with 14 outputs to prevent JUCE graph buffer aliasing
 - `Source/Modules/FilterModule.h`: Multi-mode filter (LadderFilter for LPF/HPF/BPF + SVF for notch), atomic modulated params for visualizer, type parameter
 - `Source/Modules/VisualBuffer.h`: Thread-safe circular buffer using `std::atomic<float>`
-- `Source/PresetManager.h/cpp`: Factory presets with categorized organization
-- `Source/UI/ModuleComponent.cpp`: Auto-UI with type-safe `ModuleType` switching, parameter listener for undo, safe detach lifecycle, FrequencyResponseComponent integration and spectrum toggle
+- `Source/PresetManager.h/cpp`: Factory presets with categorized organization; Poly Pad (case 6) includes Amp Env -> Osc Level (ch12) as DirectCV plus Amp Env -> VCA per-voice CV (PolyBus)
+- `Source/UI/ModuleComponent.cpp`: Auto-UI with type-safe `ModuleType` switching, parameter listener for undo, safe detach lifecycle, FrequencyResponseComponent integration and spectrum toggle; modulation rings read `getModulationRoutings()`
 - `Source/UI/FrequencyResponseComponent.h`: Serum-style frequency response curve with FFT spectrum overlay
-- `Source/UI/GraphEditor.cpp`: Graph editor with attenuverter knob rendering, modulation routing, and undo integration
+- `Source/UI/GraphEditor.cpp`: Graph editor with attenuverter knob rendering, poly-bus wire drawing (collapsed N-voice connections with "xN" badge), modulation routing, and undo integration; uses logical-port API to anchor wires to visible jacks
 - `Source/UI/SettingsWindow.h/cpp`: Consolidated tabbed settings window (Audio, AI, General tabs) with tab persistence
 - `Source/ShortcutManager.h`: Configurable keyboard shortcut manager with action→KeyPress mapping, persistence, case-insensitive key matching, and conflict detection
 - `Source/UI/ModuleLibraryComponent.h`: Categorized sidebar with section headers for module drag-and-drop
@@ -146,8 +149,10 @@ Refer to [docs/shortcuts.md](docs/shortcuts.md) for the full list of configurabl
 - `Source/Modules/FX/CompressorModule.h`: Compressor with manual makeup gain
 - `Source/Modules/FX/FlangerModule.h`: Flanger via `juce::dsp::Chorus` with low-delay tuning
 - `Source/Modules/FX/LimiterModule.h`: Brickwall limiter with input gain drive
-- `Source/UI/AIChatComponent.cpp/.h`: Chat interface for AI-assisted patching
+- `Source/UI/AIChatComponent.cpp/.h`: Chat interface for AI-assisted patching. **Logging gotcha:** this component registers itself as the global `juce::Logger` (`setCurrentLogger`) and pipes every `juce::Logger::writeToLog(...)` into a `TextEditor` debug console (Debug builds only). Appends are coalesced + the console is length-bounded, but DO NOT add high-frequency `writeToLog` calls (per-parameter, per-sample, per-frame, per-connection) — they run on the UI thread. Keep logging to errors/rare events. (A per-parameter log on preset load once caused a multi-second UI freeze; guarded by `AIStateMapperTest.PresetLoadDoesNotSpamLogger`.)
+- **UI rendering perf:** `ModuleComponent` uses `setBufferedToImage(true)` and gates its 15Hz `timerCallback` repaint (RMS-change / active-modulation / sequencer-step-change only) so the GraphEditor's 30Hz connection animation composites cached module images instead of re-running JUCE text layout every frame. Don't reintroduce unconditional per-tick `repaint()` on modules or their always-visible children.
 - `Source/UI/ScopeComponent.h`: Oscilloscope/waveform display component
 - `Source/Modules/FX/DistortionModule.h`: Distortion effect with configurable oversampling (Off/2x/4x), soft-clipping using `tanh`-based curve, Drive and Mix parameters
-- `Tests/E2EWorkflowTests.cpp`: 24 E2E workflow tests — preset loading, module drop/delete/replace, connection drag, mod matrix, undo/redo sequences, and stress tests
-- `Tests/`: ~324 tests across 43 suites (audio rendering, integration, component workflow, state management, E2E workflow)
+- `Tests/E2EWorkflowTests.cpp`: E2E workflow tests — preset loading, module drop/delete/replace, connection drag, mod matrix, undo/redo sequences, and stress tests
+- `Tests/`: ~371 tests across ~53 suites (audio rendering, integration, component workflow, state management, E2E workflow)
+- `docs/modulation.md`: Full reference for the modulation routing model, logical-port API, and poly-bus wire rendering

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,6 +1,6 @@
-# CLAUDE.md
+# GEMINI.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides guidance to Gemini CLI when working with code in this repository.
 
 ## Project Overview
 
@@ -16,28 +16,29 @@ The project follows a modular architecture with:
 
 ### Key Components
 
-- **ModuleBase**: Abstract base class for all audio modules with `ModuleType` enum, `ModulationTarget` metadata, and `VisualBuffer` support
-- **AudioEngine**: Manages audio device I/O, the audio processor graph, and modulation matrix routing
-- **GraphEditor**: Visual editor for connecting modules with zoom/pan and drag-to-connect
-- **ModuleComponent**: Auto-UI generation from module parameters with type-safe layout switching via `ModuleType` enum
-- **AttenuverterModule**: Intermediary module for modulation routing with bypass and CV amount control; exposes `lastOutputPeak`/`lastModValue` atomics for UI visualization
+- **ModuleBase**: Abstract base class for all audio modules with `ModuleType` enum, `ModulationTarget` metadata, `VisualBuffer` support, logical-port API (`mapInputChannel`/`mapOutputChannel`, `PortRole`, `LogicalPort`), and `isAutoPromotableModTarget` guard that prevents poly-mode CV inputs from being auto-wrapped in attenuverters
+- **AudioEngine**: Manages audio device I/O, the audio processor graph, and modulation matrix routing; exposes `getModulationRoutings()` — a read-only derived view (`RoutingKind`: AttenuverterChain / DirectCV / PolyBus) that is never serialized; `getActiveModRoutings()` and `getModulationDisplayInfo()` are thin adapters over it
+- **GraphEditor**: Visual editor with zoom/pan and drag-to-connect; draws poly-bus wires (collapsed N-voice `DirectCV` connections) with an "xN" badge and anchors all wires to visible jacks via the logical-port API
+- **ModuleComponent**: Auto-UI generation from module parameters with type-safe layout switching via `ModuleType` enum; modulation rings read `getModulationRoutings()`
+- **AttenuverterModule**: Intermediary module for modulation routing with bypass and CV amount control; exposes `lastOutputPeak`/`lastModValue` atomics for UI visualization; constructor default Amount = 0.0 (set to 1.0 by `addModRouting`, left at 0.0 by `addEmptyModRouting`)
 - **Port Labels**: Virtual `getInputPortLabel()`/`getOutputPortLabel()` on ModuleBase, overridden per-module for descriptive port names in the UI
 - **GravisynthUndoManager**: Snapshot-based undo/redo system wrapping `juce::UndoManager`, captures full graph state on every change
 - **AI Integration** (`Source/AI/`): AIIntegrationService orchestrates LLM-powered features via OllamaProvider; AIStateMapper translates graph state for AI context
 
 ### Audio Modules
 
-- Oscillator: Waveform generator (Sine, Saw, Square, Triangle)
+- Oscillator: Waveform generator (Sine, Saw, Square, Triangle); poly mode consumes shared mod-CV on ch8=Waveform, 9=Octave, 10=Coarse, 11=Fine, 12=Level; declared with 14 outputs to prevent JUCE graph buffer aliasing
 - Filter: Multi-mode filter with 7 types (LPF24, LPF12, HPF24, HPF12, BPF24, BPF12, Notch), cutoff/resonance control, and frequency response visualizer
-- VCA: Voltage Controlled Amplifier for dynamic control
-- ADSR: Envelope generator for amplitude/filter modulation
+- VCA: Voltage Controlled Amplifier; poly mode sums 8 voices with per-voice envelope CV
+- ADSR: Envelope generator for amplitude/filter modulation; poly mode drives 8 per-voice ADSRs from gate CV
 - LFO: Low Frequency Oscillator for modulation
 - Sequencer: Step sequencer with per-step pitch control
 - MIDI Keyboard: Interactive on-screen keyboard for MIDI input
 - FX Modules: Delay, Distortion, Reverb, Chorus, Phaser, Compressor, Flanger, Limiter
 - Preset System: Factory presets with categorized organization
-- Poly MIDI: Polyphonic MIDI input handling
+- Poly MIDI: Polyphonic MIDI input handling (ch0-7=pitch Hz, ch8-15=gate)
 - Poly Sequencer: Polyphonic step sequencer
+- Voice Mixer: 8-to-stereo mixer with tanh soft saturation and Level control; alternative to VCA's internal poly summing
 
 ## Build System
 
@@ -63,6 +64,8 @@ cmake --build build
 
 ### Run Tests
 ```bash
+# ENABLE_TESTS defaults OFF — must configure with it explicitly
+cmake -S . -B build -DENABLE_TESTS=ON
 cmake --build build --target GravisynthTests
 ./build/Tests/GravisynthTests
 # Run only E2E workflow tests:
@@ -95,7 +98,7 @@ bash scripts/install-hooks.sh    # Install pre-push hook (runs lint + Release bu
 
 CI runs via `.github/workflows/ci.yml` on PRs only (4 parallel jobs):
 - **Lint** (Ubuntu, ~30s) — clang-format check
-- **Build, Test, and Coverage** (Ubuntu Debug) — coverage threshold 80%
+- **Build, Test, and Coverage** (Ubuntu Debug) — coverage threshold 85%
 - **Build and Test** (macOS) — Release build, catches UB/segfaults + cross-platform
 - **Build and Test** (Windows) — Release build, catches UB/segfaults + cross-platform
 
@@ -116,30 +119,26 @@ Post-merge, `.github/workflows/build-artifacts.yml` runs on push to main (4 jobs
 
 ## Testing Strategy
 
-~314 tests across 41 suites, all headless (no audio device, no GUI window). Five test layers: audio rendering (DSP verification), integration (signal chains, mod routing), component workflow (UI interactions), state management (presets, undo/redo, serialization), and E2E workflow (full application paths). Code coverage threshold: 85%. See [`docs/testing.md`](docs/testing.md) for the full breakdown, patterns, and how to add tests for new modules.
+~371 tests across ~53 suites, all headless (no audio device, no GUI window). Five test layers: audio rendering (DSP verification), integration (signal chains, mod routing), component workflow (UI interactions), state management (presets, undo/redo, serialization), and E2E workflow (full application paths). Code coverage threshold: 85%. See [`docs/testing.md`](docs/testing.md) for the full breakdown, patterns, and how to add tests for new modules.
 
 ## Keyboard Shortcuts
 
 Refer to [docs/shortcuts.md](docs/shortcuts.md) for the full list of configurable keyboard shortcuts.
 
-## Agent Reference
-
-Refer to [docs/agents.md](docs/agents.md) for AI and Agent configuration standards.
-
 
 ## Key Files to Understand
 
 - `CMakeLists.txt`: Main build configuration (version 0.13.2)
-- `Source/AudioEngine.h/cpp`: Audio processing engine, device management, and modulation matrix
+- `Source/AudioEngine.h/cpp`: Audio processing engine, device management; `getModulationRoutings()` returns read-only `ModulationRouting` structs (`RoutingKind`: AttenuverterChain / DirectCV / PolyBus) derived from the live graph; `getActiveModRoutings()` / `getModulationDisplayInfo()` are adapters over it
 - `Source/GravisynthUndoManager.h/cpp`: Snapshot-based undo/redo with `SnapshotAction`, safe detach/reattach lifecycle
-- `Source/Modules/ModuleBase.h`: Base class with `ModuleType` enum, `ModulationTarget`, `ModulationCategory`
-- `Source/Modules/OscillatorModule.h`: Oscillator with PolyBLEP/PolyBLAMP anti-aliasing, waveform crossfade, and CV feedback fix (channel 0 shared between CV input and audio output, saved before overwrite)
+- `Source/Modules/ModuleBase.h`: Base class with `ModuleType` enum, `ModulationTarget`, `ModulationCategory`; logical-port API (`PortRole`, `LogicalPort`, `mapInputChannel`, `mapOutputChannel`); `isAutoPromotableModTarget` guard for poly-mode connections
+- `Source/Modules/OscillatorModule.h`: Oscillator with PolyBLEP/PolyBLAMP anti-aliasing, waveform crossfade; poly mode reads shared mod-CV on ch8-12 and saves them before clearing the buffer; declared with 14 outputs to prevent JUCE graph buffer aliasing
 - `Source/Modules/FilterModule.h`: Multi-mode filter (LadderFilter for LPF/HPF/BPF + SVF for notch), atomic modulated params for visualizer, type parameter
 - `Source/Modules/VisualBuffer.h`: Thread-safe circular buffer using `std::atomic<float>`
-- `Source/PresetManager.h/cpp`: Factory presets with categorized organization
-- `Source/UI/ModuleComponent.cpp`: Auto-UI with type-safe `ModuleType` switching, parameter listener for undo, safe detach lifecycle, FrequencyResponseComponent integration and spectrum toggle
+- `Source/PresetManager.h/cpp`: Factory presets with categorized organization; Poly Pad (case 6) includes Amp Env -> Osc Level (ch12) as DirectCV plus Amp Env -> VCA per-voice CV (PolyBus)
+- `Source/UI/ModuleComponent.cpp`: Auto-UI with type-safe `ModuleType` switching, parameter listener for undo, safe detach lifecycle, FrequencyResponseComponent integration and spectrum toggle; modulation rings read `getModulationRoutings()`
 - `Source/UI/FrequencyResponseComponent.h`: Serum-style frequency response curve with FFT spectrum overlay
-- `Source/UI/GraphEditor.cpp`: Graph editor with attenuverter knob rendering, modulation routing, and undo integration
+- `Source/UI/GraphEditor.cpp`: Graph editor with attenuverter knob rendering, poly-bus wire drawing (collapsed N-voice connections with "xN" badge), modulation routing, and undo integration; uses logical-port API to anchor wires to visible jacks
 - `Source/UI/SettingsWindow.h/cpp`: Consolidated tabbed settings window (Audio, AI, General tabs) with tab persistence
 - `Source/ShortcutManager.h`: Configurable keyboard shortcut manager with action→KeyPress mapping, persistence, case-insensitive key matching, and conflict detection
 - `Source/UI/ModuleLibraryComponent.h`: Categorized sidebar with section headers for module drag-and-drop
@@ -150,8 +149,10 @@ Refer to [docs/agents.md](docs/agents.md) for AI and Agent configuration standar
 - `Source/Modules/FX/CompressorModule.h`: Compressor with manual makeup gain
 - `Source/Modules/FX/FlangerModule.h`: Flanger via `juce::dsp::Chorus` with low-delay tuning
 - `Source/Modules/FX/LimiterModule.h`: Brickwall limiter with input gain drive
-- `Source/UI/AIChatComponent.cpp/.h`: Chat interface for AI-assisted patching
+- `Source/UI/AIChatComponent.cpp/.h`: Chat interface for AI-assisted patching. **Logging gotcha:** this component registers itself as the global `juce::Logger` (`setCurrentLogger`) and pipes every `juce::Logger::writeToLog(...)` into a `TextEditor` debug console (Debug builds only). Appends are coalesced + the console is length-bounded, but DO NOT add high-frequency `writeToLog` calls (per-parameter, per-sample, per-frame, per-connection) — they run on the UI thread. Keep logging to errors/rare events. (A per-parameter log on preset load once caused a multi-second UI freeze; guarded by `AIStateMapperTest.PresetLoadDoesNotSpamLogger`.)
+- **UI rendering perf:** `ModuleComponent` uses `setBufferedToImage(true)` and gates its 15Hz `timerCallback` repaint (RMS-change / active-modulation / sequencer-step-change only) so the GraphEditor's 30Hz connection animation composites cached module images instead of re-running JUCE text layout every frame. Don't reintroduce unconditional per-tick `repaint()` on modules or their always-visible children.
 - `Source/UI/ScopeComponent.h`: Oscilloscope/waveform display component
 - `Source/Modules/FX/DistortionModule.h`: Distortion effect with configurable oversampling (Off/2x/4x), soft-clipping using `tanh`-based curve, Drive and Mix parameters
-- `Tests/E2EWorkflowTests.cpp`: 24 E2E workflow tests — preset loading, module drop/delete/replace, connection drag, mod matrix, undo/redo sequences, and stress tests
-- `Tests/`: ~314 tests across 41 suites (audio rendering, integration, component workflow, state management, E2E workflow)
+- `Tests/E2EWorkflowTests.cpp`: E2E workflow tests — preset loading, module drop/delete/replace, connection drag, mod matrix, undo/redo sequences, and stress tests
+- `Tests/`: ~371 tests across ~53 suites (audio rendering, integration, component workflow, state management, E2E workflow)
+- `docs/modulation.md`: Full reference for the modulation routing model, logical-port API, and poly-bus wire rendering

--- a/Source/AI/AIStateMapper.cpp
+++ b/Source/AI/AIStateMapper.cpp
@@ -392,22 +392,12 @@ void AIStateMapper::applyParamsToProcessor(juce::AudioProcessor* processor, cons
                     // almost always valid denormalized values, not normalized.
                     bool isIntParam = (dynamic_cast<juce::AudioParameterInt*>(p) != nullptr);
                     bool rangeIsUnitInterval = (range.start >= 0.0f && range.end <= 1.0f);
-                    bool wasConverted = false;
                     if (!trusted && !isIntParam && !rangeIsUnitInterval && val >= 0.0f && val <= 1.0f) {
-                        float originalVal = val;
                         val = range.convertFrom0to1(val);
-                        wasConverted = true;
-                        juce::Logger::writeToLog("AIStateMapper: param '" + p->paramID + "' value " +
-                                                 juce::String(originalVal) + " detected as normalized, converted to " +
-                                                 juce::String(val) + " (range " + juce::String(range.start) + " to " +
-                                                 juce::String(range.end) + ")");
                     }
 
                     val = range.snapToLegalValue(val);
                     float normalizedValue = range.convertTo0to1(val);
-                    juce::Logger::writeToLog("AIStateMapper: setting '" + p->paramID + "' = " + juce::String(val) +
-                                             " (normalized: " + juce::String(normalizedValue) + ")" +
-                                             (wasConverted ? " [auto-corrected]" : ""));
                     p->setValueNotifyingHost(normalizedValue);
                 }
             }
@@ -600,14 +590,8 @@ bool AIStateMapper::applyJSONToGraph(const juce::var& json, juce::AudioProcessor
                         bool isModTarget = false;
                         if (!isMidiConnection &&
                             dynamic_cast<AttenuverterModule*>(srcNode->getProcessor()) == nullptr) {
-                            if (auto* modBase = dynamic_cast<ModuleBase*>(dstNode->getProcessor())) {
-                                for (const auto& t : modBase->getModulationTargets()) {
-                                    if (t.channelIndex == dstPort) {
-                                        isModTarget = true;
-                                        break;
-                                    }
-                                }
-                            }
+                            if (auto* modBase = dynamic_cast<ModuleBase*>(dstNode->getProcessor()))
+                                isModTarget = modBase->isAutoPromotableModTarget(dstPort);
                         }
 
                         if (isModTarget) {
@@ -906,9 +890,6 @@ juce::var AIStateMapper::getPatchSchema() {
 
     schema->setProperty("properties", juce::var(properties.get()));
     schema->setProperty("required", juce::Array<juce::var>({"nodes", "connections"}));
-
-    // DEBUG: Log the final schema string to diagnose format issues
-    juce::Logger::writeToLog("Generated AI Schema: " + juce::JSON::toString(juce::var(schema.get())));
 
     return juce::var(schema.get());
 }

--- a/Source/AI/OllamaProvider.cpp
+++ b/Source/AI/OllamaProvider.cpp
@@ -14,17 +14,51 @@ void OllamaProvider::setModel(const juce::String& name) { currentModel = name; }
 juce::String OllamaProvider::getCurrentModel() const { return currentModel; }
 
 void OllamaProvider::fetchAvailableModels(std::function<void(const juce::StringArray& models, bool success)> callback) {
-    // Run on a separate thread to avoid blocking UI
+    // Run on a separate thread to avoid blocking the caller (the message thread).
+    //
+    // CRITICAL: we must NOT join() on the caller's thread. The old code joined the
+    // previous discovery thread here, which blocked the UI for up to the connection
+    // timeout (was 120s) when Ollama was unreachable. Instead we guard with an
+    // atomic in-flight flag: if a discovery is already running, this call returns
+    // immediately (and reports failure asynchronously) without ever blocking.
+    bool expected = false;
+    if (!discoveryInFlight.compare_exchange_strong(expected, true)) {
+        // A discovery worker is already running. Do not block the caller and do not
+        // launch a second worker. Report "no result yet" asynchronously so callers
+        // relying on the callback still get one without us touching the UI synchronously.
+        if (callback) {
+            if (isTestMode) {
+                callback(juce::StringArray{}, false);
+            } else {
+                juce::MessageManager::callAsync([callback]() { callback(juce::StringArray{}, false); });
+            }
+        }
+        return;
+    }
+
+    // No worker was in flight. A previous worker may have finished but not yet been
+    // joined; joining a finished thread returns immediately (no blocking). We only
+    // ever reach here when discoveryInFlight just transitioned false->true, so there
+    // is no concurrent worker to wait on.
     if (discoveryThread.joinable())
         discoveryThread.join();
+
     discoveryThread = std::thread([this, callback]() {
+        // Clear the in-flight flag when this worker exits, no matter which path it
+        // takes, so a subsequent fetch can run.
+        struct InFlightGuard {
+            std::atomic<bool>& flag;
+            ~InFlightGuard() { flag.store(false); }
+        } inFlightGuard{discoveryInFlight};
+
         DBG("AI Discovery STARTED: " + ollamaHost + "/api/tags");
         juce::URL url(ollamaHost + "/api/tags");
         juce::StringArray models;
         bool success = false;
 
-        if (auto stream = createStream(url, juce::URL::InputStreamOptions(juce::URL::ParameterHandling::inAddress)
-                                                .withConnectionTimeoutMs(120000))) {
+        if (auto stream = createStream(
+                url,
+                juce::URL::InputStreamOptions(juce::URL::ParameterHandling::inAddress).withConnectionTimeoutMs(4000))) {
             juce::String responseText = stream->readEntireStreamAsString();
             // DBG("AI Discovery Response (before JSON parse): [" + responseText + "]"); // Potentially expensive
             // DBG("AI Discovery Response: " + responseText); // Redundant

--- a/Source/AI/OllamaProvider.h
+++ b/Source/AI/OllamaProvider.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "AIProvider.h"
+#include <atomic>
 #include <juce_core/juce_core.h>
 #include <juce_events/juce_events.h>
 #include <thread>
@@ -29,6 +30,12 @@ public:
 
     ~OllamaProvider() override {
         stopThread(2000);
+        // Join the discovery worker so it cannot touch our members after we are
+        // destroyed (it captures `this`). With the short 4s connection timeout
+        // and the in-flight guard ensuring at most ONE worker exists, this join
+        // can block for at most ~4s in the worst case (server unreachable), never
+        // the old 120s. We never reassign a joinable thread (the worker is only
+        // launched when none is in flight), so std::terminate cannot fire here.
         if (discoveryThread.joinable())
             discoveryThread.join();
     }
@@ -60,6 +67,10 @@ private:
     InputStreamFactory createStream; // Member variable for the stream factory
     bool isTestMode = false;
     std::thread discoveryThread;
+    // Guards against (a) blocking the caller (we never join on the message thread)
+    // and (b) ever having two discovery workers alive at once. Set true before a
+    // worker launches, cleared by the worker when it finishes.
+    std::atomic<bool> discoveryInFlight{false};
 
     struct Request {
         std::vector<Message> conversation;

--- a/Source/AudioEngine.cpp
+++ b/Source/AudioEngine.cpp
@@ -13,6 +13,7 @@
 #include "Modules/VCAModule.h"
 #include "PresetManager.h"
 #include <map>
+#include <set>
 
 AudioEngine::AudioEngine() {}
 
@@ -27,16 +28,10 @@ void AudioEngine::initialise() {
 
     // Enable all available MIDI inputs by default
     for (auto& info : juce::MidiInput::getAvailableDevices()) {
-        std::cout << "Attempting to open MIDI input: " << info.name.toStdString()
-                  << " (ID: " << info.identifier.toStdString() << ")" << std::endl;
-
         auto input = juce::MidiInput::openDevice(info.identifier, this);
         if (input != nullptr) {
             input->start();
             midiInputs.push_back(std::move(input));
-            std::cout << "Successfully opened MIDI input: " << info.name.toStdString() << std::endl;
-        } else {
-            std::cout << "Failed to open MIDI input: " << info.name.toStdString() << std::endl;
         }
     }
 
@@ -69,73 +64,281 @@ void AudioEngine::ensureMidiDeviceOpen(const juce::String& deviceName) {
             if (input != nullptr) {
                 input->start();
                 midiInputs.push_back(std::move(input));
-                std::cout << "Successfully opened newly requested MIDI input: " << info.name.toStdString() << std::endl;
             }
             break;
         }
     }
 }
 
-std::vector<AudioEngine::ModRoutingInfo> AudioEngine::getActiveModRoutings() const {
-    std::vector<ModRoutingInfo> routings;
+std::vector<AudioEngine::ModulationRouting> AudioEngine::getModulationRoutings() const {
+    std::vector<ModulationRouting> routings;
+
+    // --- Pass 1: AttenuverterChain routings (unchanged) ---
     for (auto* node : mainProcessorGraph.getNodes()) {
-        if (dynamic_cast<AttenuverterModule*>(node->getProcessor()) != nullptr) {
-            ModRoutingInfo info;
-            info.attenuverterNodeID = node->nodeID;
-            info.sourceChannelIndex = 0;
+        if (auto* atten = dynamic_cast<AttenuverterModule*>(node->getProcessor())) {
+            ModulationRouting r;
+            r.kind = RoutingKind::AttenuverterChain;
+            r.attenuverterNodeID = node->nodeID;
+            r.voiceCount = 1;
+            r.role = PortRole::ModCV;
+
+            // Find source: first connection whose destination is (node, channel 0)
             for (auto& conn : mainProcessorGraph.getConnections()) {
                 if (conn.destination.nodeID == node->nodeID && conn.destination.channelIndex == 0) {
-                    info.sourceNodeID = conn.source.nodeID;
-                    info.sourceChannelIndex = conn.source.channelIndex;
+                    r.sourceNodeID = conn.source.nodeID;
+                    r.sourceChannelIndex = conn.source.channelIndex;
+                    r.hasSource = true;
                     break;
                 }
             }
+
+            // Find dest: first connection whose source is (node, channel 0)
             for (auto& conn : mainProcessorGraph.getConnections()) {
                 if (conn.source.nodeID == node->nodeID && conn.source.channelIndex == 0) {
-                    info.destNodeID = conn.destination.nodeID;
-                    info.destChannelIndex = conn.destination.channelIndex;
+                    r.destNodeID = conn.destination.nodeID;
+                    r.destChannelIndex = conn.destination.channelIndex;
+                    r.hasDest = true;
                     break;
                 }
             }
 
-            // Get bypass state
-            info.isBypassed = false;
-            if (auto* module = dynamic_cast<ModuleBase*>(node->getProcessor())) {
-                info.isBypassed = module->isBypassed();
-            }
+            // Bypass state
+            if (auto* module = dynamic_cast<ModuleBase*>(node->getProcessor()))
+                r.isBypassed = module->isBypassed();
 
-            routings.push_back(info);
+            // Signal visualization values
+            r.modSignalValue = atten->getLastModValue();
+            r.modSignalPeak = atten->getLastOutputPeak();
+
+            // sourceVisibleJack / destVisibleJack: left as 0 (not consumed yet)
+
+            routings.push_back(r);
         }
+    }
+
+    // --- Pass 2: DirectCV / PolyBus routings ---
+    // Helper: read a peak value from a VisualBuffer by scanning its contents
+    auto readVisualPeak = [](VisualBuffer* vb) -> float {
+        if (!vb)
+            return 0.0f;
+        std::vector<float> buf(static_cast<size_t>(vb->getSize()));
+        vb->copyTo(buf);
+        float peak = 0.0f;
+        for (float s : buf)
+            peak = std::max(peak, std::abs(s));
+        return peak;
+    };
+
+    // Collect candidate direct edges: connections where neither endpoint is an AttenuverterModule
+    // and the destination channel maps to role == ModCV on the dest module.
+    struct CandidateEdge {
+        juce::AudioProcessorGraph::NodeID srcNodeID;
+        int srcChannel;
+        juce::AudioProcessorGraph::NodeID dstNodeID;
+        int dstChannel;
+    };
+    std::vector<CandidateEdge> candidates;
+
+    for (auto& conn : mainProcessorGraph.getConnections()) {
+        if (conn.source.isMIDI())
+            continue;
+
+        auto* srcNode = mainProcessorGraph.getNodeForId(conn.source.nodeID);
+        auto* dstNode = mainProcessorGraph.getNodeForId(conn.destination.nodeID);
+        if (!srcNode || !dstNode)
+            continue;
+
+        // Skip if either endpoint is an attenuverter
+        if (dynamic_cast<AttenuverterModule*>(srcNode->getProcessor()))
+            continue;
+        if (dynamic_cast<AttenuverterModule*>(dstNode->getProcessor()))
+            continue;
+
+        auto* dstModule = dynamic_cast<ModuleBase*>(dstNode->getProcessor());
+        if (!dstModule)
+            continue;
+
+        LogicalPort dstPort = dstModule->mapInputChannel(conn.destination.channelIndex);
+        // Accept ModCV (parameter modulation), Pitch (poly pitch fan), and Gate (poly gate fan).
+        // Exclude Audio (osc->filter / filter->VCA audio fans) and Other/Midi.
+        if (dstPort.role != PortRole::ModCV && dstPort.role != PortRole::Pitch && dstPort.role != PortRole::Gate)
+            continue;
+
+        candidates.push_back(
+            {conn.source.nodeID, conn.source.channelIndex, conn.destination.nodeID, conn.destination.channelIndex});
+    }
+
+    // Group candidates by (srcNodeID, dstNodeID)
+    using NodeIDPair = std::pair<juce::AudioProcessorGraph::NodeID, juce::AudioProcessorGraph::NodeID>;
+    std::map<NodeIDPair, std::vector<CandidateEdge>> groups;
+    for (auto& e : candidates) {
+        groups[{e.srcNodeID, e.dstNodeID}].push_back(e);
+    }
+
+    for (auto& [pair, edges] : groups) {
+        auto [srcNodeID, dstNodeID] = pair;
+        auto* srcNode = mainProcessorGraph.getNodeForId(srcNodeID);
+        auto* dstNode = mainProcessorGraph.getNodeForId(dstNodeID);
+        if (!srcNode || !dstNode)
+            continue;
+
+        auto* srcModule = dynamic_cast<ModuleBase*>(srcNode->getProcessor());
+        auto* dstModule = dynamic_cast<ModuleBase*>(dstNode->getProcessor());
+        if (!srcModule || !dstModule)
+            continue;
+
+        // Build a quick set of (srcCh, dstCh) edges in this group for collapse check
+        std::set<std::pair<int, int>> edgeSet;
+        for (auto& e : edges)
+            edgeSet.insert({e.srcChannel, e.dstChannel});
+
+        // Track which edges have been consumed by poly-bus collapse
+        std::set<std::pair<int, int>> consumed;
+
+        // Attempt poly-bus collapse: find source head channels
+        for (auto& e : edges) {
+            if (consumed.count({e.srcChannel, e.dstChannel}))
+                continue;
+
+            LogicalPort srcPort = srcModule->mapOutputChannel(e.srcChannel);
+            LogicalPort dstPort = dstModule->mapInputChannel(e.dstChannel);
+
+            if (srcPort.isPolyGroupHead && dstPort.isPolyGroupHead) {
+                int Ns = srcPort.polyVoiceSpan;
+                int Nd = dstPort.polyVoiceSpan;
+                if (Ns == Nd && Ns > 1) {
+                    int N = Ns;
+                    int Hs = e.srcChannel;
+                    int Hd = e.dstChannel;
+                    // Check all N edges (Hs+i, Hd+i) are present
+                    bool complete = true;
+                    for (int i = 0; i < N; ++i) {
+                        if (!edgeSet.count({Hs + i, Hd + i})) {
+                            complete = false;
+                            break;
+                        }
+                    }
+                    if (complete) {
+                        // Emit one PolyBus routing and consume all N edges
+                        ModulationRouting r;
+                        r.kind = RoutingKind::PolyBus;
+                        r.sourceNodeID = srcNodeID;
+                        r.sourceChannelIndex = Hs;
+                        r.sourceVisibleJack = srcPort.visibleJackIndex;
+                        r.destNodeID = dstNodeID;
+                        r.destChannelIndex = Hd;
+                        r.destVisibleJack = dstPort.visibleJackIndex;
+                        r.voiceCount = N;
+                        r.hasSource = true;
+                        r.hasDest = true;
+                        r.amount = 1.0f;
+                        r.isBypassed = false;
+                        r.role = dstPort.role; // Pitch, Gate, or ModCV depending on dest fan type
+                        float peak = readVisualPeak(srcModule->getVisualBuffer());
+                        r.modSignalPeak = peak;
+                        r.modSignalValue = peak;
+                        routings.push_back(r);
+                        for (int i = 0; i < N; ++i)
+                            consumed.insert({Hs + i, Hd + i});
+                    }
+                }
+            }
+        }
+
+        // Remaining (non-collapsed) edges become DirectCV routings
+        for (auto& e : edges) {
+            if (consumed.count({e.srcChannel, e.dstChannel}))
+                continue;
+
+            LogicalPort srcPort = srcModule->mapOutputChannel(e.srcChannel);
+            LogicalPort dstPort = dstModule->mapInputChannel(e.dstChannel);
+
+            ModulationRouting r;
+            r.kind = RoutingKind::DirectCV;
+            r.sourceNodeID = srcNodeID;
+            r.sourceChannelIndex = e.srcChannel;
+            r.sourceVisibleJack = srcPort.visibleJackIndex;
+            r.destNodeID = dstNodeID;
+            r.destChannelIndex = e.dstChannel;
+            r.destVisibleJack = dstPort.visibleJackIndex;
+            r.voiceCount = 1;
+            r.hasSource = true;
+            r.hasDest = true;
+            r.amount = 1.0f;
+            r.isBypassed = false;
+            r.role = dstPort.role; // Pitch, Gate, or ModCV depending on dest port type
+            float peak = readVisualPeak(srcModule->getVisualBuffer());
+            r.modSignalPeak = peak;
+            r.modSignalValue = peak;
+            routings.push_back(r);
+        }
+    }
+
+    return routings;
+}
+
+std::vector<AudioEngine::ModRoutingInfo> AudioEngine::getActiveModRoutings() const {
+    std::vector<ModRoutingInfo> routings;
+    for (const auto& r : getModulationRoutings()) {
+        // Only AttenuverterChain routings are exposed to the ModMatrix
+        if (r.kind != RoutingKind::AttenuverterChain)
+            continue;
+        ModRoutingInfo info;
+        info.attenuverterNodeID = r.attenuverterNodeID;
+        info.sourceNodeID = r.sourceNodeID;
+        info.sourceChannelIndex = r.hasSource ? r.sourceChannelIndex : 0;
+        info.destNodeID = r.destNodeID;
+        info.destChannelIndex = r.destChannelIndex;
+        info.isBypassed = r.isBypassed;
+        routings.push_back(info);
     }
     return routings;
 }
 
 std::vector<AudioEngine::ModulationDisplayInfo> AudioEngine::getModulationDisplayInfo() const {
-    std::vector<ModulationDisplayInfo> result;
-    for (auto* node : mainProcessorGraph.getNodes()) {
-        if (auto* atten = dynamic_cast<AttenuverterModule*>(node->getProcessor())) {
-            ModulationDisplayInfo info;
-            info.attenuverterNodeID = node->nodeID;
-            info.modSignalValue = atten->getLastModValue();
-            info.modSignalPeak = atten->getLastOutputPeak();
-            info.isBypassed = false;
-            // Parameter 0 is bypassed, Parameter 1 is amount
-            if (auto* bp = dynamic_cast<juce::AudioParameterBool*>(node->getProcessor()->getParameters()[0]))
-                info.isBypassed = bp->get();
+    return getModulationDisplayInfo(getModulationRoutings());
+}
 
-            bool foundDest = false;
-            for (auto& conn : mainProcessorGraph.getConnections()) {
-                if (conn.source.nodeID == node->nodeID && conn.source.channelIndex == 0) {
-                    info.destNodeID = conn.destination.nodeID;
-                    info.destChannelIndex = conn.destination.channelIndex;
-                    foundDest = true;
-                    break;
-                }
-            }
-            if (foundDest)
-                result.push_back(info);
-        }
+std::vector<AudioEngine::ModulationDisplayInfo>
+AudioEngine::getModulationDisplayInfo(const std::vector<ModulationRouting>& allRoutings) const {
+    std::vector<ModulationDisplayInfo> result;
+
+    // Attenuverter routings first (as before)
+    for (const auto& r : allRoutings) {
+        if (r.kind != RoutingKind::AttenuverterChain)
+            continue;
+        if (!r.hasDest)
+            continue;
+        ModulationDisplayInfo info;
+        info.attenuverterNodeID = r.attenuverterNodeID;
+        info.destNodeID = r.destNodeID;
+        info.destChannelIndex = r.destChannelIndex;
+        info.modSignalValue = r.modSignalValue;
+        info.modSignalPeak = r.modSignalPeak;
+        info.isBypassed = r.isBypassed;
+        result.push_back(info);
     }
+
+    // DirectCV and PolyBus routings after — only emit display info for ModCV role
+    // (Pitch/Gate poly-bus routings are signal distribution, not parameter modulation,
+    //  so they must not produce knob-ring display info).
+    for (const auto& r : allRoutings) {
+        if (r.kind != RoutingKind::DirectCV && r.kind != RoutingKind::PolyBus)
+            continue;
+        if (!r.hasDest)
+            continue;
+        if (r.role != PortRole::ModCV)
+            continue;
+        ModulationDisplayInfo info;
+        // attenuverterNodeID left default-constructed (invalid) for direct/poly routings
+        info.destNodeID = r.destNodeID;
+        info.destChannelIndex = r.destChannelIndex;
+        info.modSignalValue = r.modSignalValue;
+        info.modSignalPeak = r.modSignalPeak;
+        info.isBypassed = false;
+        result.push_back(info);
+    }
+
     return result;
 }
 
@@ -262,21 +465,12 @@ void AudioEngine::createDefaultPatch() {
 }
 
 void AudioEngine::handleIncomingMidiMessage(juce::MidiInput* source, const juce::MidiMessage& message) {
-    std::cout << "MIDI Received from: " << source->getName().toStdString()
-              << " message: " << message.getDescription().toStdString() << std::endl;
-    bool routed = false;
     for (auto* node : mainProcessorGraph.getNodes()) {
         if (auto* extMidi = dynamic_cast<ExternalMidiModule*>(node->getProcessor())) {
-            std::cout << "Checking against ExternalMidiModule: " << extMidi->getName().toStdString() << std::endl;
             if (source->getName() == extMidi->getName()) {
-                std::cout << "Routing to ExternalMidiModule: " << extMidi->getName().toStdString() << std::endl;
                 extMidi->pushMidiMessage(message);
-                routed = true;
             }
         }
-    }
-    if (!routed) {
-        std::cout << "No ExternalMidiModule found for device: " << source->getName().toStdString() << std::endl;
     }
     midiMessageCollector.addMessageToQueue(message);
 }

--- a/Source/AudioEngine.h
+++ b/Source/AudioEngine.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Modules/ModuleBase.h"
 #include <juce_audio_basics/juce_audio_basics.h>
 #include <juce_audio_devices/juce_audio_devices.h>
 #include <juce_audio_processors/juce_audio_processors.h>
@@ -46,8 +47,31 @@ public:
         bool isBypassed;
     };
 
+    enum class RoutingKind { AttenuverterChain, DirectCV, PolyBus };
+
+    struct ModulationRouting {
+        RoutingKind kind = RoutingKind::AttenuverterChain;
+        juce::AudioProcessorGraph::NodeID sourceNodeID;
+        int sourceChannelIndex = 0;
+        int sourceVisibleJack = 0;
+        juce::AudioProcessorGraph::NodeID destNodeID;
+        int destChannelIndex = 0;
+        int destVisibleJack = 0;
+        juce::AudioProcessorGraph::NodeID attenuverterNodeID; // valid only for AttenuverterChain
+        int voiceCount = 1;
+        float amount = 1.0f;
+        bool isBypassed = false;
+        bool hasSource = false;
+        bool hasDest = false;
+        float modSignalValue = 0.0f;
+        float modSignalPeak = 0.0f;
+        PortRole role = PortRole::ModCV;
+    };
+
+    std::vector<ModulationRouting> getModulationRoutings() const;
     std::vector<ModRoutingInfo> getActiveModRoutings() const;
     std::vector<ModulationDisplayInfo> getModulationDisplayInfo() const;
+    std::vector<ModulationDisplayInfo> getModulationDisplayInfo(const std::vector<ModulationRouting>& routings) const;
     void addModRouting(juce::AudioProcessorGraph::NodeID sourceNodeID, int sourceChannelIndex,
                        juce::AudioProcessorGraph::NodeID destNodeID, int destChannelIndex);
     void addEmptyModRouting();

--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -25,8 +25,9 @@ MainComponent::MainComponent(std::unique_ptr<gsynth::AIProvider> provider)
         aiService.setProvider(std::make_unique<gsynth::OllamaProvider>(savedOllamaHost));
     }
 
-    aiChatComponent.refreshModels();
-
+    // NOTE: Do NOT call aiChatComponent.refreshModels() here. The AIChatComponent
+    // constructor already kicks off model discovery on construction. A second call
+    // would trigger a redundant /api/tags request on startup.
     aiService.addListener(this);
     setSize(1600, 900);
     undoManager.setGraphEditor(&graphEditor);
@@ -82,7 +83,8 @@ MainComponent::MainComponent(std::unique_ptr<gsynth::AIProvider> provider)
             if (result == 1000) {
                 openPresetFromFile();
             } else if (result > 0) {
-                if (gsynth::PresetManager::loadPreset(result - 1, audioEngine.getGraph())) {
+                bool loaded = gsynth::PresetManager::loadPreset(result - 1, audioEngine.getGraph());
+                if (loaded) {
                     graphEditor.updateComponents();
                 }
             }

--- a/Source/Modules/ADSRModule.h
+++ b/Source/Modules/ADSRModule.h
@@ -105,6 +105,50 @@ public:
     int getVisibleOutputPortCount() const override { return 1; }
     ModuleType getModuleType() const override { return ModuleType::ADSR; }
 
+    LogicalPort mapInputChannel(int raw) const override {
+        LogicalPort p;
+        if (polyParam->get()) {
+            if (raw >= 0 && raw <= 7) {
+                p.visibleJackIndex = 0;
+                p.role = PortRole::Gate;
+                p.isPolyGroupHead = (raw == 0);
+                p.polyVoiceSpan = (raw == 0) ? 8 : 1;
+                return p;
+            }
+        } else {
+            if (raw == 0) {
+                p.visibleJackIndex = 0;
+                p.role = PortRole::Gate;
+                p.isPolyGroupHead = true;
+                p.polyVoiceSpan = 1;
+                return p;
+            }
+        }
+        return ModuleBase::mapInputChannel(raw);
+    }
+
+    LogicalPort mapOutputChannel(int raw) const override {
+        LogicalPort p;
+        if (polyParam->get()) {
+            if (raw >= 0 && raw <= 7) {
+                p.visibleJackIndex = 0;
+                p.role = PortRole::ModCV;
+                p.isPolyGroupHead = (raw == 0);
+                p.polyVoiceSpan = (raw == 0) ? 8 : 1;
+                return p;
+            }
+        } else {
+            if (raw == 0) {
+                p.visibleJackIndex = 0;
+                p.role = PortRole::ModCV;
+                p.isPolyGroupHead = true;
+                p.polyVoiceSpan = 1;
+                return p;
+            }
+        }
+        return ModuleBase::mapOutputChannel(raw);
+    }
+
 private:
     static constexpr int MAX_VOICES = 8;
     juce::ADSR adsrs[MAX_VOICES];

--- a/Source/Modules/FilterModule.h
+++ b/Source/Modules/FilterModule.h
@@ -88,6 +88,78 @@ public:
     ModulationCategory getModulationCategory() const override { return ModulationCategory::Filter; }
     ModuleType getModuleType() const override { return ModuleType::Filter; }
 
+    LogicalPort mapInputChannel(int raw) const override {
+        LogicalPort p;
+        if (polyParam->get()) {
+            // Poly mode: raw 0-7 = per-voice Audio fan; raw 8,9,10 = shared ModCV
+            if (raw >= 0 && raw <= 7) {
+                p.visibleJackIndex = 0;
+                p.role = PortRole::Audio;
+                p.isPolyGroupHead = (raw == 0);
+                p.polyVoiceSpan = (raw == 0) ? 8 : 1;
+                return p;
+            }
+            if (raw == 8) {
+                p.visibleJackIndex = 1;
+                p.role = PortRole::ModCV;
+                p.isPolyGroupHead = true;
+                p.polyVoiceSpan = 1;
+                return p;
+            }
+            if (raw == 9) {
+                p.visibleJackIndex = 2;
+                p.role = PortRole::ModCV;
+                p.isPolyGroupHead = true;
+                p.polyVoiceSpan = 1;
+                return p;
+            }
+            if (raw == 10) {
+                p.visibleJackIndex = 3;
+                p.role = PortRole::ModCV;
+                p.isPolyGroupHead = true;
+                p.polyVoiceSpan = 1;
+                return p;
+            }
+        } else {
+            // Mono mode: raw 0 = Audio jack0; raw 1,2,3 = ModCV jacks 1,2,3
+            if (raw == 0) {
+                p.visibleJackIndex = 0;
+                p.role = PortRole::Audio;
+                p.isPolyGroupHead = true;
+                p.polyVoiceSpan = 1;
+                return p;
+            }
+            if (raw == 1) {
+                p.visibleJackIndex = 1;
+                p.role = PortRole::ModCV;
+                p.isPolyGroupHead = true;
+                p.polyVoiceSpan = 1;
+                return p;
+            }
+            if (raw == 2) {
+                p.visibleJackIndex = 2;
+                p.role = PortRole::ModCV;
+                p.isPolyGroupHead = true;
+                p.polyVoiceSpan = 1;
+                return p;
+            }
+            if (raw == 3) {
+                p.visibleJackIndex = 3;
+                p.role = PortRole::ModCV;
+                p.isPolyGroupHead = true;
+                p.polyVoiceSpan = 1;
+                return p;
+            }
+        }
+        return ModuleBase::mapInputChannel(raw);
+    }
+
+    bool isAutoPromotableModTarget(int dstChannel) const override {
+        if (polyParam->get())
+            return false;
+        return ModuleBase::isAutoPromotableModTarget(dstChannel);
+    }
+
     float getCurrentCutoff() const { return modulatedCutoff.load(std::memory_order_relaxed); }
     float getCurrentResonance() const { return *resonanceParam; }
     float getModulatedResonance() const { return modulatedResonance.load(std::memory_order_relaxed); }

--- a/Source/Modules/ModuleBase.h
+++ b/Source/Modules/ModuleBase.h
@@ -13,6 +13,16 @@ struct ModulationTarget {
 
 enum class ModulationCategory { Envelope, LFO, Oscillator, Sequencer, Filter, FX, Other };
 
+enum class PortRole { Audio, ModCV, Pitch, Gate, Midi, Other };
+
+struct LogicalPort {
+    int visibleJackIndex =
+        0; // which visible jack (0..getVisible*PortCount()-1) a wire to this raw channel should anchor to
+    PortRole role = PortRole::Other;
+    bool isPolyGroupHead = false; // true only for the lowest raw channel of a poly fan
+    int polyVoiceSpan = 1;        // 1 = mono; N = head of an N-voice fan
+};
+
 enum class ModuleType {
     Oscillator,
     Filter,
@@ -118,6 +128,35 @@ public:
     virtual int getVisibleOutputPortCount() const { return getTotalNumOutputChannels(); }
     virtual ModulationCategory getModulationCategory() const { return ModulationCategory::Other; }
     virtual ModuleType getModuleType() const = 0;
+
+    virtual LogicalPort mapInputChannel(int rawChannel) const {
+        LogicalPort p;
+        int vis = getVisibleInputPortCount();
+        p.visibleJackIndex = (vis > 0) ? juce::jlimit(0, vis - 1, rawChannel) : 0;
+        p.role = PortRole::Other;
+        p.isPolyGroupHead = (rawChannel < vis);
+        p.polyVoiceSpan = 1;
+        return p;
+    }
+
+    virtual LogicalPort mapOutputChannel(int rawChannel) const {
+        LogicalPort p;
+        int vis = getVisibleOutputPortCount();
+        p.visibleJackIndex = (vis > 0) ? juce::jlimit(0, vis - 1, rawChannel) : 0;
+        p.role = PortRole::Other;
+        p.isPolyGroupHead = (rawChannel < vis);
+        p.polyVoiceSpan = 1;
+        return p;
+    }
+
+    // Decouples display-advertising from JSON auto-promotion (used by AIStateMapper in a LATER increment; defined now).
+    // Default: a channel is auto-promotable iff it is one of this module's getModulationTargets() channelIndex values.
+    virtual bool isAutoPromotableModTarget(int dstChannel) const {
+        for (const auto& t : getModulationTargets())
+            if (t.channelIndex == dstChannel)
+                return true;
+        return false;
+    }
 
     VisualBuffer* getVisualBuffer() { return visualBuffer.get(); }
     void enableVisualBuffer(bool enable) {

--- a/Source/Modules/OscillatorModule.h
+++ b/Source/Modules/OscillatorModule.h
@@ -7,7 +7,13 @@ class OscillatorModule : public ModuleBase {
 public:
     OscillatorModule()
         : ModuleBase("Oscillator", 14,
-                     8) // 8 per-voice pitch CV inputs, 6 shared mod CV inputs (8-13), 8 per-voice audio outputs
+                     14) // 14 in: 8 per-voice pitch CV (0-7) + 6 shared mod CV (8-13).
+                         // 14 out declared so JUCE copies shared-mod-CV inputs when they fan out to
+                         // multiple downstream nodes (avoids buffer aliasing when inputChan >= numOuts).
+                         // Only channels 0-7 carry audio; 8-13 are silent pass-through outputs.
+                         // 14 outputs (not 8): channels 8-13 are silent pass-through outputs; this also
+                         // makes JUCE copy shared CV input buffers so our post-render clear can't
+                         // corrupt them — see processPolyMode clear note.
     {
         addParameter(waveformParam = new juce::AudioParameterChoice("waveform", "Waveform",
                                                                     {"Sine", "Square", "Saw", "Triangle"}, 0));
@@ -50,9 +56,6 @@ public:
         }
 
         if (polyParam->get()) {
-            // Clear unused channels (if any) before poly processing
-            for (int ch = 14; ch < buffer.getNumChannels(); ++ch)
-                buffer.clear(ch, 0, buffer.getNumSamples());
             processPolyMode(buffer, buffer.getNumSamples());
         } else {
             // Clear all channels except 0 at the start to prevent reading garbage
@@ -82,6 +85,71 @@ public:
     int getVisibleOutputPortCount() const override { return 1; }
     ModulationCategory getModulationCategory() const override { return ModulationCategory::Oscillator; }
     ModuleType getModuleType() const override { return ModuleType::Oscillator; }
+
+    LogicalPort mapInputChannel(int raw) const override {
+        LogicalPort p;
+        if (polyParam->get()) {
+            // Poly mode: raw 0-7 = per-voice Pitch fan; raw 8-12 = shared ModCV
+            if (raw >= 0 && raw <= 7) {
+                p.visibleJackIndex = 0;
+                p.role = PortRole::Pitch;
+                p.isPolyGroupHead = (raw == 0);
+                p.polyVoiceSpan = (raw == 0) ? 8 : 1;
+                return p;
+            }
+            if (raw == 8) {
+                p.visibleJackIndex = 1;
+                p.role = PortRole::ModCV;
+                p.isPolyGroupHead = true;
+                p.polyVoiceSpan = 1;
+                return p;
+            }
+            if (raw == 9) {
+                p.visibleJackIndex = 2;
+                p.role = PortRole::ModCV;
+                p.isPolyGroupHead = true;
+                p.polyVoiceSpan = 1;
+                return p;
+            }
+            if (raw == 10) {
+                p.visibleJackIndex = 3;
+                p.role = PortRole::ModCV;
+                p.isPolyGroupHead = true;
+                p.polyVoiceSpan = 1;
+                return p;
+            }
+            if (raw == 11) {
+                p.visibleJackIndex = 4;
+                p.role = PortRole::ModCV;
+                p.isPolyGroupHead = true;
+                p.polyVoiceSpan = 1;
+                return p;
+            }
+            if (raw == 12) {
+                p.visibleJackIndex = 5;
+                p.role = PortRole::ModCV;
+                p.isPolyGroupHead = true;
+                p.polyVoiceSpan = 1;
+                return p;
+            }
+        } else {
+            // Mono mode: raw 0-5 = ModCV jacks 0-5
+            if (raw >= 0 && raw <= 5) {
+                p.visibleJackIndex = raw;
+                p.role = PortRole::ModCV;
+                p.isPolyGroupHead = true;
+                p.polyVoiceSpan = 1;
+                return p;
+            }
+        }
+        return ModuleBase::mapInputChannel(raw);
+    }
+
+    bool isAutoPromotableModTarget(int dstChannel) const override {
+        if (polyParam->get())
+            return false;
+        return ModuleBase::isAutoPromotableModTarget(dstChannel);
+    }
 
 private:
     // -------------------------------------------------------------------------
@@ -159,7 +227,18 @@ private:
         if (isChannelActive(5))
             juce::FloatVectorOperations::copy(cvLevelSaved, buffer.getReadPointer(5), numSamples);
 
-        buffer.clear();
+        // Clear output channels 0..getTotalNumOutputChannels()-1 (==14). This range includes the
+        // shared mod-CV input channels (1-5 mono), but clearing them here is SAFE because:
+        // (a) those CVs were already cached above (into cv*Saved) before this clear; and
+        // (b) the module declares 14 output channels, so JUCE's AudioProcessorGraph treats
+        //     inputChan < numOutputs and makes a PRIVATE COPY of any CV channel that is also
+        //     consumed later by another downstream node (juce_AudioProcessorGraph addCopyChannelOp
+        //     / isBufferNeededLater). So this only zeroes our private copy, never the shared
+        //     source buffer.
+        // WARNING: this safety depends on the 14-output declaration in the constructor —
+        //          do NOT reduce it back to 8.
+        for (int ch = 0; ch < getTotalNumOutputChannels() && ch < numCh; ++ch)
+            buffer.clear(ch, 0, numSamples);
 
         float totalPitch = voices[0].lastMidiNote + (octaveParam->get() * 12.0f) + (float)coarseParam->get() +
                            (fineParam->get() / 100.0f);
@@ -273,8 +352,19 @@ private:
     // -------------------------------------------------------------------------
     void processPolyMode(juce::AudioBuffer<float>& buffer, int numSamples) {
         int numChannels = buffer.getNumChannels();
-        float level = levelParam->get();
         int ns = std::min(numSamples, 4096);
+
+        // Helper to check if a channel is active (same RMS guard as mono mode)
+        auto isChannelActive = [&](int ch) {
+            if (ch >= numChannels)
+                return false;
+            auto* data = buffer.getReadPointer(ch);
+            float rms = 0.0f;
+            int checkLen = std::min(numSamples, 64);
+            for (int i = 0; i < checkLen; ++i)
+                rms += data[i] * data[i];
+            return (rms / (float)checkLen) > 1e-6f;
+        };
 
         // Save pitch CVs (channels 0-7) before clearing buffer
         for (int v = 0; v < MAX_VOICES; ++v) {
@@ -284,7 +374,54 @@ private:
                 std::fill_n(pitchCVCache[v].data(), ns, 0.0f);
         }
 
-        buffer.clear();
+        // Cache shared mod CVs (channels 8-12) before clearing buffer
+        // ch8 -> waveformCVCache, ch9 -> octaveCVCache, ch10 -> coarseCVCache
+        // ch11 -> fineCVCache, ch12 -> levelCVCache
+        bool hasWaveCV = isChannelActive(8);
+        bool hasOctCV = isChannelActive(9);
+        bool hasCoarseCV = isChannelActive(10);
+        bool hasFineCV = isChannelActive(11);
+        bool hasLevelCV = isChannelActive(12);
+
+        if (hasWaveCV)
+            std::copy_n(buffer.getReadPointer(8), ns, waveformCVCache.data());
+        else
+            std::fill_n(waveformCVCache.data(), ns, 0.0f);
+
+        if (hasOctCV)
+            std::copy_n(buffer.getReadPointer(9), ns, octaveCVCache.data());
+        else
+            std::fill_n(octaveCVCache.data(), ns, 0.0f);
+
+        if (hasCoarseCV)
+            std::copy_n(buffer.getReadPointer(10), ns, coarseCVCache.data());
+        else
+            std::fill_n(coarseCVCache.data(), ns, 0.0f);
+
+        if (hasFineCV)
+            std::copy_n(buffer.getReadPointer(11), ns, fineCVCache.data());
+        else
+            std::fill_n(fineCVCache.data(), ns, 0.0f);
+
+        if (hasLevelCV)
+            std::copy_n(buffer.getReadPointer(12), ns, levelCVCache.data());
+        else
+            std::fill_n(levelCVCache.data(), ns, 0.0f);
+
+        bool pitchMod = hasOctCV || hasCoarseCV || hasFineCV;
+
+        // Clear output channels 0..getTotalNumOutputChannels()-1 (==14). This range includes the
+        // shared mod-CV input channels (8-12 poly), but clearing them here is SAFE because:
+        // (a) those CVs were already cached above (into *CVCache) before this clear; and
+        // (b) the module declares 14 output channels, so JUCE's AudioProcessorGraph treats
+        //     inputChan < numOutputs and makes a PRIVATE COPY of any CV channel that is also
+        //     consumed later by another downstream node (juce_AudioProcessorGraph addCopyChannelOp
+        //     / isBufferNeededLater). So this only zeroes our private copy, never the shared
+        //     source buffer.
+        // WARNING: this safety depends on the 14-output declaration in the constructor —
+        //          do NOT reduce it back to 8.
+        for (int ch = 0; ch < getTotalNumOutputChannels() && ch < numChannels; ++ch)
+            buffer.clear(ch, 0, numSamples);
 
         for (int v = 0; v < MAX_VOICES && v < numChannels; ++v) {
             float* output = buffer.getWritePointer(v);
@@ -314,27 +451,128 @@ private:
             float freq = juce::jlimit(20.0f, 20000.0f, basePitchHz);
             float baseDt = freq / (float)currentSampleRate;
             int wf = waveformParam->getIndex();
+            float level = levelParam->get();
             int unisonCount = unisonParam->get();
             float detuneCents = detuneParam->get();
 
-            // Pre-compute unison dt values (avoid pow in sample loop)
-            float uniDts[MAX_UNISON];
-            for (int u = 0; u < unisonCount; ++u) {
-                float offset = (unisonCount > 1) ? detuneCents * (2.0f * u / (unisonCount - 1) - 1.0f) : 0.0f;
-                uniDts[u] = baseDt * std::pow(2.0f, offset / 1200.0f);
-            }
-
-            for (int s = 0; s < numSamples; ++s) {
-                float sample = 0.0f;
+            if (!pitchMod) {
+                // ---- FAST PATH (no pitch CV): precomputed uniDts, byte-identical to original ----
+                // Pre-compute unison dt values (avoid pow in sample loop)
+                float uniDts[MAX_UNISON];
                 for (int u = 0; u < unisonCount; ++u) {
-                    sample += generateSample(wf, voices[v].unisonOscs[u].phase, uniDts[u]);
-                    voices[v].unisonOscs[u].phase += uniDts[u];
-                    if (voices[v].unisonOscs[u].phase >= 1.0f)
-                        voices[v].unisonOscs[u].phase -= 1.0f;
+                    float offset = (unisonCount > 1) ? detuneCents * (2.0f * u / (unisonCount - 1) - 1.0f) : 0.0f;
+                    uniDts[u] = baseDt * std::pow(2.0f, offset / 1200.0f);
                 }
-                output[s] = (sample / (float)unisonCount) * level;
+
+                // Seed previousWaveform before the loop so the first sample doesn't
+                // spuriously trigger a crossfade from the default-initialised value 0.
+                if (hasWaveCV)
+                    voices[v].previousWaveform = wf;
+
+                for (int s = 0; s < numSamples; ++s) {
+                    int idx = std::min(s, ns - 1);
+                    int wfS = hasWaveCV ? juce::jlimit(0, 3, wf + (int)std::round(waveformCVCache[idx] * 3.0f)) : wf;
+
+                    if (hasWaveCV) {
+                        if (wfS != voices[v].previousWaveform) {
+                            voices[v].fadingFromWaveform = voices[v].previousWaveform;
+                            voices[v].crossfadeSamplesRemaining = CROSSFADE_SAMPLES;
+                            voices[v].previousWaveform = wfS;
+                        }
+                    }
+
+                    float sample = 0.0f;
+                    for (int u = 0; u < unisonCount; ++u) {
+                        float g;
+                        if (hasWaveCV && voices[v].crossfadeSamplesRemaining > 0) {
+                            float alpha = (float)voices[v].crossfadeSamplesRemaining / (float)CROSSFADE_SAMPLES;
+                            g = generateSample(voices[v].fadingFromWaveform, voices[v].unisonOscs[u].phase, uniDts[u]) *
+                                    alpha +
+                                generateSample(wfS, voices[v].unisonOscs[u].phase, uniDts[u]) * (1.0f - alpha);
+                        } else {
+                            g = generateSample(wfS, voices[v].unisonOscs[u].phase, uniDts[u]);
+                        }
+                        sample += g;
+                        voices[v].unisonOscs[u].phase += uniDts[u];
+                        if (voices[v].unisonOscs[u].phase >= 1.0f)
+                            voices[v].unisonOscs[u].phase -= 1.0f;
+                    }
+
+                    if (hasWaveCV && voices[v].crossfadeSamplesRemaining > 0)
+                        --voices[v].crossfadeSamplesRemaining;
+
+                    float lv = hasLevelCV ? juce::jlimit(0.0f, 1.0f, level + levelCVCache[idx]) : level;
+                    output[s] = (sample / (float)unisonCount) * lv;
+                }
+            } else {
+                // ---- PER-SAMPLE PATH (pitch CV active): recompute dt each sample ----
+                // Pre-compute unison offset cents (avoid recomputing per-sample)
+                float uniOffsetCents[MAX_UNISON];
+                for (int u = 0; u < unisonCount; ++u) {
+                    uniOffsetCents[u] = (unisonCount > 1) ? detuneCents * (2.0f * u / (unisonCount - 1) - 1.0f) : 0.0f;
+                }
+
+                // Seed previousWaveform before the loop so the first sample doesn't
+                // spuriously trigger a crossfade from the default-initialised value 0.
+                if (hasWaveCV)
+                    voices[v].previousWaveform = wf;
+
+                for (int s = 0; s < numSamples; ++s) {
+                    int idx = std::min(s, ns - 1);
+
+                    float extraPitchShift = 0.0f;
+                    if (hasOctCV)
+                        extraPitchShift += std::round(octaveCVCache[idx] * 4.0f) * 12.0f;
+                    if (hasCoarseCV)
+                        extraPitchShift += std::round(coarseCVCache[idx] * 12.0f);
+                    if (hasFineCV)
+                        extraPitchShift += fineCVCache[idx]; // cvFine * 100 / 100 == cvFine
+
+                    float freqS =
+                        (extraPitchShift != 0.0f) ? basePitchHz * std::pow(2.0f, extraPitchShift / 12.0f) : basePitchHz;
+                    freqS = juce::jlimit(20.0f, 20000.0f, freqS);
+                    float dtS = freqS / (float)currentSampleRate;
+
+                    int wfS = hasWaveCV ? juce::jlimit(0, 3, wf + (int)std::round(waveformCVCache[idx] * 3.0f)) : wf;
+
+                    if (hasWaveCV) {
+                        if (wfS != voices[v].previousWaveform) {
+                            voices[v].fadingFromWaveform = voices[v].previousWaveform;
+                            voices[v].crossfadeSamplesRemaining = CROSSFADE_SAMPLES;
+                            voices[v].previousWaveform = wfS;
+                        }
+                    }
+
+                    float sample = 0.0f;
+                    for (int u = 0; u < unisonCount; ++u) {
+                        float uniDtS = dtS * std::pow(2.0f, uniOffsetCents[u] / 1200.0f);
+                        float g;
+                        if (hasWaveCV && voices[v].crossfadeSamplesRemaining > 0) {
+                            float alpha = (float)voices[v].crossfadeSamplesRemaining / (float)CROSSFADE_SAMPLES;
+                            g = generateSample(voices[v].fadingFromWaveform, voices[v].unisonOscs[u].phase, uniDtS) *
+                                    alpha +
+                                generateSample(wfS, voices[v].unisonOscs[u].phase, uniDtS) * (1.0f - alpha);
+                        } else {
+                            g = generateSample(wfS, voices[v].unisonOscs[u].phase, uniDtS);
+                        }
+                        sample += g;
+                        voices[v].unisonOscs[u].phase += uniDtS;
+                        if (voices[v].unisonOscs[u].phase >= 1.0f)
+                            voices[v].unisonOscs[u].phase -= 1.0f;
+                    }
+
+                    if (hasWaveCV && voices[v].crossfadeSamplesRemaining > 0)
+                        --voices[v].crossfadeSamplesRemaining;
+
+                    float lv = hasLevelCV ? juce::jlimit(0.0f, 1.0f, level + levelCVCache[idx]) : level;
+                    output[s] = (sample / (float)unisonCount) * lv;
+                }
             }
         }
+
+        // Clear CV channels (>= 8) so they do not leak downstream
+        for (int ch = 8; ch < numChannels; ++ch)
+            buffer.clear(ch, 0, numSamples);
 
         // Push voice 0 to visual buffer
         if (auto* vb = getVisualBuffer()) {

--- a/Source/Modules/PolyMidiModule.h
+++ b/Source/Modules/PolyMidiModule.h
@@ -88,6 +88,27 @@ public:
     juce::String getOutputPortLabel(int) const override { return "Poly Out"; }
     int getVisibleInputPortCount() const override { return 0; }
 
+    LogicalPort mapOutputChannel(int raw) const override {
+        LogicalPort p;
+        // Pitch fan: raw 0-7
+        if (raw >= 0 && raw <= 7) {
+            p.visibleJackIndex = 0;
+            p.role = PortRole::Pitch;
+            p.isPolyGroupHead = (raw == 0);
+            p.polyVoiceSpan = (raw == 0) ? 8 : 1;
+            return p;
+        }
+        // Gate fan: raw 8-15
+        if (raw >= 8 && raw <= 15) {
+            p.visibleJackIndex = 0;
+            p.role = PortRole::Gate;
+            p.isPolyGroupHead = (raw == 8);
+            p.polyVoiceSpan = (raw == 8) ? 8 : 1;
+            return p;
+        }
+        return ModuleBase::mapOutputChannel(raw);
+    }
+
 private:
     static constexpr int MAX_VOICES = 8;
 

--- a/Source/Modules/VCAModule.h
+++ b/Source/Modules/VCAModule.h
@@ -120,6 +120,50 @@ public:
     int getVisibleOutputPortCount() const override { return 1; }
     ModuleType getModuleType() const override { return ModuleType::VCA; }
 
+    LogicalPort mapInputChannel(int raw) const override {
+        LogicalPort p;
+        if (polyParam->get()) {
+            // Poly mode: raw 0-7 = per-voice Audio fan; raw 8-15 = per-voice ModCV fan
+            if (raw >= 0 && raw <= 7) {
+                p.visibleJackIndex = 0;
+                p.role = PortRole::Audio;
+                p.isPolyGroupHead = (raw == 0);
+                p.polyVoiceSpan = (raw == 0) ? 8 : 1;
+                return p;
+            }
+            if (raw >= 8 && raw <= 15) {
+                p.visibleJackIndex = 1;
+                p.role = PortRole::ModCV;
+                p.isPolyGroupHead = (raw == 8);
+                p.polyVoiceSpan = (raw == 8) ? 8 : 1;
+                return p;
+            }
+        } else {
+            // Mono mode
+            if (raw == 0) {
+                p.visibleJackIndex = 0;
+                p.role = PortRole::Audio;
+                p.isPolyGroupHead = true;
+                p.polyVoiceSpan = 1;
+                return p;
+            }
+            if (raw == 1) {
+                p.visibleJackIndex = 1;
+                p.role = PortRole::ModCV;
+                p.isPolyGroupHead = true;
+                p.polyVoiceSpan = 1;
+                return p;
+            }
+        }
+        return ModuleBase::mapInputChannel(raw);
+    }
+
+    bool isAutoPromotableModTarget(int dstChannel) const override {
+        if (polyParam->get())
+            return false;
+        return ModuleBase::isAutoPromotableModTarget(dstChannel);
+    }
+
 private:
     static constexpr int MAX_VOICES = 8;
     juce::AudioParameterFloat* gainParam = nullptr;

--- a/Source/UI/AIChatComponent.cpp
+++ b/Source/UI/AIChatComponent.cpp
@@ -509,15 +509,41 @@ void AIChatComponent::refreshModels() {
 
 #ifndef NDEBUG
 void AIChatComponent::appendDebugLog(const juce::String& msg) {
-    juce::Component::SafePointer<AIChatComponent> safeThis(this);
-    juce::MessageManager::callAsync([safeThis, msg]() {
-        if (safeThis.getComponent() == nullptr)
-            return;
-        auto* self = safeThis.getComponent();
+    {
+        const juce::ScopedLock sl(logLock);
+        pendingLogLines.add(msg);
+    }
+    bool expected = false;
+    if (logFlushScheduled.compare_exchange_strong(expected, true)) {
+        juce::Component::SafePointer<AIChatComponent> safeThis(this);
+        juce::MessageManager::callAsync([safeThis]() {
+            if (auto* self = safeThis.getComponent())
+                self->flushDebugLog();
+        });
+    }
+}
 
-        self->debugConsole.moveCaretToEnd();
-        self->debugConsole.insertTextAtCaret(msg + "\n");
-    });
+void AIChatComponent::flushDebugLog() {
+    logFlushScheduled.store(false);
+
+    juce::StringArray batch;
+    {
+        const juce::ScopedLock sl(logLock);
+        batch.swapWith(pendingLogLines);
+    }
+
+    if (batch.isEmpty())
+        return;
+
+    debugConsole.moveCaretToEnd();
+    debugConsole.insertTextAtCaret(batch.joinIntoString("\n") + "\n");
+
+    const int maxChars = 8000;
+    auto txt = debugConsole.getText();
+    if (txt.length() > maxChars) {
+        debugConsole.setText(txt.substring(txt.length() - maxChars), juce::dontSendNotification);
+        debugConsole.moveCaretToEnd();
+    }
 }
 
 void AIChatComponent::logMessage(const juce::String& message) { appendDebugLog(message); }

--- a/Source/UI/AIChatComponent.h
+++ b/Source/UI/AIChatComponent.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../AI/AIIntegrationService.h"
+#include <atomic>
 #include <juce_gui_basics/juce_gui_basics.h>
 #include <juce_gui_extra/juce_gui_extra.h>
 
@@ -61,6 +62,11 @@ private:
     juce::TextButton toggleDebugButton;
     bool debugConsoleVisible = false;
     void logMessage(const juce::String& message) override;
+    void flushDebugLog();
+
+    juce::CriticalSection logLock;
+    juce::StringArray pendingLogLines;
+    std::atomic<bool> logFlushScheduled{false};
 
 public:
     void appendDebugLog(const juce::String& msg);

--- a/Source/UI/GraphEditor.cpp
+++ b/Source/UI/GraphEditor.cpp
@@ -20,6 +20,9 @@
 #include "../Modules/VCAModule.h"
 #include "../Modules/VoiceMixerModule.h"
 #include "ModuleComponent.h"
+#include <set>
+#include <tuple>
+#include <unordered_map>
 
 GraphEditor::GraphEditor(AudioEngine& engine, GravisynthUndoManager* undoMgr)
     : audioEngine(engine)
@@ -44,6 +47,23 @@ void GraphEditor::GraphContentComponent::paint(juce::Graphics& g) {
     auto& graph = editor.audioEngine.getGraph();
     g.setColour(juce::Colours::yellow);
 
+    // Build a set of raw edges that Pass-2 (PolyBus / DirectCV wires) will draw,
+    // so Pass-1 does not render them a second time in a conflicting generic style.
+    // AttenuverterChain edges are intentionally excluded — they are handled by the
+    // existing attenuverter branch inside Pass-1.
+    using EdgeKey = std::tuple<uint32_t, int, uint32_t, int>;
+    std::set<EdgeKey> pass2HandledEdges;
+    for (const auto& routing : editor.cachedModRoutings) {
+        if (routing.kind == AudioEngine::RoutingKind::DirectCV) {
+            pass2HandledEdges.emplace(routing.sourceNodeID.uid, routing.sourceChannelIndex, routing.destNodeID.uid,
+                                      routing.destChannelIndex);
+        } else if (routing.kind == AudioEngine::RoutingKind::PolyBus) {
+            for (int i = 0; i < routing.voiceCount; ++i)
+                pass2HandledEdges.emplace(routing.sourceNodeID.uid, routing.sourceChannelIndex + i,
+                                          routing.destNodeID.uid, routing.destChannelIndex + i);
+        }
+    }
+
     for (auto& connection : graph.getConnections()) {
         auto* node1 = graph.getNodeForId(connection.source.nodeID);
         auto* node2 = graph.getNodeForId(connection.destination.nodeID);
@@ -66,6 +86,16 @@ void GraphEditor::GraphContentComponent::paint(juce::Graphics& g) {
                 if (connection.destination.channelIndex >= dstMb->getVisibleInputPortCount())
                     continue;
             }
+        }
+
+        // Skip raw edges that Pass-2 (PolyBus / DirectCV) will draw to avoid
+        // double-rendering in conflicting styles.
+        if (connection.source.channelIndex != juce::AudioProcessorGraph::midiChannelIndex &&
+            connection.destination.channelIndex != juce::AudioProcessorGraph::midiChannelIndex) {
+            EdgeKey ek{connection.source.nodeID.uid, connection.source.channelIndex, connection.destination.nodeID.uid,
+                       connection.destination.channelIndex};
+            if (pass2HandledEdges.count(ek))
+                continue;
         }
 
         if (dynamic_cast<AttenuverterModule*>(node2->getProcessor()) != nullptr) {
@@ -183,6 +213,85 @@ void GraphEditor::GraphContentComponent::paint(juce::Graphics& g) {
             }
         }
     }
+
+    // ---- Draw PolyBus / DirectCV modulation wires ----
+    // Build a nodeID -> ModuleComponent* lookup map once for O(1) per routing.
+    std::unordered_map<uint32_t, ModuleComponent*> nodeCompMap;
+    for (auto* comp : moduleComponents) {
+        if (comp == nullptr)
+            continue;
+        // Match against graph nodes by processor pointer.
+        for (auto* node : graph.getNodes()) {
+            if (node->getProcessor() == comp->getModule()) {
+                nodeCompMap[node->nodeID.uid] = comp;
+                break;
+            }
+        }
+    }
+
+    for (const auto& routing : editor.cachedModRoutings) {
+        if (routing.kind == AudioEngine::RoutingKind::AttenuverterChain)
+            continue; // Already rendered by the existing loop above.
+
+        auto srcIt = nodeCompMap.find(routing.sourceNodeID.uid);
+        auto dstIt = nodeCompMap.find(routing.destNodeID.uid);
+        if (srcIt == nodeCompMap.end() || dstIt == nodeCompMap.end())
+            continue;
+
+        auto* srcComp = srcIt->second;
+        auto* dstComp = dstIt->second;
+        if (srcComp == nullptr || dstComp == nullptr)
+            continue;
+
+        // getPortCenter now clamps out-of-range indices to the last visible jack,
+        // so these points always land on a real rendered port.
+        juce::Point<int> p1 =
+            srcComp->getBounds().getPosition() + srcComp->getPortCenter(routing.sourceVisibleJack, /*isInput=*/false);
+        juce::Point<int> p2 =
+            dstComp->getBounds().getPosition() + dstComp->getPortCenter(routing.destVisibleJack, /*isInput=*/true);
+
+        // Brightness / width scaled by signal activity (mirrors attenuverter line ~lines 107-110).
+        float modPeak = routing.modSignalPeak;
+        float lineWidth = 2.5f + modPeak * 2.0f;
+        float brightness = juce::jlimit(0.5f, 1.0f, 0.5f + modPeak * 0.5f);
+
+        // Color by role: ModCV = cyan (poly bus) or gold (direct), Pitch = light blue, Gate = orange
+        juce::Colour wireColour;
+        if (routing.role == PortRole::Pitch) {
+            wireColour = juce::Colour(0xffaad4ff); // light blue for pitch fan
+        } else if (routing.role == PortRole::Gate) {
+            wireColour = juce::Colour(0xffffa500); // orange for gate fan
+        } else {
+            wireColour = (routing.kind == AudioEngine::RoutingKind::PolyBus)
+                             ? juce::Colour(0xff00e5ff)  // cyan for ModCV poly bus
+                             : juce::Colour(0xffffd700); // gold for ModCV direct CV
+        }
+
+        if (routing.isBypassed)
+            wireColour = wireColour.withAlpha(0.3f);
+
+        g.setColour(wireColour.withMultipliedBrightness(brightness));
+        g.drawLine(p1.toFloat().x, p1.toFloat().y, p2.toFloat().x, p2.toFloat().y, lineWidth);
+
+        // Animated dots along the wire.
+        for (int d = 0; d < 3; ++d) {
+            float t = std::fmod(connectionAnimPhase + (float)d / 3.0f, 1.0f);
+            float dotX = p1.toFloat().x + (p2.toFloat().x - p1.toFloat().x) * t;
+            float dotY = p1.toFloat().y + (p2.toFloat().y - p1.toFloat().y) * t;
+            g.setColour(wireColour.withAlpha(0.7f));
+            g.fillEllipse(dotX - 2.5f, dotY - 2.5f, 5.0f, 5.0f);
+        }
+
+        // For poly buses, label the midpoint with "x{voiceCount}" so the bundle is visible.
+        if (routing.kind == AudioEngine::RoutingKind::PolyBus && routing.voiceCount > 1) {
+            auto mid = ((p1 + p2) / 2).toFloat();
+            g.setColour(juce::Colours::white);
+            g.setFont(11.0f);
+            g.drawText("x" + juce::String(routing.voiceCount), (int)mid.x + 5, (int)mid.y - 8, 28, 16,
+                       juce::Justification::left, false);
+        }
+    }
+    // ---- End PolyBus / DirectCV wires ----
 
     // Draw Line being dragged
     if (editor.isDraggingConnection) {
@@ -836,7 +945,9 @@ void GraphEditor::disconnectPort(ModuleComponent* module, int portIndex, bool is
 }
 
 void GraphEditor::timerCallback() {
-    cachedModDisplayInfo = audioEngine.getModulationDisplayInfo();
+    // Compute the routing traversal once; derive display info from the same snapshot.
+    cachedModRoutings = audioEngine.getModulationRoutings();
+    cachedModDisplayInfo = audioEngine.getModulationDisplayInfo(cachedModRoutings);
     content.connectionAnimPhase += 0.02f;
     if (content.connectionAnimPhase >= 1.0f)
         content.connectionAnimPhase -= 1.0f;

--- a/Source/UI/GraphEditor.h
+++ b/Source/UI/GraphEditor.h
@@ -94,6 +94,7 @@ private:
 
     GravisynthUndoManager* undoManager = nullptr;
     std::vector<AudioEngine::ModulationDisplayInfo> cachedModDisplayInfo;
+    std::vector<AudioEngine::ModulationRouting> cachedModRoutings;
 
     void updateTransform();
 
@@ -101,6 +102,8 @@ public:
     const std::vector<AudioEngine::ModulationDisplayInfo>& getCachedModDisplayInfo() const {
         return cachedModDisplayInfo;
     }
+
+    const std::vector<AudioEngine::ModulationRouting>& getCachedModRoutings() const { return cachedModRoutings; }
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(GraphEditor)
 };

--- a/Source/UI/ModuleComponent.cpp
+++ b/Source/UI/ModuleComponent.cpp
@@ -1,6 +1,7 @@
 #include "ModuleComponent.h"
 #include "../Modules/ExternalMidiModule.h"
 #include "../Modules/ModuleBase.h"
+#include "../Modules/PolySequencerModule.h"
 #include "../Modules/SequencerModule.h"
 #include "GraphEditor.h"
 
@@ -64,8 +65,9 @@ ModuleComponent::ModuleComponent(juce::AudioProcessor* m, juce::AudioProcessorGr
     }
 
     setTitle(module->getName());
+    setBufferedToImage(true);
     createControls();
-    startTimerHz(30); // 30 FPS for step visualization
+    startTimerHz(15); // 15 FPS is plenty for activity glow / step indicator; lower CPU than 30
 }
 
 ModuleComponent::~ModuleComponent() { detachFromProcessor(); }
@@ -139,7 +141,71 @@ void ModuleComponent::timerCallback() {
         }
     }
 
-    repaint();
+    // Gate repaint: only invalidate the buffered image when something has
+    // visually changed.  Idle modules (no signal, no modulation) produce no
+    // repaint, so the parent content.repaint() from GraphEditor composites the
+    // cached image cheaply instead of re-running the expensive text layout.
+    bool needsRepaint = false;
+
+    // 1. RMS changed meaningfully (activity glow / LED).
+    //    Threshold is deliberately coarse (0.05): a steady tone produces small
+    //    tick-to-tick RMS jitter from the sliding analysis window, and a tight
+    //    threshold (e.g. 0.002) treated that jitter as "activity changed" and
+    //    repainted every tick — invalidating the buffered image and re-running
+    //    the expensive text layout 30x/sec (the startup/preset-switch freeze).
+    if (std::abs(cachedRMS - lastPaintedRMS) > 0.05f)
+        needsRepaint = true;
+
+    // 2. Active modulation targeting this module (Serum mod rings)
+    if (!needsRepaint) {
+        const auto& modInfo = owner.getCachedModDisplayInfo();
+        for (const auto& info : modInfo) {
+            if (info.destNodeID == nodeId && std::abs(info.modSignalValue) > 0.001f) {
+                needsRepaint = true;
+                break;
+            }
+        }
+    }
+
+    // 3. Sequencer / PolySequencer: repaint only when the active step changes
+    //    so the playhead highlight animates without repainting on every idle tick.
+    if (!needsRepaint) {
+        auto t = getType(module);
+        if (t == ModuleType::Sequencer) {
+            if (auto* seq = dynamic_cast<SequencerModule*>(module)) {
+                int step = seq->currentActiveStep.load();
+                if (step != lastActiveStep) {
+                    lastActiveStep = step;
+                    needsRepaint = true;
+                }
+            } else {
+                // Fallback: sequencer type but no accessor — repaint each tick
+                needsRepaint = true;
+            }
+        } else if (t == ModuleType::PolySequencer) {
+            if (auto* pseq = dynamic_cast<PolySequencerModule*>(module)) {
+                int step = pseq->currentActiveStep.load();
+                if (step != lastActiveStep) {
+                    lastActiveStep = step;
+                    needsRepaint = true;
+                }
+            } else {
+                // Fallback: sequencer type but no accessor — repaint each tick
+                needsRepaint = true;
+            }
+        }
+    }
+
+    // NOTE: condition #4 (visible animated children — scope/freqResponse) is intentionally
+    // omitted.  FrequencyResponseComponent and ScopeComponent manage their own repaints
+    // via their own timers and only invalidate when their data changes.  Forcing a full
+    // parent repaint every tick because a child is visible caused a repaint storm on every
+    // Filter module (freqResponseComponent is always visible).
+
+    if (needsRepaint) {
+        lastPaintedRMS = cachedRMS;
+        repaint();
+    }
 }
 
 void ModuleComponent::createControls() {
@@ -519,11 +585,21 @@ juce::Point<int> ModuleComponent::getPortCenter(int index, bool isInput) {
                          // (getWidth() - 10, 30)
     }
 
+    // Clamp index to visible jack range so wires never terminate at a phantom y
+    // below the module. In-bounds indices are unchanged (clamped == index).
+    int visible = 0;
+    if (auto* mb = dynamic_cast<ModuleBase*>(module)) {
+        visible = isInput ? mb->getVisibleInputPortCount() : mb->getVisibleOutputPortCount();
+    } else {
+        visible = isInput ? module->getTotalNumInputChannels() : module->getTotalNumOutputChannels();
+    }
+    int clamped = (visible > 0) ? juce::jlimit(0, visible - 1, index) : 0;
+
     if (isInput) {
-        return {10, headerHeight + portOffset + index * yStep + 20}; // Left side, apply offset
+        return {10, headerHeight + portOffset + clamped * yStep + 20}; // Left side, apply offset
     } else {
         // No additional midiOffset for outputs here, as MIDI out is now fixed.
-        return {getWidth() - 10, headerHeight + portOffset + index * yStep + 20}; // Right side, apply offset
+        return {getWidth() - 10, headerHeight + portOffset + clamped * yStep + 20}; // Right side, apply offset
     }
 }
 

--- a/Source/UI/ModuleComponent.h
+++ b/Source/UI/ModuleComponent.h
@@ -87,7 +87,9 @@ private:
     juce::Point<int> dragStartPosition;
 
     float cachedRMS = 0.0f;
+    float lastPaintedRMS = -1.0f;
     std::vector<float> rmsReadBuffer;
+    int lastActiveStep = -1;
 
     void createControls();
     void updateLayout();

--- a/Tests/AIStateMapperTests.cpp
+++ b/Tests/AIStateMapperTests.cpp
@@ -4,6 +4,7 @@
 #include "../Source/Modules/LFOModule.h"
 #include "../Source/Modules/OscillatorModule.h"
 #include "../Source/Modules/VCAModule.h"
+#include "../Source/PresetManager.h"
 #include <gtest/gtest.h>
 #include <juce_audio_processors/juce_audio_processors.h>
 
@@ -573,4 +574,49 @@ TEST(AIStateMapperTest, Modulation_UnconnectedAttenuverterNotSerialized) {
     auto* modArr = rootObj->getProperty("modulations").getArray();
     ASSERT_NE(modArr, nullptr);
     EXPECT_EQ(modArr->size(), 0); // Unconnected attenuverter should NOT appear
+}
+
+// Regression test: AIStateMapper::applyJSONToGraph must NOT spam the logger
+// (one line per parameter per module) on preset load.
+//
+// Before the fix, AIChatComponent's juce::Logger implementation piped every
+// log line into an O(n^2) TextEditor append, causing multi-second UI freezes
+// on preset load.  A healthy load should produce at most a handful of
+// error/diagnostic lines — never one per parameter.
+TEST(AIStateMapperTest, PresetLoadDoesNotSpamLogger) {
+    struct CountingLogger : juce::Logger {
+        std::atomic<int> count{0};
+        void logMessage(const juce::String&) override { ++count; }
+    };
+
+    CountingLogger cl;
+    juce::Logger::setCurrentLogger(&cl);
+
+    // Load three representative presets (Default=0, Modulated Bass=3, Poly Pad=6)
+    // into fresh graphs so applyJSONToGraph is exercised in full each time.
+    {
+        juce::AudioProcessorGraph g0;
+        gsynth::PresetManager::loadPreset(0, g0);
+    }
+    {
+        juce::AudioProcessorGraph g3;
+        gsynth::PresetManager::loadPreset(3, g3);
+    }
+    {
+        juce::AudioProcessorGraph g6;
+        gsynth::PresetManager::loadPreset(6, g6);
+    }
+
+    // Capture count and reset logger BEFORE assertions so the logger is never
+    // left pointing at a destroyed object even if an EXPECT fires.
+    const int logCount = cl.count.load();
+    juce::Logger::setCurrentLogger(nullptr);
+
+    std::cout << "[PresetLoadDoesNotSpamLogger] logger calls across 3 presets: " << logCount << "\n";
+
+    // A healthy run emits ~0 lines for valid presets.  20 gives ample margin
+    // for any genuine one-off diagnostics without allowing per-parameter spam
+    // (which would be 100+ for a typical multi-module preset).
+    EXPECT_LT(logCount, 20) << "applyJSONToGraph is spamming the logger (" << logCount
+                            << " lines for 3 presets). This causes UI freezes in AIChatComponent.";
 }

--- a/Tests/AudioEngineModRoutingTests.cpp
+++ b/Tests/AudioEngineModRoutingTests.cpp
@@ -1,0 +1,262 @@
+#include "../Source/AudioEngine.h"
+#include "../Source/Modules/ADSRModule.h"
+#include "../Source/Modules/AttenuverterModule.h"
+#include "../Source/Modules/LFOModule.h"
+#include "../Source/Modules/OscillatorModule.h"
+#include "../Source/Modules/PolyMidiModule.h"
+#include "../Source/Modules/VCAModule.h"
+#include "../Source/PresetManager.h"
+#include <gtest/gtest.h>
+
+class AudioEngineModRoutingTests : public ::testing::Test {
+protected:
+    void SetUp() override {
+        engine.initialise();
+        engine.getGraph().clear();
+    }
+
+    void TearDown() override { engine.shutdown(); }
+
+    AudioEngine engine;
+};
+
+TEST_F(AudioEngineModRoutingTests, GetModulationRoutings_AttenuverterChainSurfaces) {
+    auto& graph = engine.getGraph();
+
+    auto lfoNode = graph.addNode(std::make_unique<LFOModule>());
+    auto vcaNode = graph.addNode(std::make_unique<VCAModule>());
+    ASSERT_NE(lfoNode, nullptr);
+    ASSERT_NE(vcaNode, nullptr);
+
+    // Wire LFO -> atten -> VCA.ch1 (mirror AudioEngine::addModRouting)
+    engine.addModRouting(lfoNode->nodeID, 0, vcaNode->nodeID, 1);
+
+    auto routings = engine.getModulationRoutings();
+    ASSERT_EQ(routings.size(), 1u);
+
+    const auto& r = routings[0];
+    EXPECT_EQ(r.kind, AudioEngine::RoutingKind::AttenuverterChain);
+    EXPECT_EQ(r.voiceCount, 1);
+    EXPECT_TRUE(r.hasSource);
+    EXPECT_TRUE(r.hasDest);
+    EXPECT_EQ(r.sourceNodeID, lfoNode->nodeID);
+    EXPECT_EQ(r.destNodeID, vcaNode->nodeID);
+    EXPECT_EQ(r.destChannelIndex, 1);
+}
+
+TEST_F(AudioEngineModRoutingTests, PolyEnvToVCA_CollapsesToOneRouting) {
+    auto& graph = engine.getGraph();
+    graph.clear();
+    bool loaded = gsynth::PresetManager::loadPreset(6, graph);
+    ASSERT_TRUE(loaded) << "Preset 6 (Poly Pad) failed to load";
+
+    auto routings = engine.getModulationRoutings();
+
+    // Now that Pitch and Gate fans are also collapsed into PolyBus routings,
+    // filter to only the ModCV PolyBus (the ADSR->VCA envelope fan).
+    int modCVPolyBusCount = 0;
+    AudioEngine::ModulationRouting modCVPolyBusRouting;
+    for (const auto& r : routings) {
+        if (r.kind == AudioEngine::RoutingKind::PolyBus && r.role == PortRole::ModCV) {
+            ++modCVPolyBusCount;
+            modCVPolyBusRouting = r;
+        }
+    }
+    EXPECT_EQ(modCVPolyBusCount, 1) << "Expected exactly 1 PolyBus routing with role==ModCV";
+    EXPECT_EQ(modCVPolyBusRouting.voiceCount, 8) << "Expected voiceCount == 8 for ADSR->VCA poly bus";
+
+    // Find ADSR (Amp Env) and VCA nodes by type
+    juce::AudioProcessorGraph::NodeID adsrNodeID, vcaNodeID;
+    bool foundAdsr = false, foundVca = false;
+    for (auto* node : graph.getNodes()) {
+        if (dynamic_cast<ADSRModule*>(node->getProcessor()) && !foundAdsr) {
+            adsrNodeID = node->nodeID;
+            foundAdsr = true;
+        }
+        if (dynamic_cast<VCAModule*>(node->getProcessor()) && !foundVca) {
+            vcaNodeID = node->nodeID;
+            foundVca = true;
+        }
+    }
+    ASSERT_TRUE(foundAdsr) << "ADSR (Amp Env) node not found in graph";
+    ASSERT_TRUE(foundVca) << "VCA node not found in graph";
+
+    EXPECT_EQ(modCVPolyBusRouting.sourceNodeID, adsrNodeID) << "PolyBus routing source should be ADSR";
+    EXPECT_EQ(modCVPolyBusRouting.destNodeID, vcaNodeID) << "PolyBus routing dest should be VCA";
+    EXPECT_EQ(modCVPolyBusRouting.destChannelIndex, 8)
+        << "PolyBus routing dest channel should be 8 (start of VCA ModCV fan)";
+}
+
+TEST_F(AudioEngineModRoutingTests, NoDoubleCountAttenuverterPlusDirect) {
+    auto& graph = engine.getGraph();
+    graph.clear();
+
+    auto lfoNode = graph.addNode(std::make_unique<LFOModule>());
+    auto vcaNode = graph.addNode(std::make_unique<VCAModule>());
+    ASSERT_NE(lfoNode, nullptr);
+    ASSERT_NE(vcaNode, nullptr);
+
+    // Wire LFO -> atten -> VCA.ch1 (standard attenuverter chain)
+    engine.addModRouting(lfoNode->nodeID, 0, vcaNode->nodeID, 1);
+
+    auto routings = engine.getModulationRoutings();
+
+    // Should be exactly 1 routing total (the attenuverter chain)
+    EXPECT_EQ(routings.size(), 1u)
+        << "Expected exactly 1 routing; attenuverter connections must not also appear as DirectCV";
+
+    EXPECT_EQ(routings[0].kind, AudioEngine::RoutingKind::AttenuverterChain)
+        << "The single routing should be AttenuverterChain";
+
+    int directOrPolyCount = 0;
+    for (const auto& r : routings) {
+        if (r.kind == AudioEngine::RoutingKind::DirectCV || r.kind == AudioEngine::RoutingKind::PolyBus)
+            ++directOrPolyCount;
+    }
+    EXPECT_EQ(directOrPolyCount, 0) << "Attenuverter-mediated connections must not appear as DirectCV/PolyBus";
+}
+
+TEST_F(AudioEngineModRoutingTests, PolyPitchAndGateFansCollapseToBuses) {
+    auto& graph = engine.getGraph();
+    graph.clear();
+    bool loaded = gsynth::PresetManager::loadPreset(6, graph);
+    ASSERT_TRUE(loaded) << "Preset 6 (Poly Pad) failed to load";
+
+    auto routings = engine.getModulationRoutings();
+
+    // Find relevant nodes by type
+    juce::AudioProcessorGraph::NodeID polyMidiNodeID, oscNodeID, adsrNodeID;
+    bool foundPolyMidi = false, foundOsc = false, foundAdsr = false;
+    for (auto* node : graph.getNodes()) {
+        if (dynamic_cast<PolyMidiModule*>(node->getProcessor()) && !foundPolyMidi) {
+            polyMidiNodeID = node->nodeID;
+            foundPolyMidi = true;
+        }
+        if (dynamic_cast<OscillatorModule*>(node->getProcessor()) && !foundOsc) {
+            oscNodeID = node->nodeID;
+            foundOsc = true;
+        }
+        if (dynamic_cast<ADSRModule*>(node->getProcessor()) && !foundAdsr) {
+            adsrNodeID = node->nodeID;
+            foundAdsr = true;
+        }
+    }
+    ASSERT_TRUE(foundPolyMidi) << "PolyMidi node not found in graph";
+    ASSERT_TRUE(foundOsc) << "Oscillator node not found in graph";
+    ASSERT_TRUE(foundAdsr) << "ADSR (Amp Env) node not found in graph";
+
+    // Assert there is a PolyBus routing role==Pitch: PolyMidi -> Oscillator, voiceCount==8
+    bool foundPitchBus = false;
+    for (const auto& r : routings) {
+        if (r.kind == AudioEngine::RoutingKind::PolyBus && r.role == PortRole::Pitch) {
+            EXPECT_EQ(r.sourceNodeID, polyMidiNodeID) << "Pitch bus source should be PolyMidi";
+            EXPECT_EQ(r.destNodeID, oscNodeID) << "Pitch bus dest should be Oscillator";
+            EXPECT_EQ(r.voiceCount, 8) << "Pitch bus should have voiceCount == 8";
+            foundPitchBus = true;
+            break;
+        }
+    }
+    EXPECT_TRUE(foundPitchBus) << "Expected a PolyBus routing with role==Pitch (PolyMidi -> Oscillator)";
+
+    // Assert there is a PolyBus routing role==Gate: PolyMidi -> ADSR, voiceCount==8
+    bool foundGateBus = false;
+    for (const auto& r : routings) {
+        if (r.kind == AudioEngine::RoutingKind::PolyBus && r.role == PortRole::Gate) {
+            EXPECT_EQ(r.sourceNodeID, polyMidiNodeID) << "Gate bus source should be PolyMidi";
+            EXPECT_EQ(r.destNodeID, adsrNodeID) << "Gate bus dest should be ADSR (Amp Env)";
+            EXPECT_EQ(r.voiceCount, 8) << "Gate bus should have voiceCount == 8";
+            foundGateBus = true;
+            break;
+        }
+    }
+    EXPECT_TRUE(foundGateBus) << "Expected a PolyBus routing with role==Gate (PolyMidi -> ADSR)";
+}
+
+TEST_F(AudioEngineModRoutingTests, PitchGateRoutingsDoNotProduceRingDisplayInfo) {
+    auto& graph = engine.getGraph();
+    graph.clear();
+    bool loaded = gsynth::PresetManager::loadPreset(6, graph);
+    ASSERT_TRUE(loaded) << "Preset 6 (Poly Pad) failed to load";
+
+    // Find relevant nodes by type
+    juce::AudioProcessorGraph::NodeID oscNodeID, adsrNodeID, vcaNodeID;
+    bool foundOsc = false, foundAdsr = false, foundVca = false;
+    for (auto* node : graph.getNodes()) {
+        if (dynamic_cast<OscillatorModule*>(node->getProcessor()) && !foundOsc) {
+            oscNodeID = node->nodeID;
+            foundOsc = true;
+        }
+        if (dynamic_cast<ADSRModule*>(node->getProcessor()) && !foundAdsr) {
+            adsrNodeID = node->nodeID;
+            foundAdsr = true;
+        }
+        if (dynamic_cast<VCAModule*>(node->getProcessor()) && !foundVca) {
+            vcaNodeID = node->nodeID;
+            foundVca = true;
+        }
+    }
+    ASSERT_TRUE(foundOsc) << "Oscillator node not found in graph";
+    ASSERT_TRUE(foundAdsr) << "ADSR node not found in graph";
+    ASSERT_TRUE(foundVca) << "VCA node not found in graph";
+
+    auto displayInfos = engine.getModulationDisplayInfo();
+
+    // Pitch fan (PolyMidi -> Oscillator, dest channels 0-7) must NOT produce display info entries
+    // for the Oscillator node at those channels (Pitch role -> no ring).
+    for (const auto& info : displayInfos) {
+        if (info.destNodeID == oscNodeID) {
+            // Channel 0-7 are Pitch fan channels — none should appear
+            EXPECT_GE(info.destChannelIndex, 8) << "Oscillator pitch channels (0-7) must not produce ring display info";
+        }
+    }
+
+    // Gate fan (PolyMidi -> ADSR, dest channels 0-7) must NOT produce display info entries
+    // for the ADSR node at those channels (Gate role -> no ring).
+    for (const auto& info : displayInfos) {
+        if (info.destNodeID == adsrNodeID) {
+            FAIL() << "ADSR node must not have any ring display info (gate fan should not produce rings)";
+        }
+    }
+
+    // The env->VCA ModCV bus MUST still produce display info for VCA destChannelIndex==8
+    bool foundVcaEntry = false;
+    for (const auto& info : displayInfos) {
+        if (info.destNodeID == vcaNodeID && info.destChannelIndex == 8) {
+            foundVcaEntry = true;
+            break;
+        }
+    }
+    EXPECT_TRUE(foundVcaEntry)
+        << "Expected a ModulationDisplayInfo entry for VCA destChannelIndex==8 (ADSR->VCA ModCV poly bus)";
+}
+
+TEST_F(AudioEngineModRoutingTests, DirectCVRoutingProducesDisplayInfo) {
+    auto& graph = engine.getGraph();
+    graph.clear();
+    bool loaded = gsynth::PresetManager::loadPreset(6, graph);
+    ASSERT_TRUE(loaded) << "Preset 6 (Poly Pad) failed to load";
+
+    auto displayInfos = engine.getModulationDisplayInfo();
+
+    // Find VCA node
+    juce::AudioProcessorGraph::NodeID vcaNodeID;
+    bool foundVca = false;
+    for (auto* node : graph.getNodes()) {
+        if (dynamic_cast<VCAModule*>(node->getProcessor()) && !foundVca) {
+            vcaNodeID = node->nodeID;
+            foundVca = true;
+        }
+    }
+    ASSERT_TRUE(foundVca) << "VCA node not found in graph";
+
+    // At least one ModulationDisplayInfo should target VCA channel 8 (ADSR->VCA poly bus)
+    bool found = false;
+    for (const auto& info : displayInfos) {
+        if (info.destNodeID == vcaNodeID && info.destChannelIndex == 8) {
+            found = true;
+            break;
+        }
+    }
+    EXPECT_TRUE(found)
+        << "Expected at least one ModulationDisplayInfo for VCA destChannelIndex==8 (ADSR->VCA poly bus)";
+}

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -47,6 +47,10 @@ add_executable(GravisynthTests
     SettingsWindowTests.cpp
     ShortcutManagerTests.cpp
     AudioRenderingTests.cpp
+    LogicalPortTests.cpp
+    StateRoundTripTests.cpp
+    AudioEngineModRoutingTests.cpp
+    PerformanceTests.cpp
     ../Source/MainComponent.cpp
     ../Source/UI/GraphEditor.cpp
     ../Source/UI/ModMatrixComponent.cpp

--- a/Tests/E2EWorkflowTests.cpp
+++ b/Tests/E2EWorkflowTests.cpp
@@ -21,6 +21,7 @@
 #include "../Source/UI/GraphEditor.h"
 #include "../Source/UI/ModuleComponent.h"
 #include "MainComponent.h"
+#include <cmath>
 #include <gtest/gtest.h>
 #include <juce_gui_basics/juce_gui_basics.h>
 
@@ -645,3 +646,61 @@ TEST_F(E2EWorkflowTest, FullWorkflow_PresetModifyUndoRedo) {
 // pumpMessages() call. With 7 presets × 3 operations × multiple pumps, the test
 // exceeds CI timeout. Coverage is provided by LoadAllPresets_NoCrash (all presets)
 // and DropAllModuleTypes_NoCrash (all 17 module types) independently.
+
+// ============================================================================
+// Section 8: Audio Smoke Validation (1 test)
+// ============================================================================
+
+// "App works fine" guard: every factory preset, when loaded into a fresh graph,
+// prepared for playback, and fed a MIDI note-on, must produce finite audio for
+// ~50 blocks (no NaN/Inf, no crash). This stops a future change from silently
+// breaking a preset's audio path.
+TEST_F(E2EWorkflowTest, AllPresetsRenderFiniteAudio) {
+    constexpr double kSampleRate = 44100.0;
+    constexpr int kBlockSize = 512;
+    constexpr int kNumBlocks = 50;
+    constexpr int kNumPresets = 7; // Default..Poly Pad
+
+    for (int presetIdx = 0; presetIdx < kNumPresets; ++presetIdx) {
+        loadPreset(presetIdx);
+
+        auto& g = graph();
+        // Prepare the graph for stereo playback (closed audio device in tests).
+        g.setPlayConfigDetails(0, 2, kSampleRate, kBlockSize);
+        g.prepareToPlay(kSampleRate, kBlockSize);
+
+        const int numChannels = juce::jmax(2, g.getMainBusNumOutputChannels());
+        juce::AudioBuffer<float> buffer(numChannels, kBlockSize);
+
+        // Feed a MIDI note-on on the first block (the graph routes MIDI to its
+        // MIDI-input nodes automatically).
+        juce::MidiBuffer noteOn;
+        noteOn.addEvent(juce::MidiMessage::noteOn(1, 60, (juce::uint8)100), 0);
+
+        bool allFinite = true;
+        for (int block = 0; block < kNumBlocks; ++block) {
+            buffer.clear();
+            if (block == 0) {
+                EXPECT_NO_THROW({ g.processBlock(buffer, noteOn); })
+                    << "Preset " << presetIdx << " crashed on first block";
+            } else {
+                juce::MidiBuffer empty;
+                EXPECT_NO_THROW({ g.processBlock(buffer, empty); })
+                    << "Preset " << presetIdx << " crashed on block " << block;
+            }
+
+            for (int ch = 0; ch < buffer.getNumChannels() && allFinite; ++ch) {
+                const float* data = buffer.getReadPointer(ch);
+                for (int s = 0; s < buffer.getNumSamples(); ++s) {
+                    if (!std::isfinite(data[s])) {
+                        allFinite = false;
+                        break;
+                    }
+                }
+            }
+        }
+
+        g.releaseResources();
+        EXPECT_TRUE(allFinite) << "Preset " << presetIdx << " produced non-finite (NaN/Inf) audio";
+    }
+}

--- a/Tests/GraphEditorTests.cpp
+++ b/Tests/GraphEditorTests.cpp
@@ -2,9 +2,11 @@
 #include "../Source/Modules/ADSRModule.h"
 #include "../Source/Modules/FilterModule.h"
 #include "../Source/Modules/LFOModule.h"
+#include "../Source/Modules/ModuleBase.h"
 #include "../Source/Modules/OscillatorModule.h"
 #include "../Source/Modules/SequencerModule.h"
 #include "../Source/Modules/VCAModule.h"
+#include "../Source/PresetManager.h"
 #include "../Source/UI/GraphEditor.h"
 #include "../Source/UI/ModuleComponent.h"
 #include <gtest/gtest.h>
@@ -303,6 +305,66 @@ TEST_F(GraphEditorTest, ReplaceModulePreservesMidiConnections) {
         }
     }
     EXPECT_TRUE(midiConnFound);
+}
+
+// Inc-4: Verify that for the Poly Pad preset's PolyBus (ADSR->VCA) routing,
+// sourceVisibleJack and destVisibleJack are within their module's visible port counts.
+// This guarantees getPortCenter() lands on a real rendered jack, not a phantom y.
+// Placed in AudioEngine-level fixture (no GUI needed) to keep the test headless.
+TEST_F(GraphEditorTest, PolyBusWireResolvesToVisibleJacks) {
+    AudioEngine engine;
+    engine.initialise();
+    engine.getGraph().clear();
+
+    bool loaded = gsynth::PresetManager::loadPreset(6, engine.getGraph());
+    ASSERT_TRUE(loaded) << "Poly Pad preset (index 6) must load successfully";
+
+    auto routings = engine.getModulationRoutings();
+
+    // Find the PolyBus routing
+    const AudioEngine::ModulationRouting* polyRouting = nullptr;
+    for (const auto& r : routings) {
+        if (r.kind == AudioEngine::RoutingKind::PolyBus) {
+            polyRouting = &r;
+            break;
+        }
+    }
+    ASSERT_NE(polyRouting, nullptr) << "Expected a PolyBus routing in the Poly Pad preset";
+
+    // Locate source and dest processors to query their visible port counts.
+    auto& graph = engine.getGraph();
+    juce::AudioProcessor* srcProcessor = nullptr;
+    juce::AudioProcessor* dstProcessor = nullptr;
+    for (auto* node : graph.getNodes()) {
+        if (node->nodeID == polyRouting->sourceNodeID)
+            srcProcessor = node->getProcessor();
+        if (node->nodeID == polyRouting->destNodeID)
+            dstProcessor = node->getProcessor();
+    }
+    ASSERT_NE(srcProcessor, nullptr) << "Source node must exist in graph";
+    ASSERT_NE(dstProcessor, nullptr) << "Dest node must exist in graph";
+
+    // Get visible port counts — use ModuleBase if available, else fall back.
+    int srcVisibleOuts = srcProcessor->getTotalNumOutputChannels();
+    int dstVisibleIns = dstProcessor->getTotalNumInputChannels();
+    if (auto* mb = dynamic_cast<ModuleBase*>(srcProcessor))
+        srcVisibleOuts = mb->getVisibleOutputPortCount();
+    if (auto* mb = dynamic_cast<ModuleBase*>(dstProcessor))
+        dstVisibleIns = mb->getVisibleInputPortCount();
+
+    // Key assertions: both visible jacks must be within the visible range,
+    // so paint() / getPortCenter() will use a real jack (not a phantom y).
+    EXPECT_LT(polyRouting->sourceVisibleJack, srcVisibleOuts)
+        << "PolyBus sourceVisibleJack (" << polyRouting->sourceVisibleJack
+        << ") must be < source visible output count (" << srcVisibleOuts << ")";
+    EXPECT_GE(polyRouting->sourceVisibleJack, 0) << "PolyBus sourceVisibleJack must be non-negative";
+
+    EXPECT_LT(polyRouting->destVisibleJack, dstVisibleIns)
+        << "PolyBus destVisibleJack (" << polyRouting->destVisibleJack << ") must be < dest visible input count ("
+        << dstVisibleIns << ")";
+    EXPECT_GE(polyRouting->destVisibleJack, 0) << "PolyBus destVisibleJack must be non-negative";
+
+    engine.shutdown();
 }
 
 TEST_F(GraphEditorTest, ReplaceModuleIsUndoable) {

--- a/Tests/IntegrationTests.cpp
+++ b/Tests/IntegrationTests.cpp
@@ -3,10 +3,13 @@
 #include "Modules/ADSRModule.h"
 #include "Modules/FilterModule.h"
 #include "Modules/LFOModule.h"
+#include "Modules/MidiKeyboardModule.h"
 #include "Modules/OscillatorModule.h"
 #include "Modules/VCAModule.h"
 #include "PresetManager.h"
+#include <cmath>
 #include <gtest/gtest.h>
+#include <juce_audio_processors/juce_audio_processors.h>
 
 class IntegrationTest : public ::testing::Test {
 protected:
@@ -153,4 +156,288 @@ TEST_F(IntegrationTest, AllPresetsLoadAndHaveSignalPath) {
         EXPECT_GT(graph.getConnections().size(), 0)
             << "Preset '" << presetNames[i].toStdString() << "' has no connections";
     }
+}
+
+// ---------------------------------------------------------------------------
+// PolyPad_EnvToOscModulatesOscLevel
+//
+// Proves that ADSR envelope output fed into Oscillator channel 12 (Level CV)
+// raises oscillator output amplitude as the envelope rises.
+//
+// Strategy:
+//   1. Create an ADSRModule (mono, so MIDI note-on drives it) + OscillatorModule
+//      (mono mode, Sine wave, base level = 0.5).
+//   2. Process them manually: ADSR output is written into the oscillator's
+//      ch12 before each processBlock call, exactly as the JUCE graph would do
+//      when the connection {"src": Amp Env, "srcPort": 0, "dst": Osc, "dstPort": 12}
+//      is present.
+//   3. Measure output RMS during an early block (env still rising from near 0)
+//      versus a later block (env has risen substantially).
+//   4. Assert late-block RMS > early-block RMS with a clear margin (2x).
+//
+//  Attack is set to 0.5s so there is a long, measurable ramp across many blocks.
+//  Base level is set to 0.0 (purely CV-driven) to make the effect unambiguous.
+// ---------------------------------------------------------------------------
+TEST(PolyPad_EnvToOscModulatesOscLevel, RisingEnvelopeRaisesOscillatorLevel) {
+    constexpr double kSampleRate = 44100.0;
+    constexpr int kBlockSize = 512;
+
+    // --- Setup ADSR (mono) ---
+    ADSRModule adsr;
+    adsr.prepareToPlay(kSampleRate, kBlockSize);
+
+    // Long attack (0.5s) so the ramp is clearly visible across blocks.
+    // Sustain = 1.0, decay/release don't matter for this test.
+    // Parameter indices (ModuleBase adds bypassed at 0, then ADSR adds attack=1, decay=2, sustain=3, release=4, poly=5)
+    auto* attackParam = dynamic_cast<juce::AudioParameterFloat*>(adsr.getParameters()[1]);
+    auto* sustainParam = dynamic_cast<juce::AudioParameterFloat*>(adsr.getParameters()[3]);
+    ASSERT_NE(attackParam, nullptr);
+    ASSERT_NE(sustainParam, nullptr);
+    *attackParam = 0.5f;
+    *sustainParam = 1.0f;
+
+    // --- Setup Oscillator in POLY mode (ch12 = Level CV in poly mode), Saw wave ---
+    OscillatorModule osc;
+    osc.prepareToPlay(kSampleRate, kBlockSize);
+
+    // Parameter indices (ModuleBase adds bypassed at 0):
+    //   0=bypassed, 1=waveform, 2=octave, 3=coarse, 4=fine, 5=level, 6=poly, 7=unison, 8=detune, 9=muted
+    auto* levelParam = dynamic_cast<juce::AudioParameterFloat*>(osc.getParameters()[5]);
+    auto* polyParam = dynamic_cast<juce::AudioParameterBool*>(osc.getParameters()[6]);
+    ASSERT_NE(levelParam, nullptr);
+    ASSERT_NE(polyParam, nullptr);
+    *levelParam = 0.0f;                     // base level zero; output is purely CV-driven
+    polyParam->setValueNotifyingHost(1.0f); // poly mode: Level CV = ch12
+
+    // In poly mode, voice 0 uses MIDI fallback (lastMidiNote) when pitch CV < 20 Hz.
+    // Prime lastMidiNote via a mono-mode processBlock with noteOn before switching to poly.
+    {
+        juce::MidiBuffer noteOn;
+        noteOn.addEvent(juce::MidiMessage::noteOn(1, 60, (juce::uint8)100), 0);
+        // Temporarily process in mono mode (poly not yet true in the param flush);
+        // the note-on is captured in voices[0].lastMidiNote regardless of poly flag.
+        juce::AudioBuffer<float> primeBuf(14, kBlockSize);
+        primeBuf.clear();
+        osc.processBlock(primeBuf, noteOn);
+    }
+
+    // --- Trigger ADSR with a note-on ---
+    juce::MidiBuffer noteOnMidi;
+    noteOnMidi.addEvent(juce::MidiMessage::noteOn(1, 60, (juce::uint8)100), 0);
+
+    // Helper: run one block through ADSR (mono) and Oscillator (poly), routing ADSR ch0 → Osc ch12.
+    // Returns the RMS of voice 0 audio output (ch0).
+    auto runBlock = [&](juce::MidiBuffer& midiForAdsr) -> float {
+        // ADSR: mono mode, fill gate with 1.0, apply envelope to ch0
+        juce::AudioBuffer<float> adsrBuf(8, kBlockSize);
+        for (int ch = 0; ch < 8; ++ch)
+            juce::FloatVectorOperations::fill(adsrBuf.getWritePointer(ch), 1.0f, kBlockSize);
+        adsr.processBlock(adsrBuf, midiForAdsr);
+        // adsrBuf.ch0 = envelope [0..1] rising during attack
+
+        // Oscillator: 14 channels — ch0 = voice 0 pitch CV (0 means MIDI fallback), ch12 = Level CV
+        juce::AudioBuffer<float> oscBuf(14, kBlockSize);
+        oscBuf.clear();
+        // ch0 = 0.0 Hz → poly voice 0 uses MIDI fallback (note 60 → ~261 Hz)
+        juce::FloatVectorOperations::copy(oscBuf.getWritePointer(12), adsrBuf.getReadPointer(0), kBlockSize);
+        juce::MidiBuffer emptyMidi;
+        osc.processBlock(oscBuf, emptyMidi);
+
+        // Compute RMS of voice 0 audio output (ch0 in poly mode)
+        const float* out = oscBuf.getReadPointer(0);
+        float sumSq = 0.0f;
+        for (int i = 0; i < kBlockSize; ++i)
+            sumSq += out[i] * out[i];
+        return std::sqrt(sumSq / static_cast<float>(kBlockSize));
+    };
+
+    // Block 1 (immediately after note-on): env is near zero, expect very low RMS
+    float earlyRMS = runBlock(noteOnMidi);
+
+    // Advance ~0.4s (34 blocks * 512 / 44100 ≈ 0.39s) — env has risen substantially
+    juce::MidiBuffer emptyMidi;
+    for (int i = 0; i < 34; ++i)
+        runBlock(emptyMidi);
+
+    // Block at ~0.4s into attack: env should be around 0.8, osc level much higher
+    float lateRMS = runBlock(emptyMidi);
+
+    // Sanity: early RMS should be small (envelope near 0, so near-silent output)
+    EXPECT_LT(earlyRMS, 0.05f) << "earlyRMS=" << earlyRMS << " — expected near-silence at env start";
+
+    // Key assertion: rising envelope raises oscillator output clearly (at least 5x louder)
+    EXPECT_GT(lateRMS, earlyRMS * 5.0f) << "lateRMS=" << lateRMS << " earlyRMS=" << earlyRMS
+                                        << " — rising envelope should raise oscillator level significantly";
+
+    // Also assert lateRMS is non-trivial (env has actually produced audio)
+    EXPECT_GT(lateRMS, 0.1f) << "lateRMS=" << lateRMS << " — expected audible signal after envelope rises";
+}
+
+// ---------------------------------------------------------------------------
+// PolyPad_EnvModulatesOutput_NotSilenced
+//
+// REGRESSION LOCK: Guards against the JUCE AudioProcessorGraph buffer-aliasing
+// hazard that was fixed by giving OscillatorModule 14 output channels.
+//
+// THE BUG (now fixed):
+//   Preset "Poly Pad" routes ADSR(8) output 0 to BOTH:
+//     (a) OscillatorModule(5) input 12  [Level CV]
+//     (b) VCAModule(7)        input 8   [voice-0 amplitude CV]
+//
+//   When OscillatorModule had only 8 output channels, JUCE's render graph saw
+//   that input channel 12 >= numOuts (8) and reused the ADSR output buffer for
+//   Oscillator's input 12 (no copy / aliased pointer).
+//
+//   Oscillator's processBlock (poly mode) then called:
+//     buffer.clear(ch, 0, numSamples)  for ch = 0 .. numOutputs-1
+//   With 14 outputs this loop runs ch 0..13, clearing the aliased ch12 buffer —
+//   which IS the ADSR output buffer.  VCA then read 0.0 from its input 8,
+//   multiplied every voice by 0, and the graph output went silent.
+//
+//   The fix: declare 14 output channels.  JUCE now allocates a unique buffer for
+//   ch12, so zeroing it does NOT destroy the ADSR source buffer.
+//
+// HOW TO VERIFY THE TEST CATCHES A REGRESSION:
+//   Temporarily change OscillatorModule("Oscillator", 14, 14) back to (14, 8),
+//   rebuild, and run this test — it must FAIL (lateRMS ≈ 0 with aliasing).
+//   Restore to 14,14, rebuild → test passes.
+//
+// APPROACH: Minimal hand-built graph that exactly replicates the two-consumer
+// aliasing topology (a single ADSR source feeding both Osc.in12 and VCA.in8).
+// Using a full JUCE AudioProcessorGraph so JUCE's buffer-allocation logic runs.
+// ---------------------------------------------------------------------------
+TEST(PolyPad_EnvModulatesOutput_NotSilenced, EnvToVcaNotZeroedByOscillatorClear) {
+    constexpr double kSampleRate = 44100.0;
+    constexpr int kBlockSize = 512;
+
+    // Build a minimal graph that reproduces the aliasing topology.
+    // Graph I/O: 0 inputs, 2 outputs (stereo, matching VCA poly sum on ch0/ch1).
+    using AudioGraphIOProcessor = juce::AudioProcessorGraph::AudioGraphIOProcessor;
+    using NodePtr = juce::AudioProcessorGraph::Node::Ptr;
+    juce::AudioProcessorGraph graph;
+
+    // Configure play settings BEFORE adding connections — the Audio Output node's
+    // input channel count is determined by the graph's output channel count.
+    graph.setPlayConfigDetails(0, 2, kSampleRate, kBlockSize);
+
+    // Add IO nodes
+    NodePtr outNode = graph.addNode(std::make_unique<AudioGraphIOProcessor>(AudioGraphIOProcessor::audioOutputNode));
+    ASSERT_NE(outNode, nullptr);
+
+    // Add a MidiKeyboard so we can trigger MIDI note-on through the graph
+    NodePtr kbNode = graph.addNode(std::make_unique<MidiKeyboardModule>());
+    ASSERT_NE(kbNode, nullptr);
+
+    // Add ADSR (mono: responds to MIDI note-on, produces rising envelope on ch0)
+    auto adsrMod = std::make_unique<ADSRModule>("Amp Env");
+    // Short attack (0.1 s) so envelope rises within ~9 blocks at 512/44100 ≈ 0.094 s
+    // Use parameter setters after adding so prepareToPlay inherits them.
+    NodePtr adsrNode = graph.addNode(std::move(adsrMod));
+    ASSERT_NE(adsrNode, nullptr);
+    {
+        // Parameters: 0=bypassed, 1=attack, 2=decay, 3=sustain, 4=release, 5=poly, 6=muted
+        auto* aParam = dynamic_cast<juce::AudioParameterFloat*>(adsrNode->getProcessor()->getParameters()[1]);
+        auto* sParam = dynamic_cast<juce::AudioParameterFloat*>(adsrNode->getProcessor()->getParameters()[3]);
+        ASSERT_NE(aParam, nullptr);
+        ASSERT_NE(sParam, nullptr);
+        *aParam = 0.1f; // 0.1 s attack
+        *sParam = 1.0f; // full sustain so envelope holds up during late blocks
+    }
+
+    // Add Oscillator in POLY mode — this is the "hazardous" consumer of ADSR ch0.
+    // Its Level CV input is channel 12. Having 14 output channels prevents aliasing.
+    auto oscMod = std::make_unique<OscillatorModule>();
+    NodePtr oscNode = graph.addNode(std::move(oscMod));
+    ASSERT_NE(oscNode, nullptr);
+    {
+        // Parameters: 0=bypassed, 1=waveform, 2=octave, 3=coarse, 4=fine, 5=level, 6=poly, 7=unison, 8=detune, 9=muted
+        auto* polyParam = dynamic_cast<juce::AudioParameterBool*>(oscNode->getProcessor()->getParameters()[6]);
+        auto* levelParam = dynamic_cast<juce::AudioParameterFloat*>(oscNode->getProcessor()->getParameters()[5]);
+        ASSERT_NE(polyParam, nullptr);
+        ASSERT_NE(levelParam, nullptr);
+        polyParam->setValueNotifyingHost(1.0f); // poly mode: Level CV = input 12
+        *levelParam = 0.7f;
+    }
+
+    // Add VCA in POLY mode — voice 0 amplitude CV is channel 8 (the aliasing victim).
+    // If Osc clears the shared ADSR buffer (ch12 aliased), VCA.in8 becomes 0 and output is silent.
+    auto vcaMod = std::make_unique<VCAModule>();
+    NodePtr vcaNode = graph.addNode(std::move(vcaMod));
+    ASSERT_NE(vcaNode, nullptr);
+    {
+        // Parameters: 0=bypassed, 1=gain, 2=poly, 3=muted
+        auto* polyParam = dynamic_cast<juce::AudioParameterBool*>(vcaNode->getProcessor()->getParameters()[2]);
+        auto* gainParam = dynamic_cast<juce::AudioParameterFloat*>(vcaNode->getProcessor()->getParameters()[1]);
+        ASSERT_NE(polyParam, nullptr);
+        ASSERT_NE(gainParam, nullptr);
+        polyParam->setValueNotifyingHost(1.0f); // poly mode
+        *gainParam = 0.8f;
+    }
+
+    // --- Connections ---
+    // MIDI: keyboard -> ADSR (so note-on triggers envelope) and -> Oscillator (voice 0 MIDI fallback)
+    const int MIDI = juce::AudioProcessorGraph::midiChannelIndex;
+    EXPECT_TRUE(graph.addConnection({{kbNode->nodeID, MIDI}, {adsrNode->nodeID, MIDI}}));
+    EXPECT_TRUE(graph.addConnection({{kbNode->nodeID, MIDI}, {oscNode->nodeID, MIDI}}));
+
+    // Audio: Oscillator poly voice 0 output (ch0) -> VCA poly audio input voice 0 (ch0)
+    EXPECT_TRUE(graph.addConnection({{oscNode->nodeID, 0}, {vcaNode->nodeID, 0}}));
+
+    // THE ALIASING TOPOLOGY: ADSR ch0 fans out to BOTH Osc ch12 AND VCA ch8.
+    // With Osc having only 8 outputs, JUCE would alias the ADSR buffer to Osc.in12.
+    // Osc's processBlock clears ch0..numOuts-1, clobbering the ADSR buffer, so VCA reads 0.
+    // With 14 outputs, JUCE gives Osc.in12 its own buffer — aliasing cannot occur.
+    EXPECT_TRUE(graph.addConnection({{adsrNode->nodeID, 0}, {oscNode->nodeID, 12}})); // ADSR -> Osc Level CV
+    EXPECT_TRUE(graph.addConnection({{adsrNode->nodeID, 0}, {vcaNode->nodeID, 8}}));  // ADSR -> VCA voice-0 CV
+
+    // VCA stereo output -> graph audio output
+    EXPECT_TRUE(graph.addConnection({{vcaNode->nodeID, 0}, {outNode->nodeID, 0}}));
+    EXPECT_TRUE(graph.addConnection({{vcaNode->nodeID, 1}, {outNode->nodeID, 1}}));
+
+    // --- Prepare ---
+    // (setPlayConfigDetails was already called above, before connections were added)
+    graph.prepareToPlay(kSampleRate, kBlockSize);
+
+    // Trigger note-on via the keyboard module's state (same pattern as AudioRenderingTests)
+    if (auto* kb = dynamic_cast<MidiKeyboardModule*>(kbNode->getProcessor()))
+        kb->getKeyboardState().noteOn(1, 60, 1.0f);
+
+    // --- Process blocks ---
+    // Block 1 (note-on just fired): envelope still near zero, expect near-silence
+    {
+        juce::AudioBuffer<float> buf(2, kBlockSize);
+        buf.clear();
+        juce::MidiBuffer emptyMidi;
+        graph.processBlock(buf, emptyMidi);
+    }
+
+    // Advance ~0.15 s (13 blocks) — attack (0.1 s) completes, envelope at full sustain (1.0)
+    for (int i = 0; i < 12; ++i) {
+        juce::AudioBuffer<float> buf(2, kBlockSize);
+        buf.clear();
+        juce::MidiBuffer emptyMidi;
+        graph.processBlock(buf, emptyMidi);
+    }
+
+    // Measure the LATE block (envelope should be fully risen)
+    juce::AudioBuffer<float> lateBuf(2, kBlockSize);
+    lateBuf.clear();
+    {
+        juce::MidiBuffer emptyMidi;
+        graph.processBlock(lateBuf, emptyMidi);
+    }
+
+    float sumSq = 0.0f;
+    const float* outData = lateBuf.getReadPointer(0);
+    for (int i = 0; i < kBlockSize; ++i)
+        sumSq += outData[i] * outData[i];
+    float lateRMS = std::sqrt(sumSq / static_cast<float>(kBlockSize));
+
+    // KEY ASSERTION: if the aliasing bug is present, lateRMS ≈ 0 (VCA multiplies by 0).
+    // With the fix (14 output channels), ADSR buffer survives Osc.processBlock and
+    // VCA reads a real envelope value (~1.0), producing audible output.
+    EXPECT_GT(lateRMS, 0.01f) << "lateRMS=" << lateRMS
+                              << " — VCA output is near-silent; the ADSR→VCA envelope buffer may have been "
+                                 "zeroed by Oscillator's processBlock (buffer-aliasing regression). "
+                                 "Check OscillatorModule output channel count (must be 14, not 8).";
 }

--- a/Tests/LogicalPortTests.cpp
+++ b/Tests/LogicalPortTests.cpp
@@ -1,0 +1,124 @@
+#include "../Source/Modules/ADSRModule.h"
+#include "../Source/Modules/FilterModule.h"
+#include "../Source/Modules/ModuleBase.h"
+#include "../Source/Modules/OscillatorModule.h"
+#include "../Source/Modules/PolyMidiModule.h"
+#include "../Source/Modules/VCAModule.h"
+#include <gtest/gtest.h>
+
+TEST(LogicalPortTests, DefaultMappingClampsPhantomChannels) {
+    VCAModule vca;
+
+    // VCAModule has getVisibleInputPortCount() == 2
+    ASSERT_EQ(vca.getVisibleInputPortCount(), 2);
+
+    // rawChannel 8 >= vis(2) in mono mode: falls through to base, clamped to vis-1 == 1, isPolyGroupHead == false
+    auto port8 = vca.mapInputChannel(8);
+    EXPECT_EQ(port8.visibleJackIndex, 1);
+    EXPECT_EQ(port8.role, PortRole::Other);
+    EXPECT_EQ(port8.polyVoiceSpan, 1);
+    EXPECT_FALSE(port8.isPolyGroupHead);
+
+    // rawChannel 0 < vis(2), so visibleJackIndex == 0, isPolyGroupHead == true
+    auto port0 = vca.mapInputChannel(0);
+    EXPECT_EQ(port0.visibleJackIndex, 0);
+    EXPECT_TRUE(port0.isPolyGroupHead);
+
+    // VCA target is {"CV", 1}, so channel 1 is auto-promotable, channel 8 is not
+    EXPECT_TRUE(vca.isAutoPromotableModTarget(1));
+    EXPECT_FALSE(vca.isAutoPromotableModTarget(8));
+}
+
+// Helper to find and set a bool parameter by ID
+static void setPolyParam(juce::AudioProcessor& proc, bool value) {
+    for (auto* param : proc.getParameters()) {
+        if (auto* p = dynamic_cast<juce::AudioProcessorParameterWithID*>(param)) {
+            if (p->paramID == "poly") {
+                p->setValueNotifyingHost(value ? 1.0f : 0.0f);
+                return;
+            }
+        }
+    }
+}
+
+TEST(LogicalPortTests, PolyModulesDescribeTheirFans) {
+    // ---- VCA (poly) ----
+    VCAModule vca;
+    setPolyParam(vca, true);
+
+    // Raw 0: Audio jack0, head of 8-voice fan
+    auto vca_in0 = vca.mapInputChannel(0);
+    EXPECT_EQ(vca_in0.visibleJackIndex, 0);
+    EXPECT_EQ(vca_in0.role, PortRole::Audio);
+    EXPECT_TRUE(vca_in0.isPolyGroupHead);
+    EXPECT_EQ(vca_in0.polyVoiceSpan, 8);
+
+    // Raw 8: ModCV jack1, head of 8-voice fan
+    auto vca_in8 = vca.mapInputChannel(8);
+    EXPECT_EQ(vca_in8.visibleJackIndex, 1);
+    EXPECT_EQ(vca_in8.role, PortRole::ModCV);
+    EXPECT_TRUE(vca_in8.isPolyGroupHead);
+    EXPECT_EQ(vca_in8.polyVoiceSpan, 8);
+
+    // Raw 9: ModCV jack1, NOT head (not a group head)
+    auto vca_in9 = vca.mapInputChannel(9);
+    EXPECT_FALSE(vca_in9.isPolyGroupHead);
+
+    // ---- ADSR (poly) ----
+    ADSRModule adsr;
+    setPolyParam(adsr, true);
+
+    // Output raw 0: ModCV, head of 8-voice fan
+    auto adsr_out0 = adsr.mapOutputChannel(0);
+    EXPECT_EQ(adsr_out0.visibleJackIndex, 0);
+    EXPECT_EQ(adsr_out0.role, PortRole::ModCV);
+    EXPECT_TRUE(adsr_out0.isPolyGroupHead);
+    EXPECT_EQ(adsr_out0.polyVoiceSpan, 8);
+
+    // Output raw 3: ModCV, NOT head
+    auto adsr_out3 = adsr.mapOutputChannel(3);
+    EXPECT_FALSE(adsr_out3.isPolyGroupHead);
+
+    // ---- Oscillator (poly) ----
+    OscillatorModule osc;
+    setPolyParam(osc, true);
+
+    // Input raw 0: Pitch, head of 8-voice fan
+    auto osc_in0 = osc.mapInputChannel(0);
+    EXPECT_EQ(osc_in0.role, PortRole::Pitch);
+    EXPECT_TRUE(osc_in0.isPolyGroupHead);
+    EXPECT_EQ(osc_in0.polyVoiceSpan, 8);
+
+    // Input raw 12: ModCV at jack 5 (Level), head span 1
+    auto osc_in12 = osc.mapInputChannel(12);
+    EXPECT_EQ(osc_in12.visibleJackIndex, 5);
+    EXPECT_EQ(osc_in12.role, PortRole::ModCV);
+    EXPECT_TRUE(osc_in12.isPolyGroupHead);
+    EXPECT_EQ(osc_in12.polyVoiceSpan, 1);
+
+    // ---- PolyMidi (always poly) ----
+    PolyMidiModule polyMidi;
+
+    // Output raw 0: Pitch, head of 8-voice fan
+    auto pm_out0 = polyMidi.mapOutputChannel(0);
+    EXPECT_EQ(pm_out0.role, PortRole::Pitch);
+    EXPECT_TRUE(pm_out0.isPolyGroupHead);
+    EXPECT_EQ(pm_out0.polyVoiceSpan, 8);
+
+    // Output raw 8: Gate, head of 8-voice fan
+    auto pm_out8 = polyMidi.mapOutputChannel(8);
+    EXPECT_EQ(pm_out8.role, PortRole::Gate);
+    EXPECT_TRUE(pm_out8.isPolyGroupHead);
+    EXPECT_EQ(pm_out8.polyVoiceSpan, 8);
+
+    // ---- Auto-promotion guard ----
+    // Poly osc: isAutoPromotableModTarget returns false
+    EXPECT_FALSE(osc.isAutoPromotableModTarget(12));
+    // Poly VCA: isAutoPromotableModTarget returns false for any channel
+    EXPECT_FALSE(vca.isAutoPromotableModTarget(1));
+
+    // Mono osc: channel 0 (Pitch) is in getModulationTargets(), so it should be auto-promotable
+    OscillatorModule monoOsc;
+    // polyParam defaults to false
+    EXPECT_TRUE(monoOsc.isAutoPromotableModTarget(0));
+}

--- a/Tests/ModuleBypassTests.cpp
+++ b/Tests/ModuleBypassTests.cpp
@@ -126,9 +126,11 @@ TEST_F(ModuleBypassTest, BypassedSourceOutputsSilence) {
 
     oscillator.prepareToPlay(sampleRate, blockSize);
 
-    // Create a buffer with the right number of output channels
+    // Create a buffer with the right number of output channels.
+    // OscillatorModule declares 14 output channels (8 audio + 6 silent pass-throughs)
+    // so that JUCE correctly copies shared CV input buffers that fan out to multiple nodes.
     int numChannels = oscillator.getTotalNumOutputChannels();
-    EXPECT_EQ(numChannels, 8);
+    EXPECT_EQ(numChannels, 14);
 
     juce::AudioBuffer<float> buffer(numChannels, blockSize);
     juce::MidiBuffer midiBuffer;

--- a/Tests/ModuleComponentTests.cpp
+++ b/Tests/ModuleComponentTests.cpp
@@ -1,4 +1,5 @@
 #include "../Source/Modules/OscillatorModule.h"
+#include "../Source/Modules/VCAModule.h"
 #include "../Source/UI/GraphEditor.h"
 #include "../Source/UI/ModuleComponent.h"
 #include <gtest/gtest.h>
@@ -49,4 +50,42 @@ TEST_F(ModuleComponentTest, TimerCallbackDoesNotCrash) {
     ModuleComponent moduleComponent(&processor, juce::AudioProcessorGraph::NodeID(1), editor);
 
     EXPECT_NO_THROW(moduleComponent.timerCallback());
+}
+
+// Inc-4: Verify getPortCenter clamps out-of-range indices to the last visible jack
+// so poly-bus wire endpoints never land at a phantom y below the module.
+TEST_F(ModuleComponentTest, GetPortCenter_ClampsOutOfRangeToLastVisibleJack) {
+    AudioEngine engine;
+    GraphEditor editor(engine);
+    VCAModule processor; // VCA: getVisibleInputPortCount() == 2, getVisibleOutputPortCount() == 1
+    ModuleComponent moduleComponent(&processor, juce::AudioProcessorGraph::NodeID(2), editor);
+    moduleComponent.setSize(280, 200);
+
+    // --- Input side ---
+    // VCA has 2 visible input ports (indices 0 and 1).
+    // Index 8 is far beyond visible range; it must clamp to index 1 (last visible).
+    auto p_in_1 = moduleComponent.getPortCenter(1, /*isInput=*/true);
+    auto p_in_8 = moduleComponent.getPortCenter(8, /*isInput=*/true);
+    auto p_in_0 = moduleComponent.getPortCenter(0, /*isInput=*/true);
+    auto p_in_0_ref = moduleComponent.getPortCenter(0, /*isInput=*/true);
+
+    // Clamped (index 8 -> index 1): y must equal the y for index 1.
+    EXPECT_EQ(p_in_8.y, p_in_1.y)
+        << "getPortCenter(8,true).y should clamp to getPortCenter(1,true).y (last visible input jack)";
+
+    // Must NOT equal the unbounded phantom formula value (headerHeight + portOffset + 8*20 + 20 = 30+0+160+20=210).
+    // We check it is strictly less than that phantom value.
+    int phantomY = 30 + 8 * 20 + 20; // headerHeight=30, yStep=20, portOffset=0 for VCA (no MIDI out)
+    EXPECT_LT(p_in_8.y, phantomY) << "getPortCenter(8,true).y must not equal the phantom unbounded formula value";
+
+    // In-bounds index (0) must be unchanged: clamped == index.
+    EXPECT_EQ(p_in_0.y, p_in_0_ref.y) << "getPortCenter(0,true) must be unchanged (in-bounds index, no clamping)";
+
+    // --- Output side ---
+    // VCA has 1 visible output port (index 0 only).
+    auto p_out_0 = moduleComponent.getPortCenter(0, /*isInput=*/false);
+    auto p_out_5 = moduleComponent.getPortCenter(5, /*isInput=*/false);
+
+    EXPECT_EQ(p_out_5.y, p_out_0.y)
+        << "getPortCenter(5,false).y should clamp to getPortCenter(0,false).y (only visible output jack)";
 }

--- a/Tests/OllamaProviderTests.cpp
+++ b/Tests/OllamaProviderTests.cpp
@@ -1,4 +1,5 @@
 #include "../Source/AI/OllamaProvider.h" // Correct path
+#include <chrono>                        // For steady_clock timing
 #include <future>                        // For std::promise/std::future
 #include <gtest/gtest.h>
 #include <juce_core/juce_core.h>
@@ -204,6 +205,73 @@ TEST_F(OllamaProviderTest, SendPromptSuccessWithMock) {
     ASSERT_TRUE(std::get<1>(result));            // Should be successful
     ASSERT_FALSE(std::get<0>(result).isEmpty()); // Response should not be empty
     ASSERT_TRUE(std::get<0>(result).contains("Mocked AI response."));
+}
+
+// A stream whose read() blocks for ~300ms to simulate a slow/unreachable Ollama
+// server during model discovery. Mirrors SlowInputStream but with a fixed delay
+// used specifically by the non-blocking discovery test.
+class BlockingDiscoveryStream : public juce::InputStream {
+public:
+    bool failedToOpen() const { return false; }
+    juce::int64 getTotalLength() override { return 1; }
+    juce::int64 getPosition() override { return readCalled ? 1 : 0; }
+    bool setPosition(juce::int64 newPosition) override {
+        juce::ignoreUnused(newPosition);
+        return false;
+    }
+    bool isExhausted() override { return readCalled; }
+
+    int read(void* destBuffer, int maxBytesToRead) override {
+        juce::ignoreUnused(destBuffer, maxBytesToRead);
+        if (readCalled)
+            return 0;
+        // Sleep in small increments so the worker can still be stopped cleanly.
+        int elapsed = 0;
+        while (elapsed < 300) {
+            if (juce::Thread::currentThreadShouldExit())
+                return 0;
+            juce::Thread::sleep(50);
+            elapsed += 50;
+        }
+        readCalled = true;
+        return 0;
+    }
+
+private:
+    bool readCalled = false;
+};
+
+// REGRESSION LOCK (UI-hang fix): fetchAvailableModels() must NOT block the caller
+// (the message thread). Even when the underlying stream is slow/unreachable, the
+// call must return immediately because discovery runs on a worker thread. A second
+// immediate call must also return immediately (it must not join the first worker).
+TEST_F(OllamaProviderTest, FetchAvailableModelsDoesNotBlockCaller) {
+    auto blockingFactory = [](const juce::URL& url,
+                              const juce::URL::InputStreamOptions& options) -> std::unique_ptr<juce::InputStream> {
+        juce::ignoreUnused(url, options);
+        return std::make_unique<BlockingDiscoveryStream>();
+    };
+
+    gsynth::OllamaProvider provider{"http://mock-host:11434", blockingFactory};
+    provider.setTestMode(true);
+
+    using clock = std::chrono::steady_clock;
+
+    auto t0 = clock::now();
+    provider.fetchAvailableModels([](const juce::StringArray&, bool) {});
+    auto firstCallMs = std::chrono::duration_cast<std::chrono::milliseconds>(clock::now() - t0).count();
+
+    auto t1 = clock::now();
+    provider.fetchAvailableModels([](const juce::StringArray&, bool) {});
+    auto secondCallMs = std::chrono::duration_cast<std::chrono::milliseconds>(clock::now() - t1).count();
+
+    EXPECT_LT(firstCallMs, 50) << "First fetchAvailableModels() blocked the caller for " << firstCallMs
+                               << " ms (the worker stream sleeps ~300ms; the call must return immediately)";
+    EXPECT_LT(secondCallMs, 50) << "Second fetchAvailableModels() blocked the caller for " << secondCallMs
+                                << " ms (it must NOT join/wait on the first in-flight discovery)";
+
+    // Let the worker finish so the destructor join is fast and clean.
+    provider.stopThread(5000);
 }
 
 TEST_F(OllamaProviderTest, SendPromptTimeoutFails) {

--- a/Tests/OscillatorCVModulationTests.cpp
+++ b/Tests/OscillatorCVModulationTests.cpp
@@ -113,3 +113,191 @@ TEST_F(OscillatorCVModulationTest, CoarseCVShiftsFrequency) {
 
     EXPECT_GT(modFreq, refFreq * 1.5f) << "Coarse CV should shift frequency up";
 }
+
+// ============================================================
+// Poly-mode CV modulation tests
+// ============================================================
+
+// Helper to enable poly mode on an oscillator
+static void enablePolyMode(OscillatorModule& osc_) {
+    for (auto* p : osc_.getParameters()) {
+        if (p->getName(100) == "Poly") {
+            if (auto* bp = dynamic_cast<juce::AudioParameterBool*>(p))
+                *bp = true;
+            break;
+        }
+    }
+}
+
+TEST(OscillatorPolyModulationTest, PolyLevelCVReducesAmplitude) {
+    constexpr double sr = 44100.0;
+    constexpr int N = 512;
+
+    // --- Baseline: Level CV = 0 ---
+    OscillatorModule oscBase;
+    enablePolyMode(oscBase);
+    oscBase.prepareToPlay(sr, N);
+
+    juce::AudioBuffer<float> baseBuf(14, N);
+    baseBuf.clear();
+    for (int i = 0; i < N; ++i)
+        baseBuf.setSample(0, i, 440.0f); // voice 0 pitch = 440 Hz
+    juce::MidiBuffer emptyMidi;
+    oscBase.processBlock(baseBuf, emptyMidi);
+    float rmsBase = 0.0f;
+    for (int i = 0; i < N; ++i) {
+        float s = baseBuf.getSample(0, i);
+        rmsBase += s * s;
+    }
+    rmsBase = std::sqrt(rmsBase / N);
+
+    // --- CV run: Level CV = -0.5 on ch12 ---
+    OscillatorModule oscCut;
+    enablePolyMode(oscCut);
+    oscCut.prepareToPlay(sr, N);
+
+    juce::AudioBuffer<float> cutBuf(14, N);
+    cutBuf.clear();
+    for (int i = 0; i < N; ++i) {
+        cutBuf.setSample(0, i, 440.0f);
+        cutBuf.setSample(12, i, -0.5f); // Level CV = -0.5 -> level clamp(1.0 - 0.5) = 0.5
+    }
+    oscCut.processBlock(cutBuf, emptyMidi);
+    float rmsCut = 0.0f;
+    for (int i = 0; i < N; ++i) {
+        float s = cutBuf.getSample(0, i);
+        rmsCut += s * s;
+    }
+    rmsCut = std::sqrt(rmsCut / N);
+
+    EXPECT_GT(rmsBase, 0.01f) << "Baseline should have signal";
+    EXPECT_LT(rmsCut, rmsBase * 0.8f) << "Level CV -0.5 should audibly reduce amplitude";
+}
+
+TEST(OscillatorPolyModulationTest, PolyOctaveCVShiftsFrequency) {
+    constexpr double sr = 44100.0;
+    constexpr int N = 512;
+
+    auto countZeroCrossings = [&](const juce::AudioBuffer<float>& buf, int ch) {
+        int xings = 0;
+        for (int i = 1; i < N; ++i)
+            if ((buf.getSample(ch, i - 1) >= 0.0f) != (buf.getSample(ch, i) >= 0.0f))
+                ++xings;
+        return xings;
+    };
+
+    // --- Baseline: no octave CV ---
+    OscillatorModule oscBase;
+    enablePolyMode(oscBase);
+    oscBase.prepareToPlay(sr, N);
+
+    juce::AudioBuffer<float> baseBuf(14, N);
+    baseBuf.clear();
+    for (int i = 0; i < N; ++i)
+        baseBuf.setSample(0, i, 220.0f); // 220 Hz
+    juce::MidiBuffer emptyMidi;
+    oscBase.processBlock(baseBuf, emptyMidi);
+    int xBase = countZeroCrossings(baseBuf, 0);
+
+    // --- CV run: Octave CV = +0.25 on ch9 -> round(0.25*4)=1 octave up -> ~440 Hz ---
+    OscillatorModule oscOct;
+    enablePolyMode(oscOct);
+    oscOct.prepareToPlay(sr, N);
+
+    juce::AudioBuffer<float> octBuf(14, N);
+    octBuf.clear();
+    for (int i = 0; i < N; ++i) {
+        octBuf.setSample(0, i, 220.0f);
+        octBuf.setSample(9, i, 0.25f); // Octave CV = +0.25
+    }
+    oscOct.processBlock(octBuf, emptyMidi);
+    int xOct = countZeroCrossings(octBuf, 0);
+
+    EXPECT_GT(xBase, 0) << "Baseline should have zero crossings";
+    float ratio = (xBase > 0) ? (float)xOct / (float)xBase : 0.0f;
+    // Expect ~2x zero crossings (1 octave up), allow tolerance [1.6, 2.4]
+    EXPECT_GT(ratio, 1.6f) << "Octave CV should roughly double frequency; ratio=" << ratio;
+    EXPECT_LT(ratio, 2.4f) << "Octave CV should not more than double+tolerance; ratio=" << ratio;
+}
+
+TEST(OscillatorPolyModulationTest, PolyWaveformCVCrossfadeNoClick) {
+    // Verify that a mid-block waveform boundary crossing produces no audible click
+    // (max adjacent-sample delta must be below a threshold even as waveform changes).
+    constexpr double sr = 44100.0;
+    constexpr int N = 256; // >= 128 as required; 2 * CROSSFADE_SAMPLES = 128
+    juce::MidiBuffer emptyMidi;
+
+    OscillatorModule osc;
+    enablePolyMode(osc);
+    osc.prepareToPlay(sr, N);
+
+    // Build buffer: voice 0 at 220 Hz constant pitch (ch0).
+    // Waveform CV (ch8): 0.0f for first half, 0.34f for second half.
+    //   round(0.0  * 3) = 0  -> waveform index = base (0, Sine)
+    //   round(0.34 * 3) = 1  -> waveform index = base+1 (1, Square)
+    // This forces exactly one boundary crossing at sample N/2.
+    juce::AudioBuffer<float> buf(14, N);
+    buf.clear();
+    for (int i = 0; i < N; ++i) {
+        buf.setSample(0, i, 220.0f);
+        buf.setSample(8, i, (i < N / 2) ? 0.0f : 0.34f);
+    }
+
+    osc.processBlock(buf, emptyMidi);
+
+    // Measure max absolute adjacent-sample delta across the whole output block.
+    float maxDelta = 0.0f;
+    for (int i = 1; i < N; ++i) {
+        float delta = std::abs(buf.getSample(0, i) - buf.getSample(0, i - 1));
+        if (delta > maxDelta)
+            maxDelta = delta;
+    }
+
+    // Crossfade should smooth the transition: no instantaneous jump >= 0.5.
+    EXPECT_LT(maxDelta, 0.5f) << "Waveform CV crossfade should suppress clicks; maxDelta=" << maxDelta;
+
+    // Verify non-zero output (audible signal present).
+    float rms = 0.0f;
+    for (int i = 0; i < N; ++i) {
+        float s = buf.getSample(0, i);
+        rms += s * s;
+    }
+    rms = std::sqrt(rms / N);
+    EXPECT_GT(rms, 0.01f) << "Output should be non-zero after waveform CV crossfade";
+}
+
+TEST(OscillatorPolyModulationTest, PolyZeroCVEqualsBaseline) {
+    constexpr double sr = 44100.0;
+    constexpr int N = 512;
+    juce::MidiBuffer emptyMidi;
+
+    // Run A: 14-channel buffer with channels 8-13 all zero
+    OscillatorModule oscA;
+    enablePolyMode(oscA);
+    oscA.prepareToPlay(sr, N);
+
+    juce::AudioBuffer<float> bufA(14, N);
+    bufA.clear();
+    for (int i = 0; i < N; ++i)
+        bufA.setSample(0, i, 440.0f);
+    // channels 8-13 remain zero (already cleared)
+    oscA.processBlock(bufA, emptyMidi);
+
+    // Run B: 8-channel buffer (no CV channels 8-13 present at all)
+    OscillatorModule oscB;
+    enablePolyMode(oscB);
+    oscB.prepareToPlay(sr, N);
+
+    juce::AudioBuffer<float> bufB(8, N);
+    bufB.clear();
+    for (int i = 0; i < N; ++i)
+        bufB.setSample(0, i, 440.0f);
+    // No crash expected even with numChannels <= 12
+    oscB.processBlock(bufB, emptyMidi); // must not OOB-read
+
+    // Both outputs should be equal sample-by-sample within 1e-5
+    for (int i = 0; i < N; ++i) {
+        EXPECT_NEAR(bufA.getSample(0, i), bufB.getSample(0, i), 1e-5f)
+            << "Sample " << i << " differs: A=" << bufA.getSample(0, i) << " B=" << bufB.getSample(0, i);
+    }
+}

--- a/Tests/PerformanceTests.cpp
+++ b/Tests/PerformanceTests.cpp
@@ -1,0 +1,133 @@
+// PerformanceTests.cpp
+//
+// Wall-clock performance regression guards for the startup / preset-switch paths
+// that the user reported as "stuck for quite some time". These tests MEASURE the
+// real cost of the hot paths so a future change cannot silently reintroduce a hang:
+//   - PresetLoadIsFast            : PresetManager::loadPreset per factory preset
+//   - ModulationRoutingsIsFast    : getModulationRoutings/getModulationDisplayInfo (30fps UI)
+//   - GraphEditorUpdateComponentsIsFast : GraphEditor::updateComponents on a preset switch
+//
+// Timings are printed with std::cout so the numbers are visible in the test log.
+
+#include "../Source/AudioEngine.h"
+#include "../Source/PresetManager.h"
+#include "../Source/UI/GraphEditor.h"
+#include <chrono>
+#include <gtest/gtest.h>
+#include <iostream>
+#include <juce_audio_processors/juce_audio_processors.h>
+#include <juce_gui_basics/juce_gui_basics.h>
+
+namespace {
+using clock_type = std::chrono::steady_clock;
+
+double msSince(clock_type::time_point start) {
+    return std::chrono::duration<double, std::milli>(clock_type::now() - start).count();
+}
+
+constexpr int kNumPresets = 7; // Default..Poly Pad (indices 0..6)
+constexpr int kPolyPadPreset = 6;
+} // namespace
+
+// Each factory preset must load quickly into a fresh graph. Real cost should be a
+// few ms; a 250ms budget catches a genuine regression (e.g. a 100x blowup) without
+// being flaky on a loaded CI box.
+TEST(PerformanceTest, PresetLoadIsFast) {
+    for (int i = 0; i < kNumPresets; ++i) {
+        juce::AudioProcessorGraph graph;
+        graph.setPlayConfigDetails(0, 2, 44100.0, 512);
+
+        auto start = clock_type::now();
+        bool loaded = gsynth::PresetManager::loadPreset(i, graph);
+        double elapsedMs = msSince(start);
+
+        EXPECT_TRUE(loaded) << "Preset " << i << " failed to load";
+        std::cout << "[PERF] loadPreset(" << i << ") = " << elapsedMs << " ms" << std::endl;
+        EXPECT_LT(elapsedMs, 250.0) << "Preset " << i << " load took " << elapsedMs << " ms (budget 250ms)";
+    }
+}
+
+// getModulationRoutings()/getModulationDisplayInfo() run every UI frame (~30fps),
+// so they must be cheap. Average per-call budget is 5ms; in practice these are
+// sub-millisecond. We use Poly Pad (the heaviest factory preset) as the worst case.
+TEST(PerformanceTest, ModulationRoutingsIsFast) {
+    AudioEngine engine;
+    engine.initialise();
+    engine.getGraph().clear();
+    bool loaded = gsynth::PresetManager::loadPreset(kPolyPadPreset, engine.getGraph());
+    ASSERT_TRUE(loaded) << "Poly Pad preset (index 6) failed to load";
+
+    constexpr int kIters = 100;
+
+    // getModulationRoutings
+    double maxRoutingsMs = 0.0;
+    auto routingsStart = clock_type::now();
+    for (int i = 0; i < kIters; ++i) {
+        auto callStart = clock_type::now();
+        auto routings = engine.getModulationRoutings();
+        double callMs = msSince(callStart);
+        maxRoutingsMs = std::max(maxRoutingsMs, callMs);
+        (void)routings;
+    }
+    double avgRoutingsMs = msSince(routingsStart) / kIters;
+
+    // getModulationDisplayInfo
+    double maxDisplayMs = 0.0;
+    auto displayStart = clock_type::now();
+    for (int i = 0; i < kIters; ++i) {
+        auto callStart = clock_type::now();
+        auto info = engine.getModulationDisplayInfo();
+        double callMs = msSince(callStart);
+        maxDisplayMs = std::max(maxDisplayMs, callMs);
+        (void)info;
+    }
+    double avgDisplayMs = msSince(displayStart) / kIters;
+
+    std::cout << "[PERF] getModulationRoutings    avg=" << avgRoutingsMs << " ms  max=" << maxRoutingsMs << " ms"
+              << std::endl;
+    std::cout << "[PERF] getModulationDisplayInfo avg=" << avgDisplayMs << " ms  max=" << maxDisplayMs << " ms"
+              << std::endl;
+
+    EXPECT_LT(avgRoutingsMs, 5.0) << "getModulationRoutings avg " << avgRoutingsMs << " ms exceeds 5ms (runs at 30fps)";
+    EXPECT_LT(avgDisplayMs, 5.0) << "getModulationDisplayInfo avg " << avgDisplayMs
+                                 << " ms exceeds 5ms (runs at 30fps)";
+
+    engine.shutdown();
+}
+
+// GraphEditor::updateComponents() rebuilds the visual graph on a preset switch.
+// This is the headless analog of the user-facing "preset switch hang". We time it
+// for the heaviest preset and again after switching to a different preset.
+TEST(PerformanceTest, GraphEditorUpdateComponentsIsFast) {
+    AudioEngine engine;
+    engine.initialise();
+    GraphEditor editor(engine);
+    editor.setSize(1200, 800);
+
+    // Load Poly Pad and time the first updateComponents (initial render).
+    editor.detachAllModuleComponents();
+    engine.getGraph().clear();
+    ASSERT_TRUE(gsynth::PresetManager::loadPreset(kPolyPadPreset, engine.getGraph()))
+        << "Poly Pad preset (index 6) failed to load";
+
+    auto start1 = clock_type::now();
+    editor.updateComponents();
+    double firstMs = msSince(start1);
+    std::cout << "[PERF] updateComponents (load Poly Pad) = " << firstMs << " ms" << std::endl;
+    EXPECT_LT(firstMs, 500.0) << "updateComponents after loading Poly Pad took " << firstMs << " ms (budget 500ms)";
+
+    // Switch to a different preset (index 0) and time updateComponents again —
+    // this simulates a preset switch in the running app.
+    editor.detachAllModuleComponents();
+    engine.getGraph().clear();
+    ASSERT_TRUE(gsynth::PresetManager::loadPreset(0, engine.getGraph())) << "Preset 0 failed to load";
+
+    auto start2 = clock_type::now();
+    editor.updateComponents();
+    double secondMs = msSince(start2);
+    std::cout << "[PERF] updateComponents (switch to preset 0) = " << secondMs << " ms" << std::endl;
+    EXPECT_LT(secondMs, 500.0) << "updateComponents on preset switch took " << secondMs << " ms (budget 500ms)";
+
+    editor.detachAllModuleComponents();
+    engine.shutdown();
+}

--- a/Tests/PresetManagerTests.cpp
+++ b/Tests/PresetManagerTests.cpp
@@ -1,3 +1,6 @@
+#include "../Source/Modules/ADSRModule.h"
+#include "../Source/Modules/AttenuverterModule.h"
+#include "../Source/Modules/OscillatorModule.h"
 #include "../Source/PresetManager.h"
 #include <gtest/gtest.h>
 
@@ -78,4 +81,55 @@ TEST(PresetManagerTest, PresetNamesMatchPresetList) {
     for (int i = 0; i < names.size(); ++i) {
         EXPECT_EQ(names[i], presets[i].name);
     }
+}
+
+TEST(PresetManagerTest, PolyPad_NoEnvToOscLevelConnection) {
+    juce::AudioProcessorGraph graph;
+    ASSERT_TRUE(gsynth::PresetManager::loadPreset(6, graph)) << "Failed to load Poly Pad preset (index 6)";
+
+    // Find the ADSR node named "Amp Env" and the Oscillator node
+    juce::AudioProcessorGraph::Node* adsrNode = nullptr;
+    juce::AudioProcessorGraph::Node* oscNode = nullptr;
+    int attenuverterCount = 0;
+
+    for (auto* node : graph.getNodes()) {
+        if (node->getProcessor()->getName() == "Amp Env")
+            adsrNode = node;
+        else if (auto* osc = dynamic_cast<OscillatorModule*>(node->getProcessor()))
+            oscNode = node;
+        if (dynamic_cast<AttenuverterModule*>(node->getProcessor()) != nullptr)
+            ++attenuverterCount;
+    }
+
+    ASSERT_NE(adsrNode, nullptr) << "Poly Pad should have an 'Amp Env' node";
+    ASSERT_NE(oscNode, nullptr) << "Poly Pad should have an Oscillator node";
+
+    // Assert the oscillator is in poly mode
+    // OscillatorModule parameter indices: 0=bypassed, 1=waveform, 2=octave, 3=coarse, 4=fine,
+    //   5=level, 6=poly, 7=unison, 8=detune, 9=muted
+    auto* osc = dynamic_cast<OscillatorModule*>(oscNode->getProcessor());
+    ASSERT_NE(osc, nullptr);
+    auto* polyParam = dynamic_cast<juce::AudioParameterBool*>(osc->getParameters()[6]);
+    ASSERT_NE(polyParam, nullptr);
+    EXPECT_TRUE(polyParam->get()) << "Oscillator in Poly Pad should have poly=true";
+
+    // Assert there is NO connection from (Amp Env, ch 0) to (Oscillator, ch 12).
+    // The oscillator's Level CV (poly channel 12) is shared across all voices, so
+    // routing Amp Env voice-0 into it couples all voices to voice 0's envelope.
+    // The capability still works (see IntegrationTests), but we no longer bake
+    // this particular wire into the factory preset.
+    bool foundEnvToOscLevelConn = false;
+    for (auto& conn : graph.getConnections()) {
+        if (conn.source.nodeID == adsrNode->nodeID && conn.source.channelIndex == 0 &&
+            conn.destination.nodeID == oscNode->nodeID && conn.destination.channelIndex == 12) {
+            foundEnvToOscLevelConn = true;
+            break;
+        }
+    }
+    EXPECT_FALSE(foundEnvToOscLevelConn)
+        << "Poly Pad must NOT have a direct connection from Amp Env (ch 0) to Oscillator (ch 12 = Level CV): "
+           "that wire couples all voices to voice-0's envelope via a shared-channel";
+
+    // Assert zero attenuverter nodes
+    EXPECT_EQ(attenuverterCount, 0) << "Poly Pad should have 0 attenuverter nodes";
 }

--- a/Tests/StateRoundTripTests.cpp
+++ b/Tests/StateRoundTripTests.cpp
@@ -1,0 +1,64 @@
+#include "../Source/AI/AIStateMapper.h"
+#include "../Source/Modules/AttenuverterModule.h"
+#include "../Source/PresetManager.h"
+#include <gtest/gtest.h>
+#include <juce_audio_processors/juce_audio_processors.h>
+#include <juce_core/juce_core.h>
+
+static int countAttenuverterNodes(juce::AudioProcessorGraph& graph) {
+    int count = 0;
+    for (auto* node : graph.getNodes()) {
+        if (dynamic_cast<AttenuverterModule*>(node->getProcessor()) != nullptr)
+            ++count;
+    }
+    return count;
+}
+
+TEST(StateRoundTripTests, PolyPadJSONRoundTripIsLossless) {
+    // Step 1: Load Poly Pad (index 6) into g1, capture its JSON
+    juce::AudioProcessorGraph g1;
+    ASSERT_TRUE(gsynth::PresetManager::loadPreset(6, g1)) << "Failed to load Poly Pad preset (index 6)";
+    juce::var J1 = gsynth::AIStateMapper::graphToJSON(g1);
+
+    int g1_nodes = g1.getNumNodes();
+    int g1_connections = (int)g1.getConnections().size();
+    EXPECT_GT(g1_nodes, 0) << "Poly Pad should have nodes";
+    EXPECT_GT(g1_connections, 0) << "Poly Pad should have connections";
+
+    // Step 2: Apply J1 to fresh g2, capture its JSON
+    juce::AudioProcessorGraph g2;
+    ASSERT_TRUE(gsynth::AIStateMapper::applyJSONToGraph(J1, g2, /*clearExisting=*/true))
+        << "applyJSONToGraph J1->g2 failed";
+    juce::var J2 = gsynth::AIStateMapper::graphToJSON(g2);
+
+    int g2_nodes = g2.getNumNodes();
+    int g2_connections = (int)g2.getConnections().size();
+
+    // Step 3: Apply J2 to fresh g3, capture its JSON
+    juce::AudioProcessorGraph g3;
+    ASSERT_TRUE(gsynth::AIStateMapper::applyJSONToGraph(J2, g3, /*clearExisting=*/true))
+        << "applyJSONToGraph J2->g3 failed";
+    juce::var J3 = gsynth::AIStateMapper::graphToJSON(g3);
+
+    int g3_nodes = g3.getNumNodes();
+    int g3_connections = (int)g3.getConnections().size();
+
+    // Same node and connection counts across all three graphs
+    EXPECT_EQ(g1_nodes, g2_nodes) << "g1 has " << g1_nodes << " nodes but g2 has " << g2_nodes;
+    EXPECT_EQ(g1_nodes, g3_nodes) << "g1 has " << g1_nodes << " nodes but g3 has " << g3_nodes;
+    EXPECT_EQ(g1_connections, g2_connections)
+        << "g1 has " << g1_connections << " connections but g2 has " << g2_connections;
+    EXPECT_EQ(g1_connections, g3_connections)
+        << "g1 has " << g1_connections << " connections but g3 has " << g3_connections;
+
+    // ZERO attenuverter nodes in g2 and g3 (Poly Pad has none — proves no silent promotion)
+    EXPECT_EQ(countAttenuverterNodes(g2), 0)
+        << "g2 unexpectedly has attenuverter nodes (silent poly-CV promotion detected)";
+    EXPECT_EQ(countAttenuverterNodes(g3), 0)
+        << "g3 unexpectedly has attenuverter nodes (silent poly-CV promotion detected)";
+
+    // Byte-identical fixpoint: J2 and J3 should produce the same JSON string
+    juce::String s2 = juce::JSON::toString(J2);
+    juce::String s3 = juce::JSON::toString(J3);
+    EXPECT_EQ(s2, s3) << "JSON is not a fixpoint: J2 != J3 (round-trip is not lossless)";
+}

--- a/Tests/UndoRedoTests.cpp
+++ b/Tests/UndoRedoTests.cpp
@@ -1,8 +1,11 @@
 #include "../Source/AI/AIStateMapper.h"
 #include "../Source/GravisynthUndoManager.h"
+#include "../Source/Modules/ADSRModule.h"
+#include "../Source/Modules/AttenuverterModule.h"
 #include "../Source/Modules/FilterModule.h"
 #include "../Source/Modules/OscillatorModule.h"
 #include "../Source/Modules/VCAModule.h"
+#include "../Source/PresetManager.h"
 #include <gtest/gtest.h>
 #include <juce_audio_processors/juce_audio_processors.h>
 
@@ -467,4 +470,127 @@ TEST_F(UndoRedoTest, RedoWithParameterValueInUnitInterval) {
     float valueAfterRedo = redoDriveParam->getNormalisableRange().convertFrom0to1(redoDriveParam->getValue());
     ASSERT_NEAR(valueAfterRedo, 1.0f, 0.001f)
         << "Parameter value should be 1.0 after redo, not 10.0 (double-converted)";
+}
+
+/**
+ * Test 12: PolyPad_RoutingSurvivesUndoRedo
+ *
+ * Verifies that the "Poly Pad" preset (index 6) connections survive a full
+ * undo/redo cycle modelled by the graphToJSON -> applyJSONToGraph round-trip
+ * (the same operation that GravisynthUndoManager::SnapshotAction performs on
+ * undo and redo).
+ *
+ * The following connections must survive:
+ *   (A) 8 direct poly-bus edges: Amp Env ch0-7 → VCA ch8-15
+ *       (per-voice amplitude envelope modulation)
+ *
+ * The env->osc Level CV wire (Amp Env ch0 → Oscillator ch12) was removed from
+ * the factory preset because that channel is shared across all voices and was
+ * coupling all voices to voice-0's envelope. The capability itself still works
+ * (see IntegrationTests::PolyPad_EnvToOscModulatesOscLevel).
+ *
+ * Additionally, the restored patch must NOT introduce any new AttenuverterModule
+ * nodes — these connections are direct poly-bus connections, not mod-matrix
+ * routings, and the serializer must preserve them as-is without substituting
+ * attenuverter chains.
+ *
+ * Strategy (mirrors GravisynthUndoManager behaviour):
+ *   1. Load Poly Pad (preset 6) into graph g.
+ *   2. Snapshot: J0 = graphToJSON(g).
+ *   3. Simulate "undo-apply-different-state": load preset 0 into g (clobbers Poly Pad).
+ *   4. Simulate "redo-restore-original-state": applyJSONToGraph(J0, g, clear=true, trusted=true).
+ *   5. Count the required connections; assert both groups are fully present.
+ *   6. Assert zero AttenuverterModule nodes were introduced for these paths.
+ */
+TEST_F(UndoRedoTest, PolyPad_RoutingSurvivesUndoRedo) {
+    // Step 1 — Load Poly Pad (preset 6) into graph
+    ASSERT_TRUE(gsynth::PresetManager::loadPreset(6, graph));
+
+    // Sanity: locate Amp Env (ADSR), Oscillator, and VCA by type
+    juce::AudioProcessorGraph::NodeID adsrID, oscID, vcaID;
+    for (auto* node : graph.getNodes()) {
+        auto* proc = node->getProcessor();
+        if (auto* mb = dynamic_cast<ADSRModule*>(proc)) {
+            // Preset 6 has one ADSR named "Amp Env"
+            if (mb->getName().contains("Amp Env") || mb->getName().contains("ADSR"))
+                adsrID = node->nodeID;
+        } else if (dynamic_cast<OscillatorModule*>(proc)) {
+            oscID = node->nodeID;
+        } else if (dynamic_cast<VCAModule*>(proc)) {
+            vcaID = node->nodeID;
+        }
+    }
+    ASSERT_NE(adsrID.uid, 0u) << "Poly Pad should have an Amp Env (ADSR) node";
+    ASSERT_NE(oscID.uid, 0u) << "Poly Pad should have an Oscillator node";
+    ASSERT_NE(vcaID.uid, 0u) << "Poly Pad should have a VCA node";
+
+    // Helper: count specific connections in the current graph
+    auto countConns = [&](juce::AudioProcessorGraph::NodeID srcID, int srcCh, juce::AudioProcessorGraph::NodeID dstID,
+                          int dstCh) -> int {
+        int count = 0;
+        for (const auto& conn : graph.getConnections()) {
+            if (conn.source.nodeID == srcID && conn.source.channelIndex == srcCh && conn.destination.nodeID == dstID &&
+                conn.destination.channelIndex == dstCh)
+                ++count;
+        }
+        return count;
+    };
+
+    // Verify the connections exist in the freshly loaded preset (pre-cycle baseline)
+    int envVcaConnsBaseline = 0;
+    for (int v = 0; v < 8; ++v)
+        envVcaConnsBaseline += countConns(adsrID, v, vcaID, 8 + v);
+
+    ASSERT_EQ(envVcaConnsBaseline, 8) << "Poly Pad baseline: expected 8 ADSR->VCA poly-bus connections";
+
+    // Step 2 — Snapshot the loaded Poly Pad state
+    juce::var J0 = gsynth::AIStateMapper::graphToJSON(graph);
+
+    // Step 3 — Overwrite with a completely different preset (simulates the
+    // modification that would be "undone")
+    ASSERT_TRUE(gsynth::PresetManager::loadPreset(0, graph)); // Default preset — no poly modules
+    EXPECT_EQ(countConns(adsrID, 0, vcaID, 8), 0)
+        << "After loading preset 0, original Poly Pad connections should be gone";
+
+    // Step 4 — Re-apply the Poly Pad snapshot (simulates undo/redo restore)
+    ASSERT_TRUE(gsynth::AIStateMapper::applyJSONToGraph(J0, graph, /*clearExisting=*/true, /*trusted=*/true))
+        << "applyJSONToGraph should succeed for a freshly-captured Poly Pad snapshot";
+
+    // Re-locate nodes by type after round-trip (node IDs may differ after clear+rebuild)
+    adsrID = vcaID = oscID = {};
+    for (auto* node : graph.getNodes()) {
+        auto* proc = node->getProcessor();
+        if (auto* mb = dynamic_cast<ADSRModule*>(proc)) {
+            if (mb->getName().contains("Amp Env") || mb->getName().contains("ADSR"))
+                adsrID = node->nodeID;
+        } else if (dynamic_cast<OscillatorModule*>(proc)) {
+            oscID = node->nodeID;
+        } else if (dynamic_cast<VCAModule*>(proc)) {
+            vcaID = node->nodeID;
+        }
+    }
+    ASSERT_NE(adsrID.uid, 0u) << "Post-roundtrip: Amp Env node should exist";
+    ASSERT_NE(oscID.uid, 0u) << "Post-roundtrip: Oscillator node should exist";
+    ASSERT_NE(vcaID.uid, 0u) << "Post-roundtrip: VCA node should exist";
+
+    // Step 5 — Verify all 8 ADSR->VCA poly-bus connections survived
+    int envVcaConnsAfter = 0;
+    for (int v = 0; v < 8; ++v)
+        envVcaConnsAfter += countConns(adsrID, v, vcaID, 8 + v);
+    EXPECT_EQ(envVcaConnsAfter, 8)
+        << "Post-undo/redo: expected 8 ADSR->VCA per-voice connections (ch0->ch8, ch1->ch9 ... ch7->ch15)";
+
+    // Step 6 — Assert NO AttenuverterModule nodes were introduced for these paths.
+    // Direct poly-bus connections must remain direct — serialization must not
+    // silently convert them to attenuverter-chain routings.
+    int attenuverterCount = 0;
+    for (auto* node : graph.getNodes()) {
+        if (dynamic_cast<AttenuverterModule*>(node->getProcessor()))
+            ++attenuverterCount;
+    }
+    EXPECT_EQ(attenuverterCount, 0) << "Post-undo/redo: Poly Pad should have ZERO AttenuverterModule nodes; "
+                                       "found "
+                                    << attenuverterCount
+                                    << " — direct poly connections were incorrectly "
+                                       "converted to attenuverter chains during serialization round-trip";
 }

--- a/docs/Module_Development_Guide.md
+++ b/docs/Module_Development_Guide.md
@@ -219,4 +219,22 @@ All new modules **must** have unit tests in the `Tests/` directory.
 
 New modules are automatically covered by E2E workflow tests in `Tests/E2EWorkflowTests.cpp`. The `DropAllModuleTypes_NoCrash` test drops every registered module type and verifies it creates a graph node without crashing. If you add a new module type, add its name string to the `moduleTypes` array in that test.
 
+## 7. Poly Module Channel Conventions
+
+If your module supports polyphonic operation, follow the standard channel layout so the logical-port API and GraphEditor can correctly draw collapsed poly-bus wires.
+
+**Rule:** In poly mode, voices occupy channels 0-7 (audio/pitch/gate) and the shared-CV block starts at channel 8. Declare `numOutputs >= highest CV input channel index you read`, to avoid JUCE `AudioProcessorGraph` buffer aliasing when `inputChan >= getTotalNumOutputChannels()`.
+
+For example, a poly oscillator that reads CV on ch8-12 must declare at least 13 output channels even if only channels 0-7 carry audio. Channels 8-12 become silent pass-through outputs that prevent JUCE from aliasing them with another node's output buffer.
+
+Override `mapInputChannel()` and `mapOutputChannel()` to return a `LogicalPort` for each raw channel, describing:
+- `visibleJackIndex` — which visible jack the wire should anchor to in the UI
+- `role` — `PortRole::Audio`, `PortRole::Pitch`, `PortRole::Gate`, `PortRole::ModCV`, etc.
+- `isPolyGroupHead` — `true` only for the lowest channel of a fan (raw == 0 for voice fans, raw == 8 for the first shared-CV channel)
+- `polyVoiceSpan` — `8` for the head of an 8-voice fan; `1` for all others
+
+Override `isAutoPromotableModTarget()` to return `false` when `polyParam->get()` is true, so that poly CV connections are kept as plain `DirectCV` routings rather than being auto-wrapped in attenuverters.
+
+See [docs/modules.md — Poly Channel Layout](modules.md#poly-channel-layout) for the full per-module channel table and [docs/modulation.md](modulation.md) for the routing model reference.
+
 By following this guide, you can contribute robust and high-quality audio modules to Gravisynth.

--- a/docs/modulation.md
+++ b/docs/modulation.md
@@ -1,0 +1,126 @@
+# Modulation System Reference
+
+This document describes the modulation architecture: how routing is modeled, how the engine derives it from the graph, the logical-port API used to draw collapsed poly-bus wires, and how the Poly Pad preset illustrates envelope modulation.
+
+---
+
+## Routing Kinds
+
+Every CV connection in the graph resolves to one of three routing kinds, defined in `AudioEngine.h`:
+
+```cpp
+enum class RoutingKind { AttenuverterChain, DirectCV, PolyBus };
+```
+
+| Kind | What it is | How it arises |
+|------|-----------|---------------|
+| `AttenuverterChain` | A mono source signal passes through an `AttenuverterModule` node before reaching the destination's CV input. This is the standard user-adjustable modulation path. | Created by `AudioEngine::addModRouting()`. The engine automatically inserts an `AttenuverterModule` between source and destination. Amount is set to 1.0 at creation. |
+| `DirectCV` | A source output connects directly into a destination's CV/ModCV input channel, with no intermediary attenuverter. | Any non-attenuverter connection into a mod-CV jack (e.g. env output 0 -> oscillator Level ch12). |
+| `PolyBus` | N per-voice `DirectCV` connections (one per voice) that share the same source module and destination visible jack. The engine collapses them into one logical bus. | Arises when the source's `mapOutputChannel()` and destination's `mapInputChannel()` both describe a poly fan (e.g. ADSR outputs 0-7 -> VCA inputs 8-15 in the Poly Pad). |
+
+---
+
+## `AudioEngine::getModulationRoutings()`
+
+```cpp
+std::vector<ModulationRouting> getModulationRoutings() const;
+```
+
+Returns a read-only snapshot of every active modulation routing derived from the `AudioProcessorGraph`. The struct is:
+
+```cpp
+struct ModulationRouting {
+    RoutingKind kind;
+    NodeID sourceNodeID;
+    int    sourceChannelIndex;  // raw graph channel
+    int    sourceVisibleJack;   // visible jack index on source
+    NodeID destNodeID;
+    int    destChannelIndex;    // raw graph channel
+    int    destVisibleJack;     // visible jack index on destination
+    NodeID attenuverterNodeID;  // valid only for AttenuverterChain
+    int    voiceCount;          // 1 for mono routings, N for PolyBus
+    float  amount;              // attenuverter amount or 1.0 for direct
+    bool   isBypassed;
+    bool   hasSource;
+    bool   hasDest;
+    float  modSignalValue;      // last mid-block sample (UI display)
+    float  modSignalPeak;       // peak over last block (UI display)
+    PortRole role;
+};
+```
+
+**This is a derived, read-only view — it is never serialized.** The graph connections and JSON preset remain the single source of truth. Because `getModulationRoutings()` is re-derived from the live graph each time it is called, undo/redo and round-trip preset load/save are unaffected by this model.
+
+`getActiveModRoutings()` and `getModulationDisplayInfo()` are thin adapters over `getModulationRoutings()` and are retained for legacy call sites.
+
+---
+
+## Logical-Port API
+
+To map raw `AudioProcessorGraph` channel indices onto visible UI jacks, `ModuleBase` provides:
+
+```cpp
+enum class PortRole { Audio, ModCV, Pitch, Gate, Midi, Other };
+
+struct LogicalPort {
+    int  visibleJackIndex;  // which visible jack a wire anchors to (0..getVisible*PortCount()-1)
+    PortRole role;
+    bool isPolyGroupHead;   // true only for the lowest raw channel of a poly fan
+    int  polyVoiceSpan;     // 1 = mono; N = this is the head of an N-voice fan
+};
+
+virtual LogicalPort mapInputChannel(int rawChannel) const;
+virtual LogicalPort mapOutputChannel(int rawChannel) const;
+```
+
+Poly-capable modules override these to describe fans. The default base implementation clamps any out-of-range channel to the last visible jack and marks `isPolyGroupHead` based on whether `rawChannel < getVisible*PortCount()`.
+
+### How GraphEditor uses the logical-port API
+
+1. For every connection in the graph, GraphEditor calls `mapOutputChannel` on the source and `mapInputChannel` on the destination to get `LogicalPort` values.
+2. The wire is anchored to `sourceVisibleJack` and `destVisibleJack` rather than the raw channel number. This collapses N per-voice wires onto a single visible jack.
+3. If the engine classifies the routing as `PolyBus`, GraphEditor draws only one wire and overlays an "xN" voice-count badge on it (e.g. "x8").
+4. Mono `DirectCV` wires are drawn without a badge.
+5. `AttenuverterChain` wires render a draggable midpoint knob for depth control.
+
+---
+
+## `isAutoPromotableModTarget`
+
+```cpp
+virtual bool isAutoPromotableModTarget(int dstChannel) const;
+```
+
+The default implementation returns `true` if `dstChannel` appears in `getModulationTargets()`. Poly-capable modules override it to return `false` when `poly == true`:
+
+```cpp
+bool isAutoPromotableModTarget(int dstChannel) const override {
+    if (polyParam->get()) return false;
+    return ModuleBase::isAutoPromotableModTarget(dstChannel);
+}
+```
+
+**Why this matters:** AIStateMapper uses `isAutoPromotableModTarget` to decide whether to auto-wrap a connection in an `AttenuverterModule` when applying JSON patches. When a module is in poly mode, direct CV connections into the poly shared-CV block must stay as plain `DirectCV` routings rather than being auto-wrapped. Returning `false` prevents the auto-promotion.
+
+---
+
+## How Envelope Modulation Works in the Poly Pad
+
+The Poly Pad preset (preset index 6) demonstrates two distinct modulation kinds for the same Amp Env module:
+
+### Amp Env -> VCA (PolyBus)
+
+The Amp Env module runs in poly mode (8 outputs, one per voice). The VCA runs in poly mode (8 CV inputs at channels 8-15, one per voice). The preset connects:
+
+- ADSR output ch0 -> VCA input ch8  (voice 0 envelope -> voice 0 gain CV)
+- ADSR output ch1 -> VCA input ch9
+- ...
+- ADSR output ch7 -> VCA input ch15
+
+`AudioEngine::getModulationRoutings()` sees 8 `DirectCV` connections that share the same source module (Amp Env) and destination visible jack (VCA CV jack, index 1). It classifies them as a single `PolyBus` with `voiceCount = 8`. GraphEditor draws one wire with an "x8" badge. Per-voice amplitude is fully independent: when voice 3 releases, only voice 3's envelope falls.
+
+### Amp Env -> Oscillator Level (DirectCV)
+
+The preset also connects ADSR output ch0 (voice 0's envelope) directly to Oscillator input ch12 (the shared Level CV). This is a `DirectCV` routing: a single connection from one raw channel to one raw channel, without an attenuverter, and without a poly fan. `getModulationRoutings()` returns it as `DirectCV` with `voiceCount = 1`. GraphEditor draws it as a normal single wire without a badge. All 8 oscillator voices share the same level modulation (the voice-0 envelope signal).
+
+This combination — PolyBus for per-voice gate control, DirectCV for a shared timbre parameter — is a common pattern when building poly patches.

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -5,30 +5,47 @@ Detailed specifications for Gravisynth's primary synthesis modules.
 ## Oscillator Module
 - **Waveforms**: Sine, Square, Saw, Triangle.
 - **Features**: 
-    - PolyBLEP anti-aliasing on Square and Saw.
-    - MIDI-to-Frequency tracking.
+    - PolyBLEP anti-aliasing on Square and Saw; PolyBLAMP on Triangle.
+    - Waveform crossfade (64-sample fade on waveform changes).
+    - MIDI-to-Frequency tracking with unison and detune support.
     - Integrated visual buffer for real-time waveform display.
+- **Poly mode**: 8 voices driven by pitch CV (Hz). See [Poly Channel Layout](#poly-channel-layout) for channel details.
+- **Buffer aliasing note**: Declared with 14 output channels so JUCE's `AudioProcessorGraph` correctly copies shared mod-CV input channels (8-13) when they fan out to multiple downstream nodes. Channels 8-13 of the output are silent pass-throughs.
 
 ## Filter Module
-- **Type**: Resonant Low-Pass.
-- **Parameters**: Cutoff (Freq), Resonance (Q).
-- **Quality**: Zero-delay feedback (ZDF) style filtering for analog-like response.
+- **Types**: 7 filter types — `LPF24`, `LPF12`, `HPF24`, `HPF12`, `BPF24`, `BPF12`, `Notch`.
+- **Implementation**: `LPF24/12`, `HPF24/12`, `BPF24/12` use `juce::dsp::LadderFilter`; `Notch` uses `juce::dsp::StateVariableTPTFilter` (notch computed as input minus bandpass).
+- **Parameters**: Cutoff (20–20000 Hz), Resonance (0–1), Drive (1–10), Filter Type (choice), Poly (bool).
+- **CV inputs (mono mode)**: Cutoff = ch1, Resonance = ch2, Drive = ch3.
+- **CV inputs (poly mode)**: Cutoff = ch8, Resonance = ch9, Drive = ch10.
+- **Poly mode**: 8 per-voice audio inputs (ch0-7) + 3 shared CV inputs (ch8-10). Shared CV is computed once per block and applied to all active voices.
+- **`isAutoPromotableModTarget`**: Returns `false` in poly mode (poly CV connections stay plain `DirectCV`, not auto-wrapped in attenuverters).
 
 ## ADSR (Envelope) Module
 - **Stages**: Attack, Decay, Sustain, Release.
-- **Output**: Generates a mono control signal (0.0 to 1.0).
-- **Uses**: Modulation of VCA gain or Filter cutoff.
+- **Mono output**: Generates a single control signal (0.0 to 1.0) on channel 0, triggered by MIDI.
+- **Poly mode**: 8 gate CV inputs (ch0-7) drive 8 independent ADSR instances; outputs 8 per-voice envelopes (ch0-7).
+- **Uses**: Modulation of VCA gain, Filter cutoff, or Oscillator Level.
 
 ## VCA (Amplifier) Module
 - **Inputs**: 
-    - Input 0: Audio.
-    - Input 1: CV (Modulation).
-- **Features**: Parameter smoothing for "click-free" gain changes.
+    - Mono mode: Audio (ch0), CV (ch1).
+    - Poly mode: Per-voice audio ch0-7, per-voice envelope/CV ch8-15.
+- **Poly summing**: In poly mode, multiplies each voice's audio by its corresponding envelope CV, then sums all 8 voices to stereo (ch0/ch1) with `tanh` soft saturation and 1/8 normalization.
+- **Features**: Parameter smoothing for click-free gain changes.
 
 ## Poly MIDI Module
 - **Capacity**: 8 simultaneous voices.
 - **Allocation**: Least Recently Used (LRU) algorithm.
-- **Outputs**: Provides 8 separate Pitch and Gate channels for polyphonic routing.
+- **Outputs**: 16 total channels — ch0-7 = per-voice pitch (Hz), ch8-15 = per-voice gate (0/1).
+- **Visible ports**: 1 output jack ("Poly Out") representing the entire poly bus.
+
+## Voice Mixer Module
+- **Purpose**: Explicit 8-to-stereo voice summing with level control and soft saturation. An alternative to VCA's internal poly summing for patches that need a separate mix stage.
+- **Inputs**: ch0-7 (up to 8 voice signals).
+- **Outputs**: ch0 (Left), ch1 (Right) — stereo copy of the mono sum.
+- **Processing**: Sums all 8 input channels, scales by Level parameter (0–1, default 0.125), then applies `std::tanh` soft saturation for gentle clip protection. Level smoothed over 10 ms to prevent clicks.
+- **Parameter**: `Level` (0.0–1.0, default 0.125).
 
 ## MIDI Keyboard Module
 - **Purpose**: Provides an interactive on-screen keyboard for MIDI input.
@@ -38,21 +55,70 @@ Detailed specifications for Gravisynth's primary synthesis modules.
     - **MIDI Output**: Generates standard MIDI messages for driving oscillators or other MIDI-capable modules.
 
 ## Attenuverter Module (Hidden)
-- **Purpose**: Invisible gain/polarity stage automatically inserted on every CV connection.
-- **Parameters**: `Amount` — ranges from -1.0 (full inversion) to +1.0 (full depth), default 1.0.
+- **Purpose**: Invisible gain/polarity stage automatically inserted on every mono CV connection routed via the mod matrix.
+- **Parameters**: `Amount` — ranges from -1.0 (full inversion) to +1.0 (full depth), **constructor default 0.0**.
+    - `AudioEngine::addModRouting()` immediately sets Amount to 1.0 when a connection is created through the mod matrix.
+    - `AudioEngine::addEmptyModRouting()` leaves Amount at 0.0 (empty routing placeholder).
 - **Interaction**: Controlled via the **Smart Cable knob** on the graph or the **Mod Matrix** slider.
 - **Serialization**: Saved and restored as part of every preset alongside the connection it belongs to.
 
 ---
 
+## Poly Channel Layout
+
+This table shows the raw `AudioProcessorGraph` channel assignments for each poly-capable module. See [docs/modulation.md](modulation.md) for how `getModulationRoutings()` and the logical-port API collapse these into visible wires.
+
+### Rule for new poly modules
+
+In poly mode, voices occupy channels 0-7 (audio/pitch/gate) and the shared-CV block starts at channel 8. **Declare `numOutputs >= highest CV input channel index you read**, to avoid JUCE `AudioProcessorGraph` buffer aliasing when `inputChan >= getTotalNumOutputChannels()`.
+
+| Module | Channel | Direction | Content |
+|--------|---------|-----------|---------|
+| **PolyMidi** | ch0-7 | Out | Pitch CV per voice (Hz) |
+| **PolyMidi** | ch8-15 | Out | Gate CV per voice (0/1) |
+| **Oscillator (poly)** | ch0-7 | In | Per-voice pitch CV (Hz) |
+| **Oscillator (poly)** | ch8 | In | Shared Waveform CV |
+| **Oscillator (poly)** | ch9 | In | Shared Octave CV |
+| **Oscillator (poly)** | ch10 | In | Shared Coarse CV |
+| **Oscillator (poly)** | ch11 | In | Shared Fine CV |
+| **Oscillator (poly)** | ch12 | In | Shared Level CV |
+| **Oscillator (poly)** | ch0-7 | Out | Per-voice audio |
+| **Oscillator (poly)** | ch8-13 | Out | Silent pass-throughs (prevent buffer aliasing) |
+| **Oscillator (mono)** | ch0 | In/Out | Pitch CV in / Audio out (shared channel, CV saved before clear) |
+| **Oscillator (mono)** | ch1 | In | Waveform CV |
+| **Oscillator (mono)** | ch2 | In | Octave CV |
+| **Oscillator (mono)** | ch3 | In | Coarse CV |
+| **Oscillator (mono)** | ch4 | In | Fine CV |
+| **Oscillator (mono)** | ch5 | In | Level CV |
+| **Filter (poly)** | ch0-7 | In | Per-voice audio |
+| **Filter (poly)** | ch8 | In | Shared Cutoff CV |
+| **Filter (poly)** | ch9 | In | Shared Resonance CV |
+| **Filter (poly)** | ch10 | In | Shared Drive CV |
+| **Filter (poly)** | ch0-7 | Out | Filtered audio per voice |
+| **Filter (mono)** | ch0 | In/Out | Audio in / filtered audio out |
+| **Filter (mono)** | ch1 | In | Cutoff CV |
+| **Filter (mono)** | ch2 | In | Resonance CV |
+| **Filter (mono)** | ch3 | In | Drive CV |
+| **VCA (poly)** | ch0-7 | In | Per-voice audio |
+| **VCA (poly)** | ch8-15 | In | Per-voice envelope/CV |
+| **VCA (poly)** | ch0-1 | Out | Stereo sum (L/R) |
+| **ADSR (poly)** | ch0-7 | In | Per-voice gate CV |
+| **ADSR (poly)** | ch0-7 | Out | Per-voice envelope (0–1) |
+
+---
+
 ## Modulation System
 
-Gravisynth uses a **hidden Attenuverter architecture** for modulation depth control, inspired by Serum's mod matrix.
+Gravisynth uses a **hidden Attenuverter architecture** for modulation depth control, inspired by Serum's mod matrix. The engine derives a first-class `ModulationRouting` model from the graph at runtime. See [docs/modulation.md](modulation.md) for the full reference.
 
 ### Smart Cables
-- Every CV cable renders a circular knob at the midpoint of the bezier curve.
+- Every mono CV cable (AttenuverterChain routing) renders a circular knob at the midpoint of the bezier curve.
 - **Drag up/down** to sweep depth from -100% to +100%.
 - **Double-click** to instantly delete the connection.
+
+### Poly Bus Wires
+- When N per-voice `DirectCV` connections share the same source module and destination visible jack, the GraphEditor collapses them into a single wire with an "xN" badge (e.g. "x8").
+- These `PolyBus` wires have no midpoint knob because there is no attenuverter in the path.
 
 ### Mod Matrix Panel
 - Sits on the right edge of the Graph Editor (toggleable).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,17 +1,17 @@
 # Testing Guide
 
-All tests use GoogleTest and run headless (no audio device, no GUI window). ~310 tests across 39 suites.
+All tests use GoogleTest and run headless (no audio device, no GUI window). ~371 tests across ~53 suites.
 
 ```bash
-# Run all tests
-cmake -B build -DENABLE_TESTS=ON
+# Run all tests (ENABLE_TESTS defaults OFF — must be passed explicitly)
+cmake -S . -B build -DENABLE_TESTS=ON
 cmake --build build --target GravisynthTests
 ./build/Tests/GravisynthTests
 
 # Run a specific suite
 ./build/Tests/GravisynthTests --gtest_filter="E2EWorkflow*"
 
-# Check coverage (threshold: 80%)
+# Check coverage (threshold: 85%)
 bash scripts/coverage.sh
 ```
 
@@ -116,4 +116,4 @@ The `AudioRenderingTests` suite compares rendered audio against "golden" referen
 
 ## CI
 
-Tests run automatically on every PR across Ubuntu, macOS, and Windows. Coverage is enforced at 80% on the Ubuntu Debug build. See [CLAUDE.md](../CLAUDE.md) for full CI details.
+Tests run automatically on every PR across Ubuntu, macOS, and Windows. Coverage is enforced at 85% on the Ubuntu Debug build. See [CLAUDE.md](../CLAUDE.md) for full CI details.


### PR DESCRIPTION
## Summary

Adds visualization for **polyphonic modulation routing** (per-voice connections collapse into one labelled "poly bus" wire) and a real, working **env→oscillator** modulation, built on a new read-only `ModulationRouting` model + a logical-port API. Also fixes a **multi-second UI freeze** that occurred on startup and on every preset switch.

## Changes

- **Routing model:** first-class, read-only `ModulationRouting` in `AudioEngine` (`AttenuverterChain` / `DirectCV` / `PolyBus`), derived from the graph and never serialized; `getActiveModRoutings()` / `getModulationDisplayInfo()` are now thin adapters over it (one source of truth for renderer, knob rings, mod matrix).
- **Logical-port API** on `ModuleBase` (`PortRole`/`LogicalPort`, `mapInputChannel`/`mapOutputChannel`) → GraphEditor draws collapsed poly-bus wires for Amp Env→VCA, PolyMIDI→Osc (pitch) and PolyMIDI→ADSR (gate), which were previously invisible; wires anchor to real visible jacks.
- **Poly oscillator** now consumes its advertised shared mod-CV channels (Waveform/Octave/Coarse/Fine/Level); zero-CV output is bit-identical; declares 14 output channels to avoid a `juce::AudioProcessorGraph` buffer-aliasing hazard. `isAutoPromotableModTarget` guard keeps the JSON/undo round-trip lossless.
- **UI-freeze fix:** the AI panel registered as the global `juce::Logger` and piped every `writeToLog` into a `TextEditor` debug console that re-shaped its whole text on each insert (O(n²)), while `AIStateMapper` logged once per parameter on every preset load. Removed the spam and made the console coalesced + length-bounded.
- **Perf/other:** AI model discovery is non-blocking (was a 120s synchronous timeout); `ModuleComponent` image-buffering + gated repaints; removed `std::cout` from realtime callbacks.

## Test Plan

- [x] All existing tests pass — **380 tests, Debug and Release**
- [x] New tests added (routing model, logical ports, poly-bus collapse, env→osc DSP, JSON round-trip canary, performance budgets, all-presets finite-audio smoke test, `PresetLoadDoesNotSpamLogger` regression guard)
- [x] Tested locally (build + run; startup and preset-switch freeze verified gone)
- [x] Documentation updated (`docs/modulation.md`, poly channel-layout reference, logging/perf gotchas in project guidance docs)

## Screenshots

N/A
