### PR TITLE
ci: fix Windows post-merge build; align Build-and-Release with PR CI

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -53,28 +53,37 @@ jobs:
       run: |
         brew install cmake ninja
 
+    # Windows MSVC environment — required so the Ninja generator can find cl.exe.
+    # We use Ninja on every OS so this workflow's build matches the PR CI
+    # (ci.yml) exactly. The default Visual Studio generator bakes the VS version
+    # into JUCE's cached FetchContent sub-build, which breaks when GitHub bumps
+    # the windows-latest image (e.g. VS 2022 -> VS 2026); Ninja's generator
+    # string is version-agnostic, so the cache survives image upgrades.
+    - name: Setup MSVC
+      if: runner.os == 'Windows'
+      uses: ilammy/msvc-dev-cmd@v1
+
     # Cache FetchContent Dependencies
     - name: Cache FetchContent Dependencies
       uses: actions/cache@v4
       with:
         path: build/_deps
-        key: ${{ runner.os }}-release-deps-${{ hashFiles('CMakeLists.txt', 'Tests/CMakeLists.txt') }}
+        # The "-ninja" tag ties the cache to the generator so the stale
+        # Visual-Studio-generator sub-build cache (pinned to an old VS version)
+        # is never restored after this workflow switched to Ninja.
+        key: ${{ runner.os }}-release-deps-ninja-${{ hashFiles('CMakeLists.txt', 'Tests/CMakeLists.txt') }}
         restore-keys: |
-          ${{ runner.os }}-release-deps-
+          ${{ runner.os }}-release-deps-ninja-
 
-    # Configure CMake
+    # Configure CMake — Ninja on every OS so this matches the PR CI build path
+    # (see the "Setup MSVC" note above for why Ninja and not the VS generator).
     - name: Configure CMake
       shell: bash
-      run: |
-        if [ "$RUNNER_OS" == "Windows" ]; then
-          cmake -B build -DCMAKE_BUILD_TYPE=Release
-        else
-          cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release
-        fi
+      run: cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release
 
-    # Build
+    # Build (Ninja is single-config; the build type comes from configure)
     - name: Build
-      run: cmake --build build --config Release
+      run: cmake --build build
 
     # Package Linux
     - name: Package Linux Artifact
@@ -124,7 +133,10 @@ jobs:
   release:
     name: Tag and Release
     needs: [build]
-    if: always() && !contains(needs.build.result, 'failure')
+    # Only tag + release on push to main. workflow_dispatch is therefore a
+    # build-only dry-run, safe to trigger on a branch to validate the matrix
+    # (incl. the Windows build) before merging.
+    if: always() && !contains(needs.build.result, 'failure') && github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -37,7 +37,7 @@ jobs:
             artifact_name: Gravisynth-Windows-x64
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     # Linux Dependencies
     - name: Install Linux Dependencies
@@ -65,7 +65,7 @@ jobs:
 
     # Cache FetchContent Dependencies
     - name: Cache FetchContent Dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: build/_deps
         # The "-ninja" tag ties the cache to the generator so the stale
@@ -124,7 +124,7 @@ jobs:
 
     # Upload Artifact
     - name: Upload Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ matrix.artifact_name }}
         path: artifact/
@@ -139,7 +139,7 @@ jobs:
     if: always() && !contains(needs.build.result, 'failure') && github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -153,7 +153,7 @@ jobs:
           fetch_all_tags: true
 
       - name: Download All Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
           merge-multiple: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,13 +11,14 @@ on:
       - 'Tests/CMakeLists.txt'
       - 'scripts/**'
       - '.github/workflows/ci.yml'
+      - '.github/workflows/build-artifacts.yml'
 
 jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Install clang-format
       run: sudo apt-get update && sudo apt-get install -y clang-format
     - name: Check Formatting
@@ -28,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Install Dependencies
       uses: awalsh128/cache-apt-pkgs-action@latest
@@ -37,7 +38,7 @@ jobs:
         version: 1.0
 
     - name: Cache FetchContent Dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: build/_deps
         key: ${{ runner.os }}-deps-${{ hashFiles('CMakeLists.txt', 'Tests/CMakeLists.txt') }}
@@ -45,7 +46,7 @@ jobs:
           ${{ runner.os }}-deps-
 
     - name: Cache ccache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.ccache
         key: ${{ runner.os }}-ccache-${{ github.sha }}
@@ -88,7 +89,7 @@ jobs:
 
     - name: Upload Coverage Artifact (Optional)
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: coverage-report
         path: |
@@ -101,7 +102,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Install Dependencies
       uses: awalsh128/cache-apt-pkgs-action@latest
@@ -110,7 +111,7 @@ jobs:
         version: 1.0
 
     - name: Cache FetchContent Dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: build/_deps
         key: ${{ runner.os }}-deps-${{ hashFiles('CMakeLists.txt', 'Tests/CMakeLists.txt') }}
@@ -141,13 +142,13 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Install Dependencies
       run: brew install cmake ninja ccache
 
     - name: Cache FetchContent Dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: build/_deps
         key: ${{ runner.os }}-deps-${{ hashFiles('CMakeLists.txt', 'Tests/CMakeLists.txt') }}
@@ -155,7 +156,7 @@ jobs:
           ${{ runner.os }}-deps-
 
     - name: Cache ccache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/Library/Caches/ccache
         key: ${{ runner.os }}-ccache-${{ github.sha }}
@@ -190,10 +191,10 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Cache FetchContent Dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: build/_deps
         key: ${{ runner.os }}-deps-${{ hashFiles('CMakeLists.txt', 'Tests/CMakeLists.txt') }}
@@ -201,7 +202,7 @@ jobs:
           ${{ runner.os }}-deps-
 
     - name: Cache ccache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: C:\Users\runneradmin\AppData\Local\ccache
         key: ${{ runner.os }}-ccache-${{ github.sha }}


### PR DESCRIPTION
## Summary

Fixes the Windows build failure in the post-merge **Build and Release** workflow (`build-artifacts.yml`) that broke after #109 merged, and closes the gap that let it pass PR CI yet fail after merge.

**Root cause:** post-merge built Windows with the *default Visual Studio generator*, while PR CI (`ci.yml`) builds with **Ninja**. The VS generator bakes the VS version into JUCE's cached FetchContent sub-build, so when GitHub rolled `windows-latest` to **VS 18 2026** the restored cache (pinned to **VS 17 2022**) failed `Configure CMake` with a generator mismatch. PR CI never exercised that path, so the PR went green and the break only surfaced post-merge.

## Changes

- Use **Ninja on every OS** (matches the PR CI build path) and add `ilammy/msvc-dev-cmd` so Ninja finds `cl.exe` on Windows. Ninja's generator string is version-agnostic, so the deps cache survives runner-image upgrades and this failure class cannot recur.
- Tag the FetchContent cache key `-ninja-` so the poisoned VS-generator cache is abandoned, not restored.
- Gate the `release` job to `push` events only — so `workflow_dispatch` is a build-only dry-run that validates the full matrix (incl. Windows) on a branch **before** merge.

## Test Plan

- [x] All existing tests pass — unchanged (no source/test changes)
- [x] New tests added for new functionality — N/A (CI-config-only change)
- [x] Tested locally (build + run) — validated via a `workflow_dispatch` **dry-run on this branch** (release job skipped); confirms the Windows/macOS/Linux matrix builds with the new Ninja config
- [x] Documentation updated — N/A (no code/dir/dep/env changes; CI behaviour documented inline in the workflow)

## Screenshots

N/A
