### PR TITLE
docs: slim CLAUDE.md to an orientation layer; migrate detail into docs/

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,175 +1,58 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Guidance for Claude Code (claude.ai/code) in this repository. Keep this file **lean** — it is the orientation layer (commands, conventions, critical traps). Detailed reference lives in `docs/` (map below); when you change behavior, update the relevant doc, not this file.
 
-## Project Overview
+## Project
 
-This is a **modular synthesizer** application built with JUCE and C++20, featuring a node-based graph editor for sound design. The application allows users to create complex sounds by connecting audio modules in a visual patching environment.
+Modular synthesizer (JUCE, C++20) with a node-based graph editor for sound design — connect audio/CV modules in a visual patching environment. Two CMake targets:
 
-## Architecture
+- **GravisynthCore** — the library: all audio-processing modules + core logic. Headless-testable (no audio device, no GUI).
+- **Gravisynth** — the JUCE GUI application built on top of the core (GraphEditor, ModuleComponent, chrome).
 
-The project follows a modular architecture with:
+## Commands
 
-1. **Core Library (`GravisynthCore`)**: Contains all audio processing modules and core logic
-2. **Application Layer (`Gravisynth`)**: GUI application built on JUCE that uses the core library
-3. **UI Components**: Graph editor and module components for visual patching
+```bash
+# Build
+cmake -S . -B build && cmake --build build
 
-### Key Components
+# Test  (ENABLE_TESTS defaults OFF — must opt in)
+cmake -S . -B build -DENABLE_TESTS=ON
+cmake --build build --target GravisynthTests
+./build/Tests/GravisynthTests
+./build/Tests/GravisynthTests --gtest_filter="E2EWorkflow*"   # E2E only
 
-- **ModuleBase**: Abstract base class for all audio modules with `ModuleType` enum, `ModulationTarget` metadata, `VisualBuffer` support, logical-port API (`mapInputChannel`/`mapOutputChannel`, `PortRole`, `LogicalPort`), and `isAutoPromotableModTarget` guard that prevents poly-mode CV inputs from being auto-wrapped in attenuverters. **Bypass/mute contract** (every `processBlock` MUST honor it, kept uniform across all modules): `isBypassed()` → **dry pass-through** — return early WITHOUT touching audio channels (clear only CV channels ≥2 so mod CV doesn't leak as audio, mirroring Filter/Distortion); `isMuted()` → **silence** — `buffer.clear()` then return. Use two separate branches, never `if (isBypassed() || isMuted()) buffer.clear()` (that mutes on bypass instead of passing the signal through)
-- **AudioEngine**: Manages audio device I/O, the audio processor graph, and modulation matrix routing; exposes `getModulationRoutings()` — a read-only derived view (`RoutingKind`: AttenuverterChain / DirectCV / PolyBus) that is never serialized; `getActiveModRoutings()` and `getModulationDisplayInfo()` are thin adapters over it
-- **GraphEditor**: Visual editor with zoom/pan and drag-to-connect; draws poly-bus wires (collapsed N-voice `DirectCV` connections) with an "xN" badge and anchors all wires to visible jacks via the logical-port API; snaps module positions to the 8 px grid on drag-release and resolves overlaps via spiral search on every drop/drag; exposes `autoArrange()` (Cmd+L / "Auto Arrange" toolbar button) which topologically layers modules by signal-flow depth in one undo step
-- **LayoutUtil** (`Source/UI/LayoutUtil.h/.cpp`): Stateless layout helpers — `snap`, `intersectsAny`, `findFreeSlot` (expanding-square spiral search), `computeAutoArrange` (longest-path topological layering); no JUCE GUI deps, fully headless-testable
-- **ModuleComponent**: Auto-UI generation from module parameters with type-safe layout switching via `ModuleType` enum; modulation rings read `getModulationRoutings()`
-- **AttenuverterModule**: Intermediary module for modulation routing with bypass and CV amount control; exposes `lastOutputPeak`/`lastModValue` atomics for UI visualization; constructor default Amount = 0.0 (set to 1.0 by `addModRouting`, left at 0.0 by `addEmptyModRouting`)
-- **Port Labels**: Virtual `getInputPortLabel()`/`getOutputPortLabel()` on ModuleBase, overridden per-module for descriptive port names in the UI
-- **GravisynthUndoManager**: Snapshot-based undo/redo system wrapping `juce::UndoManager`, captures full graph state on every change
-- **AI Integration** (`Source/AI/`): AIIntegrationService orchestrates LLM-powered features via OllamaProvider; AIStateMapper translates graph state for AI context
-- **GravisynthLookAndFeel** (`Source/UI/Theme/GravisynthLookAndFeel.h/.cpp`): Central `LookAndFeel_V4` subclass that owns all stock-widget re-skins (ColourId mappings from theme tokens) and exposes public treatment helper draw methods (`drawModulePanel`, `drawConnectionWire`, `drawModulationRing`, `fillThemedBackground`) so module cards, wires, and rings all honor the active theme's treatment style. Holds a copy of the active `Theme` updated via `applyTheme()`. Owned by `GravisynthApplication` and installed as `Desktop::setDefaultLookAndFeel`.
-- **ThemeManager** (`Source/UI/Theme/ThemeManager.h/.cpp`): Theme registry + active selection + JSON user-theme loader + persistence via the shared `ApplicationProperties` (key `"themeId"`). Extends `juce::ChangeBroadcaster` so `MainComponent` (a `ChangeListener`) can trigger the single re-skin+repaint pass on every switch. Built-ins registered first; user `*.gtheme.json` files loaded from the user themes folder at startup and on demand.
+# Coverage  (threshold 85%)
+bash scripts/coverage.sh
 
-### Audio Modules
+# Git hooks  (run once per clone — NOT auto-installed)
+bash scripts/install-hooks.sh   # pre-commit: clang-format lint;  pre-push: lint + Release build + tests
+```
 
-- Oscillator: Waveform generator (Sine, Saw, Square, Triangle); poly mode consumes shared mod-CV on ch8=Waveform, 9=Octave, 10=Coarse, 11=Fine, 12=Level; declared with 14 outputs to prevent JUCE graph buffer aliasing
-- Filter: Multi-mode filter with 7 types (LPF24, LPF12, HPF24, HPF12, BPF24, BPF12, Notch), cutoff/resonance control, and frequency response visualizer
-- VCA: Voltage Controlled Amplifier; poly mode sums 8 voices with per-voice envelope CV
-- ADSR: Envelope generator for amplitude/filter modulation; poly mode drives 8 per-voice ADSRs from gate CV
-- LFO: Low Frequency Oscillator for modulation
-- Sequencer: Step sequencer with per-step pitch control
-- MIDI Keyboard: Interactive on-screen keyboard for MIDI input
-- FX Modules: Delay, Distortion, Reverb, Chorus, Phaser, Compressor, Flanger, Limiter
-- Preset System: Factory presets with categorized organization
-- Poly MIDI: Polyphonic MIDI input handling (ch0-7=pitch Hz, ch8-15=gate); `voiceMaskAtomic_` (`std::atomic<uint8_t>`) written end-of-processBlock — read by `AudioEngine::getDisplayVoiceCount()` via `std::popcount` without locks
-- Poly Sequencer: Polyphonic step sequencer
-- Voice Mixer: 8-to-stereo mixer with tanh soft saturation and Level control; alternative to VCA's internal poly summing
-
-## Build System
-
-The project uses CMake with:
-- JUCE framework (fetched automatically via FetchContent)
-- GoogleTest for unit testing
-- Code coverage support (enabled via `ENABLE_COVERAGE` option)
-- `JUCE_WEB_BROWSER=0` — WebBrowserComponent is unused; disabling removes WebKit/libsoup deps on Linux
+See [`docs/testing.md`](docs/testing.md) for the full build/test/CI/hooks reference.
 
 ## Planning Rules
 
 Every implementation plan **must** include:
-1. A **Tests** section — list new test cases, test file, and what each test verifies
-2. A **Docs Updates** section — list which docs files need updating (testing.md, CLAUDE.md, etc.)
 
-## Development Commands
+1. A **Tests** section — list new test cases, the test file, and what each verifies.
+2. A **Docs Updates** section — list which docs (`docs/testing.md`, `CLAUDE.md`, etc.) need updating.
 
-### Build
-```bash
-cmake -S . -B build
-cmake --build build
-```
+## Critical invariants (break these and you ship bugs)
 
-### Run Tests
-```bash
-# ENABLE_TESTS defaults OFF — must configure with it explicitly
-cmake -S . -B build -DENABLE_TESTS=ON
-cmake --build build --target GravisynthTests
-./build/Tests/GravisynthTests
-# Run only E2E workflow tests:
-./build/Tests/GravisynthTests --gtest_filter="E2EWorkflow*"
-```
+- **Bypass/mute contract** — in every signal-processing `processBlock`, use **two separate branches**: `isBypassed()` → dry pass-through (return early WITHOUT touching audio channels; clear only CV channels ≥2 so mod CV doesn't leak as audio); `isMuted()` → `buffer.clear()` then return. Never `if (isBypassed() || isMuted()) buffer.clear()` — that mutes on bypass instead of passing the signal through. **Exception:** pure source modules with no audio input (Oscillator, Poly MIDI) clear on bypass — no dry signal to pass. → [`docs/architecture.md`](docs/architecture.md)
+- **No high-frequency logging** — AIChatComponent registers a global `juce::Logger` (Debug builds only) that pipes `writeToLog` into a UI-thread console. Never add per-sample / per-frame / per-parameter / per-connection logs (one caused a multi-second freeze; guarded by `AIStateMapperTest.PresetLoadDoesNotSpamLogger`). → [`docs/AI_Engine.md`](docs/AI_Engine.md)
+- **No unconditional per-tick repaint** — `ModuleComponent` is `setBufferedToImage(true)` with a gated 15 Hz timer; the 30 Hz GraphEditor animation composites cached images. A theme switch is exactly one re-skin pass. → [`docs/layout.md`](docs/layout.md)
+- **Themes don't swap fonts** — all built-ins share Inter + JetBrains Mono; swapping the embedded typeface *family* at runtime corrupts text (JUCE 8 + CoreText). Themes differ by colour/treatment/glow only. → [`docs/theming.md`](docs/theming.md)
 
-### Build and Test (Release)
-Two git hooks are installed by `scripts/install-hooks.sh` (run it once per clone — hooks are not auto-installed): a **pre-commit** hook (`scripts/pre-commit-lint.sh`) runs a fast clang-format lint on the staged C/C++ files, and a **pre-push** hook (`scripts/pre-push-release-test.sh`) runs clang-format lint + Release build + tests before every push.
-```bash
-bash scripts/install-hooks.sh
-```
-The first push configures the `build-release` directory; subsequent pushes do fast incremental rebuilds. This catches UB/segfaults that only manifest with optimizations enabled (Debug mode hides use-after-free by zero-initializing memory). CI lints with **clang-format 18** (ubuntu-24.04) — prefer that major version locally to avoid hook-passes-but-CI-fails drift. Bypass a hook once with `git commit --no-verify` / `git push --no-verify`.
+## Docs map
 
-To run manually:
-```bash
-bash scripts/pre-commit-lint.sh        # lint staged files
-bash scripts/pre-push-release-test.sh  # lint + Release build + tests
-```
-
-### Check Coverage
-```bash
-bash scripts/coverage.sh
-```
-
-### Git Hooks
-```bash
-bash scripts/install-hooks.sh    # Install pre-commit (clang-format lint) + pre-push (lint + Release build+test) hooks
-```
-
-## CI Pipeline
-
-CI runs via `.github/workflows/ci.yml` on PRs only (4 parallel jobs):
-- **Lint** (Ubuntu, ~30s) — clang-format check
-- **Build, Test, and Coverage** (Ubuntu Debug) — coverage threshold 85%
-- **Build and Test** (macOS) — Release build, catches UB/segfaults + cross-platform
-- **Build and Test** (Windows) — Release build, catches UB/segfaults + cross-platform
-
-Post-merge, `.github/workflows/build-artifacts.yml` runs on push to main (4 jobs): build+package on Ubuntu/macOS/Windows (no tests — CI already ran them), then tag+release.
-
-**Optimizations:**
-- **ccache**: Compiler cache avoids recompiling unchanged files. `CMAKE_C/CXX_COMPILER_LAUNCHER=ccache`, cached at `~/.ccache` (Linux) / `~/Library/Caches/ccache` (macOS), 500M max, keyed by commit SHA with prefix restore.
-- **FetchContent caching**: `build/_deps` (JUCE 8.0.3 + GoogleTest 1.14.0) cached via `actions/cache`, keyed on `CMakeLists.txt` + `Tests/CMakeLists.txt` hashes.
-- **JUCE_WEB_BROWSER=0**: Disabled unused WebBrowserComponent, removed WebKit/libsoup deps from Linux builds.
-- **coverage.sh --report-only**: In CI, skips redundant configure/build/test and only does profdata merge + report.
-- **Separate lint job**: Instant formatting feedback (~30s) without waiting for full build.
-- **apt package caching**: `awalsh128/cache-apt-pkgs-action` caches Ubuntu packages across runs.
-- **Path filtering**: PRs only trigger CI when `Source/`, `Tests/`, `CMakeLists.txt`, `scripts/`, or the workflow file change. Push to main always runs.
-
-**What didn't work:** Unity builds (`CMAKE_UNITY_BUILD`) are incompatible with JUCE — Obj-C++ `.mm` files can't be merged into C++ unity translation units.
-
-**What didn't work:** Precompiled headers (PCH) — JUCE compiles its own module `.cpp` files as part of the target and they have guards against being pre-included. On macOS, `.mm` files also need Obj-C++ mode which conflicts with C++ PCH.
-
-## Testing Strategy
-
-~519 tests across ~67 suites, all headless (no audio device, no GUI window). Ten test layers: audio rendering (DSP verification), integration (signal chains, mod routing), component workflow (UI interactions), state management (presets, undo/redo, serialization), theme system (token round-trips, ColourId mapping, WCAG contrast, icon tinting), layout (grid snap, anti-overlap, auto-arrange, width buckets), icon library (SVG loading, tint stability, null fallback), status bar (CPU/voice polling, master-mute, format helpers), frequency response component (peak-bin, Hz/dB label formatting, paint smoke), scope component (no-signal threshold, amplitude mapping, paint smoke), and E2E workflow (full application paths). Code coverage threshold: 85%. See [`docs/testing.md`](docs/testing.md) for the full breakdown, patterns, and how to add tests for new modules.
-
-## Keyboard Shortcuts
-
-Refer to [docs/shortcuts.md](docs/shortcuts.md) for the full list of configurable keyboard shortcuts.
-
-
-## Key Files to Understand
-
-- `CMakeLists.txt`: Main build configuration (version 0.13.2); `GravisynthAssets` binary-data target embeds 17 OFL font files from `assets/fonts/` plus **26 SVG icon files** from `assets/icons/`; linked PUBLIC into `GravisynthCore` with `GRAVISYNTH_HAS_FONT_ASSETS=1` (so app + tests both resolve `BinaryData` typefaces and icon assets); CMake guard enforces hyphen-only icon filenames (underscore in filename → fatal error at configure time)
-- `Source/Main.cpp`: Application entry point; `MainWindow` ctor calls `setResizeLimits(480, 400, 8192, 8192)` — hard platform floor on the `DocumentWindow` so the toolbar can never collapse to zero width; called BEFORE `centreWithSize(1600, 900)`
-- `Source/AudioEngine.h/cpp`: Audio processing engine, device management; `getModulationRoutings()` returns read-only `ModulationRouting` structs (`RoutingKind`: AttenuverterChain / DirectCV / PolyBus) derived from the live graph; `getActiveModRoutings()` / `getModulationDisplayInfo()` are adapters over it; `getDisplayVoiceCount()` / `setMasterMute()` / `isMasterMuted()` for status bar + transport; `masterMuted_` is `std::atomic<bool>` — zero-fill runs AFTER `processBlock` so clocks/envelopes keep advancing; requires `#include <bit>` for `std::popcount` (C++20)
-- `Source/GravisynthUndoManager.h/cpp`: Snapshot-based undo/redo with `SnapshotAction`, safe detach/reattach lifecycle
-- `Source/Modules/ModuleBase.h`: Base class with `ModuleType` enum, `ModulationTarget`, `ModulationCategory`; logical-port API (`PortRole`, `LogicalPort`, `mapInputChannel`, `mapOutputChannel`); `isAutoPromotableModTarget` guard for poly-mode connections; `ModuleType` is used by `LayoutUtil::getModuleWidthBucket` to classify modules into NARROW/SINGLE/DOUBLE width buckets
-- `Source/Modules/OscillatorModule.h`: Oscillator with PolyBLEP/PolyBLAMP anti-aliasing, waveform crossfade; poly mode reads shared mod-CV on ch8-12 and saves them before clearing the buffer; declared with 14 outputs to prevent JUCE graph buffer aliasing
-- `Source/Modules/FilterModule.h`: Multi-mode filter (LadderFilter for LPF/HPF/BPF + SVF for notch), atomic modulated params for visualizer, type parameter
-- `Source/Modules/VisualBuffer.h`: Thread-safe circular buffer using `std::atomic<float>`
-- `Source/PresetManager.h/cpp`: Factory presets with categorized organization; Poly Pad (case 6) includes Amp Env -> Osc Level (ch12) as DirectCV plus Amp Env -> VCA per-voice CV (PolyBus); all factory preset x/y positions are baked onto the standard column model (column stride 360 px, signal row y=40, mod row y=420) and are collision-clean at `kCollisionGap=12` — validated by `PresetManagerTest.AllFactoryPresetsLoadWithoutOverlap`; Phase 3 rebakes presets 0, 1, 5: Sequencer width changed to `kDoubleWidth=560` (right edge=570), so AmpEnv moved from x=560 to x=**584** and FilterEnv from x=870 to x=**880**; presets 2, 3, 4, 6 were clean and unchanged
-- `Source/UI/ModuleComponent.cpp`: Auto-UI with type-safe `ModuleType` switching, parameter listener for undo, safe detach lifecycle, FrequencyResponseComponent integration and spectrum toggle; modulation rings read `getModulationRoutings()`; bypass/mute are `juce::DrawableButton` (not TextButton); `deleteButton` (`DrawableButton`) at header-right position `(w-26, 2, 22, 20)` calls `owner.requestDeleteModule(nodeId)` on click; `applyHeaderButtonIcons()` / `lookAndFeelChanged()` retint all three buttons from `GravisynthLookAndFeel` — null-guarded for headless tests; waveform combos (detected by exact 4-element match `{"Sine","Square","Saw","Triangle"}`) are populated via a manual `getRootMenu()->addItem(id, text, true, false, std::move(icon))` loop with per-item `WaveformSine/Saw/Square/Triangle` Drawables; all other choice combos keep `addItemList`
-- `Source/UI/FrequencyResponseComponent.h`: Serum-style frequency response curve with FFT spectrum overlay; Phase 4 additive paint: Hz axis labels (100Hz/1kHz/10kHz at vertical freq gridlines), dB axis labels (-20/0/+20 at horizontal dB lines), and a resonance peak marker (filled dot + text callout at the magnitude peak); new public static helpers: `findPeakBin(const float*, int)`, `formatHzLabel(float)`, `freqToXStatic(float,float)`, `dbToYStatic(float,float)` (headless-testable, mirror the private freq→x log map and dB→y map)
-- `Source/UI/GraphEditor.cpp`: Graph editor with attenuverter knob rendering, poly-bus wire drawing (collapsed N-voice connections with "xN" badge), modulation routing, and undo integration; uses logical-port API to anchor wires to visible jacks; drag-preview system (`beginDragPreview`/`updateDragPreview`/`endDragPreview`) shows a themed grid-dot overlay + live landing ghost (snapped + anti-overlapped in real time) during any module drag; library drops use `finalizeModuleDrag` on the real component after `updateComponents()` so the final position always anti-overlaps using the true pixel dimensions (not the size estimate); `finalizeModuleDrag()` snap+anti-overlap on drag-release, `resolvePlacement()` anti-overlap on library drop, `autoArrange()` topological auto-layout (Cmd+L / "Auto Arrange" toolbar button, single undo step); `requestDeleteModule(NodeID)` is the canonical delete entry point — `ModuleComponent::deleteButton.onClick` delegates here
-- `Source/UI/LayoutUtil.h/.cpp`: Stateless grid-layout helpers (`snap`, `intersectsAny`, `findFreeSlot`, `computeAutoArrange`); no JUCE GUI deps — all geometry in canvas coordinates; Phase 3 adds width-bucket constants (`kNarrowWidth=40`, `kSingleWidth=280`, `kDoubleWidth=560`) and `getModuleWidthBucket(ModuleType)` / `moduleWidth()` helpers (Sequencer/PolySequencer/MidiKeyboard→Double, Attenuverter→Narrow, all others→Single); `kColumnStride = kSingleWidth + kLayerGapX = 360`; see `docs/layout.md` for the full model and API reference
-- `Source/UI/ToolbarComponent.h/.cpp`: FlexBox-based responsive toolbar — holds refs to 9 `DrawableButton*` slots (Library, Save, Load, Settings, Undo, Redo, AutoArrange, ToggleModMatrix, ToggleAiPanel); `layoutButtons(bounds)` runs a single `juce::FlexBox` row with a flex spacer between the left group and right group; narrow mode fires when `bounds.getWidth() <= narrowThreshold_` (480 px) — all buttons collapse to 32 px icon-only width; `isNarrowMode()` bool read by `MainComponent::resized()` to gate `applyToolbarIcons()` to narrow-mode transitions only (avoids Drawable clone storm on every resize); `paint()` fills `theme.colors.bg0` via dynamic_cast LnF, fallback `0xff0B0D10`
-- `Source/UI/StatusBarComponent.h/.cpp`: Bottom status bar (height 24 px) — paint-plus-button component; displays patch name (left), CPU % (warning colour >80%), voice count (right); owns `masterMuteButton_` (`DrawableButton`, far-right); `update(cpu, voices, patch)` is gated — calls `repaint()` only when any value changes by threshold; `resized()` positions `masterMuteButton_` at `(w-28, 2, 20, h-4)`; static format helpers `formatCpu` / `formatVoices` / `formatPatch` are headless-testable; **ZERO `writeToLog` calls** — status polling runs at 5 Hz from `MainComponent`'s 10 Hz timer (every 2nd tick via `statusBarTickCount_`)
-- `Source/UI/SettingsWindow.h/cpp`: Consolidated tabbed settings window (Audio, AI, General tabs) with tab persistence
-- `Source/ShortcutManager.h`: Configurable keyboard shortcut manager with action→KeyPress mapping, persistence, case-insensitive key matching, and conflict detection; Phase 3 adds Cmd+B default binding → Toggle Module Library Sidebar (wired via `ApplicationCommandTarget` in `MainComponent`)
-- `Source/UI/ModuleLibraryComponent.h`: Categorized sidebar with section headers for module drag-and-drop; `paint()` draws a 16×16 category icon (from `lf->peekIcon(catIcon)`) at x=10 per header entry, shifting header text to x=30; null-guarded (falls back to text-at-x=10 when LnF absent)
-- `Source/UI/ModMatrixComponent.cpp`: Modulation matrix with undo tracking for routing and parameter changes; Phase 4: zebra rows (odd rows tinted `surfaceHi` ~45% alpha), row hover highlight (`accent` ~10% alpha) tracked via `ModRow::mouseEnter`/`mouseExit` calling owner `setHoveredRow()`/`getHoveredRow()` with member `hoveredRow_` (default -1), taller rows via `static constexpr int kRowHeight = 48` (was 40); static helper `isZebraRow(int)`
-- **Visual Signal Flow**: GraphEditor draws animated dots on connections (white for audio, cyan for modulation), pulsing modulation lines, and activity glow on modules. ModuleComponent renders Serum-style modulation rings on knobs. Driven by `AudioEngine::getModulationDisplayInfo()` cached at 30fps.
-- `Source/Modules/FX/ChorusModule.h`: Chorus effect using `juce::dsp::Chorus`, CV modulation on Rate/Depth
-- `Source/Modules/FX/PhaserModule.h`: Phaser effect using `juce::dsp::Phaser`, CV modulation on Rate/Depth
-- `Source/Modules/FX/CompressorModule.h`: Compressor with manual makeup gain
-- `Source/Modules/FX/FlangerModule.h`: Flanger via `juce::dsp::Chorus` with low-delay tuning
-- `Source/Modules/FX/LimiterModule.h`: Brickwall limiter with input gain drive
-- `Source/UI/AIChatComponent.cpp/.h`: Chat interface for AI-assisted patching. **Logging gotcha:** this component registers itself as the global `juce::Logger` (`setCurrentLogger`) and pipes every `juce::Logger::writeToLog(...)` into a `TextEditor` debug console (Debug builds only). Appends are coalesced + the console is length-bounded, but DO NOT add high-frequency `writeToLog` calls (per-parameter, per-sample, per-frame, per-connection) — they run on the UI thread. Keep logging to errors/rare events. (A per-parameter log on preset load once caused a multi-second UI freeze; guarded by `AIStateMapperTest.PresetLoadDoesNotSpamLogger`.) Visibility persists via `ApplicationProperties` key `"aiPanelVisible"` (default false); read at top of `MainComponent::initialiseCommon()`
-- **UI rendering perf:** `ModuleComponent` uses `setBufferedToImage(true)` and gates its 15Hz `timerCallback` repaint (RMS-change / active-modulation / sequencer-step-change only) so the GraphEditor's 30Hz connection animation composites cached module images instead of re-running JUCE text layout every frame. Don't reintroduce unconditional per-tick `repaint()` on modules or their always-visible children. A theme switch triggers exactly ONE re-skin pass (`GravisynthLookAndFeel::applyTheme` → `sendLookAndFeelChangeMessage` → single `repaint()`) — no timer or continuous repaint is added. `applyToolbarIcons()` (Drawable clone work) is gated to narrow-mode transitions in `MainComponent::resized()` — not called on every resize frame. Status bar polls at 5 Hz (every 2nd 10 Hz timer tick) and repaints only itself; ZERO `writeToLog` calls in any status-polling path.
-- `Source/UI/ScopeComponent.h`: Oscilloscope/waveform display component; Phase 4 additive paint: horizontal amplitude grid lines at ±0.5 and ±1.0 (plus a brighter centre line at 0.0), and a centred "No Signal" empty-state when buffer peak ≤ 0.02; new static helpers: `isNoSignal(float)` (threshold 0.02f), `amplitudeToY(float, juce::Rectangle<float>)`; themed colours via `dynamic_cast<GravisynthLookAndFeel*>` with hardcoded fallbacks for headless
-- `Source/Modules/FX/DistortionModule.h`: Distortion effect with configurable oversampling (Off/2x/4x), soft-clipping using `tanh`-based curve, Drive and Mix parameters
-- `Tests/E2EWorkflowTests.cpp`: E2E workflow tests — preset loading, module drop/delete/replace, connection drag, mod matrix, undo/redo sequences, and stress tests
-- `Tests/`: ~519 tests across ~67 suites (audio rendering, integration, component workflow, state management, theme, icon library, status bar, layout, frequency response, scope, E2E workflow); `IconLibraryTests.cpp` and `StatusBarTests.cpp` are new in Phase 3; `FrequencyResponseTests.cpp` and `ScopeTests.cpp` are new in Phase 4
-- `docs/modulation.md`: Full reference for the modulation routing model, logical-port API, and poly-bus wire rendering
-- `Source/UI/Theme/Theme.h`: Pure data model — `Colors`, `Metrics`, `Typography`, `Treatment`, `ThemeStyle`, `Theme` structs with Obsidian defaults; no JUCE GUI deps beyond `juce::Colour`/`juce::String`
-- `Source/UI/Theme/ThemeManager.h/.cpp`: Theme registry, active-theme selection, JSON user-theme loading, persistence via shared `ApplicationProperties`
-- `Source/UI/Theme/ThemeLoader.h/.cpp`: JSON ↔ `Theme` (parse + serialize); `parseHexColour`, `parseStyle`, `styleToString` helpers; `getLastError()` for test/log use
-- `Source/UI/Theme/BuiltInThemes.h/.cpp`: The three built-in `Theme` literals (`makeObsidian`, `makeNeon`, `makeWarm`, `builtInThemes`) with exact colour/metric/treatment values
-- `Source/UI/Theme/IconLibrary.h/.cpp`: SVG icon registry — **26 icons** in `gsynth::theme::Icon` enum (TransportPlay through WaveformTriangle); loads icons from `BinaryData` (26 `assets/icons/*.svg` files, hyphen-named); parallel arrays `originals_[]` (untinted) + `drawables_[]` (tinted); `setTintColour(id, colour)` always clones from `originals_[]` to avoid tint accumulation across theme switches; `getDrawable(id)` returns a fresh clone (caller owns); `peekDrawable(id)` returns non-owning pointer; exhaustive `kTable` lookup (`static_assert` count now 26 guards count); `#ifdef GRAVISYNTH_HAS_FONT_ASSETS` guard — returns `nullptr` for all icons in headless test builds without asset target; all callers must null-check. **Icons are SVG Drawable, NOT a font** — no runtime font-family swap involved. `Icon::TransportPlay` is scaffolding (no DrawableButton wired this phase). Phase 4 adds `WaveformSine`, `WaveformSaw`, `WaveformSquare`, `WaveformTriangle` (indices 22–25); BinaryData symbols: `waveformsine_svg`, `waveformsaw_svg`, `waveformsquare_svg`, `waveformtriangle_svg`; consumed by `ModuleComponent` waveform combos and rendered by `GravisynthLookAndFeel::drawPopupMenuItem`/`drawComboBox`.
-- `Source/UI/Theme/GravisynthLookAndFeel.h/.cpp`: Central `LookAndFeel_V4` — stock-widget ColourId mappings + treatment draw helpers (`drawModulePanel`, `drawConnectionWire`, `drawModulationRing`, `fillThemedBackground`); typeface resolution with `GRAVISYNTH_HAS_FONT_ASSETS` fallback; 270° knob sweep constants `kRotaryStart`/`kRotaryEnd`; Phase 3 adds: `iconLibrary_` member + `retintIcons()` (called from `applyTheme()` — same single re-skin pass) + `getIcon(id)` / `peekIcon(id)` accessors; `applyTheme()` also sets ListBox and TabbedButtonBar ColourIds; fully themed: ComboBox (pressed/chevron), PopupMenu (drawn tick, submenu arrow, disabled dim), ScrollBar (6 px slim, track+thumb), TabbedButtonBar (bg0 + hairline + accent indicator on active tab). Phase 4 adds: `retintIcons()` tints the 4 new waveform icons to `textPrimary`; `drawPopupMenuItem` now paints a 14×14 waveform glyph left of the text (previously-ignored `icon` arg); `drawComboBox` renders the selected waveform glyph in the closed combo; `positionComboBoxText` shifts the label right when the selected item has an icon. **Font limitation:** all built-in themes share Inter + JetBrains Mono — swapping the embedded typeface *family* at runtime corrupts text globally (JUCE 8 + CoreText mis-indexes already-shaped glyph runs), so themes differ by colour/treatment/glow, not font. The ctor pre-creates all embedded typefaces at startup (a runtime `createSystemTypefaceFor` after rendering is part of the corruption); module-card drop shadows use a cheap layered fill (not `juce::DropShadow`'s gaussian blur) so zoom stays smooth. See `docs/theming.md` for the user-facing note.
-- `Source/UI/AppearanceSettingsTab.h/.cpp`: The Settings "Appearance" tab — theme picker `ListBox`, swatches, "Open Themes Folder" / "Reload Themes" buttons; `ChangeListener` so external theme switches update the selection
-- `docs/theming.md`: User + developer theming guide (token reference, JSON schema, tutorial, treatment params, contrast guidance); Phase 3 adds: Icon enum + tinting section (token→tint map, null-fallback contract, parallel-array design, BinaryData naming convention, how-to-add guide), code-only Metrics layout tokens table, fully-themed widget list (ComboBox/PopupMenu/ScrollBar/TabbedButtonBar), MidiKeyboard unthemed limitation, TransportPlay scaffolding note; Phase 4 updates: waveform icon entries (26 total, `textPrimary` tint, waveform-combo consumer), removed deferred-waveform-glyphs note
-- `docs/layout.md`: Soft-grid model, kGridSize=8 rationale, anti-overlap spiral search, auto-arrange topological layering algorithm (spacing constants, role ranks, undo integration), LayoutUtil API reference; Phase 3 adds: Toolbar & Status Bar Layout section (FlexBox, narrow threshold 480 px, gate logic, Metrics tokens table, panel collapse/persistence), Module Width Buckets section (NARROW/SINGLE/DOUBLE table, kColumnStride derivation, DOUBLE auto-arrange advance, preset 0/1/5 rebake note)
+- [`docs/architecture.md`](docs/architecture.md) — layers, core classes (ModuleBase, AudioEngine, GraphEditor, UndoManager, LookAndFeel), bypass/mute contract, signal flow
+- [`docs/modules.md`](docs/modules.md) — per-module specs + poly channel layouts (Oscillator, Filter, VCA, ADSR, LFO, Sequencer, Poly MIDI, Voice Mixer …)
+- [`docs/fx_modules.md`](docs/fx_modules.md) — FX specs (Distortion, Delay, Reverb, Chorus, Phaser, Compressor, Flanger, Limiter)
+- [`docs/modulation.md`](docs/modulation.md) — routing model, logical-port API, poly-bus wires, attenuverters, visual signal flow
+- [`docs/layout.md`](docs/layout.md) — grid/snap/auto-arrange, toolbar & status-bar chrome, width buckets, visualizer components, UI perf
+- [`docs/theming.md`](docs/theming.md) — theme tokens, SVG icons, JSON user themes, LookAndFeel, font limitation
+- [`docs/testing.md`](docs/testing.md) — test layers, build/test commands, CI pipeline, git hooks, coverage
+- [`docs/Module_Development_Guide.md`](docs/Module_Development_Guide.md) — step-by-step guide to adding a module
+- [`docs/AI_Engine.md`](docs/AI_Engine.md) · [`docs/AI_Usage_Guide.md`](docs/AI_Usage_Guide.md) — AI patching subsystem (OllamaProvider, AIStateMapper, chat UI)
+- [`docs/midi_input.md`](docs/midi_input.md) · [`docs/shortcuts.md`](docs/shortcuts.md) — external MIDI routing, keyboard shortcuts

--- a/docs/AI_Engine.md
+++ b/docs/AI_Engine.md
@@ -74,7 +74,48 @@ The AI communicates with Gravisynth using a simplified JSON schema to describe s
 -   **Model Management**: Users can select from various available AI models (e.g., different Ollama models) via the application's UI.
 -   **Extensible Provider System**: The `AIProvider` interface allows for easy integration of new AI backends in the future.
 
-## 5. Future Considerations
+## 5. AIChatComponent and Logging
+
+`AIChatComponent` (`Source/UI/AIChatComponent.cpp`) is the chat UI for AI-assisted patching. It wires user prompts to `AIIntegrationService` and displays the conversation history with optional JSON patch previews.
+
+### Debug Logger Registration (Debug builds only)
+
+In **Debug builds only**, `AIChatComponent` registers itself as the global `juce::Logger` by calling `juce::Logger::setCurrentLogger(this)` inside the `#else` branch of an `#ifdef NDEBUG` guard in the constructor. The debug console (`TextEditor`) and the "Debug" toggle button are also created and wired there. The destructor unregisters under `#ifndef NDEBUG`:
+
+```cpp
+// Constructor
+#ifdef NDEBUG
+    juce::Logger::writeToLog("AIChatComponent initialized (Release)");
+#else
+    // debug console setup + addChildComponent(debugConsole) ...
+    juce::Logger::setCurrentLogger(this);
+#endif
+
+// Destructor
+#ifndef NDEBUG
+    juce::Logger::setCurrentLogger(nullptr);
+#endif
+```
+
+This means `juce::Logger::writeToLog(...)` output is piped into the in-UI `TextEditor` debug console **only in Debug builds**. In Release builds no logger registration occurs.
+
+### Logging Rules
+
+Appends to the debug console are coalesced and the console is length-bounded. However:
+
+> **Do NOT add high-frequency `writeToLog` calls** (per-parameter, per-sample, per-frame, per-connection). They run on the UI thread. A per-parameter log on preset load once caused a multi-second UI freeze; this is guarded by `AIStateMapperTest.PresetLoadDoesNotSpamLogger`. Keep logging to errors and rare events only.
+
+### Panel Visibility Persistence
+
+The AI panel visibility persists via the `ApplicationProperties` key `"aiPanelVisible"` (default `false`). It is read in `MainComponent::initialiseCommon()`:
+
+```cpp
+isAiPanelVisible = appProperties.getUserSettings()->getBoolValue("aiPanelVisible", false);
+```
+
+Changes are written back to the same key when the panel is toggled.
+
+## 6. Future Considerations
 
 -   **Direct Saving of AI Suggested Patches**: Implement functionality for users to directly save AI-generated patches as presets.
 -   **Adding AI Suggested Patches Instead of Overriding**: Provide options to merge or add AI-suggested patch components without completely replacing the existing patch.

--- a/docs/Module_Development_Guide.md
+++ b/docs/Module_Development_Guide.md
@@ -48,8 +48,16 @@ All audio modules in Gravisynth inherit from `ModuleBase`, which in turn extends
     void MyNewModule::processBlock(juce::AudioBuffer<float>& buffer, juce::MidiBuffer& midiMessages) {
         juce::ignoreUnused(midiMessages); // Use MIDI if relevant
 
-        // Clear output if no input, or if module is bypassed
+        // Bypass: dry pass-through — return early WITHOUT clearing audio channels.
+        // Clear only CV channels (index >= 2) so mod CV does not leak as audio.
         if (isBypassed()) {
+            for (int ch = 2; ch < buffer.getNumChannels(); ++ch)
+                buffer.clear(ch, 0, buffer.getNumSamples());
+            return;
+        }
+
+        // Mute: silence the entire output buffer.
+        if (isMuted()) {
             buffer.clear();
             return;
         }
@@ -88,7 +96,11 @@ All audio modules in Gravisynth inherit from `ModuleBase`, which in turn extends
 *   This is where your core audio processing happens.
 *   `buffer` contains the audio input and should be filled with your module's output.
 *   `midiMessages` can be processed if your module is MIDI-aware (e.g., an instrument or MIDI effect).
-*   **Important**: If your module is bypassed or receives no active input, `buffer.clear()` the output to prevent unwanted noise or signals.
+*   **Important — bypass/mute contract (every `processBlock` MUST honour both branches separately):**
+    *   `isBypassed()` → **dry pass-through**: return early *without* clearing audio channels so the input signal flows through unchanged. Clear only CV channels at index ≥ 2 to prevent mod CV from leaking as audio. Never call `buffer.clear()` on bypass.
+    *   `isMuted()` → **silence**: call `buffer.clear()` then return.
+    *   Never combine the two into a single `if (isBypassed() || isMuted()) buffer.clear()` — that mutes on bypass instead of passing the signal through.
+    *   **Exception — pure source modules** (e.g. `OscillatorModule`, `PolyMidiModule`) have no audio input, so there is no dry signal to pass through. These modules *do* clear their output on bypass.
 
 ## 3. Parameter Management and Modular Routing
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,33 +2,171 @@
 
 Gravisynth is built on a modular graph architecture using JUCE's `AudioProcessorGraph` (implicitly managed by `AudioEngine`).
 
+---
+
+## Project Structure
+
+The build produces two CMake targets:
+
+| Target | Kind | Contents |
+|---|---|---|
+| `GravisynthCore` | Static library | All audio modules, `AudioEngine`, `PresetManager`, `GravisynthUndoManager`, theme system, `LayoutUtil`. Headless-testable — no audio device or GUI window required. |
+| `Gravisynth` | JUCE GUI app | Links `GravisynthCore`. Houses all UI components: `GraphEditor`, `ModuleComponent`, `ToolbarComponent`, `StatusBarComponent`, etc. |
+
+`GravisynthAssets` is a separate binary-data target that embeds font files and SVG icons; it is linked into `GravisynthCore` so both the app and test targets resolve `BinaryData` symbols.
+
+---
+
 ## Core Components
 
 ### 1. AudioEngine
-The central manager for the audio device and the processor graph. It handles:
-- Audio callback via `audioDeviceIOCallback`.
-- Dynamic addition/removal of modules.
-- Loading and saving graph states.
+
+`Source/AudioEngine.h/.cpp`
+
+Manages audio device I/O (via `juce::AudioIODeviceCallback`), the `juce::AudioProcessorGraph`, and modulation-matrix routing. Key responsibilities:
+
+- **Audio callback** — `audioDeviceIOCallbackWithContext` drives `mainProcessorGraph.processBlock`, then applies master-mute zero-fill **after** `processBlock` so sequencers, LFOs, and envelopes keep advancing even while muted. `masterMuted_` is `std::atomic<bool>`.
+- **Module lifecycle** — dynamic addition/removal of modules and connections in the graph.
+- **Preset load/save** — delegates to `PresetManager`.
+- **Modulation-matrix view** — `getModulationRoutings()` returns a `std::vector<ModulationRouting>` derived on demand from the live graph. Never serialized. `RoutingKind` values: `AttenuverterChain`, `DirectCV`, `PolyBus`. `getActiveModRoutings()` and `getModulationDisplayInfo()` are thin adapters over it.
+- **Voice count / mute API** — `getDisplayVoiceCount()`, `setMasterMute(bool)`, `isMasterMuted()`.
+- Requires `#include <bit>` for `std::popcount` (C++20).
 
 ### 2. ModuleBase
-Every audio processing unit inherits from `ModuleBase`.
-- Extends `juce::AudioProcessor`.
-- Provides a standard interface for parameter management (`addParameter`).
-- Supports a high-performance visual buffer for scope visualization.
+
+`Source/Modules/ModuleBase.h`
+
+Abstract base class for every audio processing unit. Extends `juce::AudioProcessor`.
+
+#### ModuleType enum
+
+Every concrete module implements `virtual ModuleType getModuleType() const = 0`. Current values:
+
+```
+Oscillator, Filter, VCA, ADSR, LFO, Sequencer, PolySequencer,
+MidiKeyboard, PolyMidi, ExternalMidi, Attenuverter,
+Delay, Distortion, Reverb, Chorus, Phaser, Compressor, Flanger, Limiter, VoiceMixer
+```
+
+`ModuleType` is consumed by `LayoutUtil::getModuleWidthBucket` to classify modules into width buckets (Narrow / Single / Double) and by `ModuleComponent` for type-safe UI layout switching.
+
+#### ModulationTarget / ModulationCategory
+
+- `ModulationTarget { juce::String name; int channelIndex; }` — describes a modulatable parameter and the audio-buffer channel that carries its CV signal. Returned by `virtual getModulationTargets()`.
+- `ModulationCategory` enum: `Envelope, LFO, Oscillator, Sequencer, Filter, FX, Other`. Returned by `virtual getModulationCategory()`.
+
+#### VisualBuffer
+
+Modules may opt in to a thread-safe `VisualBuffer` (circular buffer of `std::atomic<float>`) for scope visualization. Enabled/disabled via `enableVisualBuffer(bool)` and accessed via `getVisualBuffer()`.
+
+#### Logical-Port API
+
+Maps raw audio-buffer channel indices to the visible jack slots shown in the UI.
+
+| Symbol | Description |
+|---|---|
+| `PortRole` | Enum: `Audio, ModCV, Pitch, Gate, Midi, Other` |
+| `LogicalPort` | `{ int visibleJackIndex; PortRole role; bool isPolyGroupHead; int polyVoiceSpan; }` |
+| `mapInputChannel(int rawChannel)` | Virtual — returns `LogicalPort` for a raw input channel |
+| `mapOutputChannel(int rawChannel)` | Virtual — returns `LogicalPort` for a raw output channel |
+| `getVisibleInputPortCount()` / `getVisibleOutputPortCount()` | How many jacks the UI renders |
+
+`GraphEditor` uses this API to anchor wire endpoints to the correct visible jack regardless of how many raw channels are fanned out underneath.
+
+#### isAutoPromotableModTarget
+
+`virtual bool isAutoPromotableModTarget(int dstChannel) const`
+
+Guards poly-mode CV inputs from being auto-wrapped in an `AttenuverterModule` by the AI/routing layer. Default: returns `true` iff `dstChannel` is in `getModulationTargets()`. Modules override this to exclude poly-voice pitch/gate channels which should not receive an attenuverter.
+
+#### Port Labels
+
+`virtual juce::String getInputPortLabel(int channelIndex) const` / `getOutputPortLabel(int channelIndex)` — overridden per-module to provide descriptive jack names (e.g. "CV In", "Audio L") shown in the UI.
+
+#### Bypass/Mute Contract
+
+Every `processBlock` override **must** honour both flags using **two separate branches**:
+
+```cpp
+if (isBypassed()) {
+    // Dry pass-through — do NOT touch audio channels (ch0, ch1).
+    // Clear CV channels (index >= 2) so mod CV does not leak as audio.
+    return;
+}
+if (isMuted()) {
+    buffer.clear();
+    return;
+}
+// ... normal DSP ...
+```
+
+**Never** collapse to `if (isBypassed() || isMuted()) buffer.clear()` — that silences on bypass instead of passing the dry signal through.
+
+**Exception:** pure source modules with no audio input (e.g. `OscillatorModule`, `PolyMidiModule`) clear their output on bypass because there is no dry signal to pass through.
 
 ### 3. GraphEditor
-The visual patching interface.
-- Represented as a node graph.
-- Handles mouse interactions for "dragging" cables between inputs and outputs.
-- Maps UI connections to internal `AudioProcessorGraph` connections.
+
+`Source/UI/GraphEditor.h/.cpp`
+
+The visual patching interface. Lives in the `Gravisynth` app target.
+
+- **Zoom/pan** — `zoomLevel` + `panOffset`; `mouseWheelMove` / `mouseDrag` on the canvas.
+- **Wire drawing** — poly-bus wires (collapsed N-voice `DirectCV` connections) rendered with an "xN" badge; wire endpoints anchored to visible jacks via `ModuleBase`'s logical-port API.
+- **Drag-to-connect** — `beginConnectionDrag` / `dragConnection` / `endConnectionDrag`; maps UI gestures to `AudioProcessorGraph` connections.
+- **Module drag** — `finalizeModuleDrag` snaps the released module to the 8 px grid and resolves overlaps via spiral search. A live drag-preview system (`beginDragPreview` / `updateDragPreview` / `endDragPreview`) shows a themed grid-dot overlay plus a snapped landing ghost during drags.
+- **Library drops** — `resolvePlacement` + `finalizeModuleDrag` run on the real component after `updateComponents()` so the final position anti-overlaps using true pixel dimensions.
+- **Auto-arrange** — `autoArrange()` (triggered by Cmd+L or the toolbar button) topologically layers modules by signal-flow depth in a single undo step. See `docs/layout.md` for the full layout model.
+- **Delete** — `requestDeleteModule(NodeID)` is the canonical deletion entry point; `ModuleComponent::deleteButton.onClick` delegates here.
+
+See [`docs/layout.md`](layout.md) for the grid model, anti-overlap algorithm, and `autoArrange` constants.
+
+---
+
+## Supporting Components
+
+### LayoutUtil
+
+`Source/UI/LayoutUtil.h/.cpp`
+
+Stateless grid-layout helpers (`snap`, `intersectsAny`, `findFreeSlot`, `computeAutoArrange`). No JUCE GUI dependencies — fully headless-testable. See [`docs/layout.md`](layout.md) for the full API reference.
+
+### ModuleComponent
+
+`Source/UI/ModuleComponent.h/.cpp`
+
+Auto-generates parameter UI from `ModuleBase` metadata using type-safe `ModuleType` switching. Modulation rings read `AudioEngine::getModulationRoutings()`. Uses `setBufferedToImage(true)` and gates its 15 Hz timer repaint so the `GraphEditor`'s 30 Hz connection animation composites cached module images without re-running JUCE text layout every frame.
+
+### AttenuverterModule
+
+`Source/Modules/AttenuverterModule.h`
+
+Intermediary inserted between a modulation source and its destination to scale CV signals. Exposes `lastOutputPeak` / `lastModValue` atomics for UI metering. Constructor default `Amount = 0.0`; set to `1.0` by `addModRouting`, left at `0.0` by `addEmptyModRouting`. See [`docs/modulation.md`](modulation.md) for the full modulation routing model.
+
+### GravisynthUndoManager
+
+`Source/GravisynthUndoManager.h/.cpp`
+
+Snapshot-based undo/redo wrapping `juce::UndoManager`. Structural graph changes (add/remove module, connect/disconnect) are captured as JSON before/after snapshots via `SnapshotAction`. Parameter and position changes have dedicated action types. Safe detach/reattach lifecycle — `setGraphEditor(nullptr)` before graph teardown.
+
+### GravisynthLookAndFeel + ThemeManager
+
+Central `LookAndFeel_V4` subclass and theme registry. Owns all stock-widget re-skins, treatment draw helpers, and the SVG `IconLibrary`. See [`docs/theming.md`](theming.md) for the full token reference, JSON schema, and how-to-add guide.
+
+---
 
 ## Signal Flow
+
 Modules communicate via two main signal types:
+
 - **Audio Channels**: Stereo (usually) audio buffers containing PCM data.
 - **CV (Control Voltage)**: Handled as control signals within the audio buffer (e.g., ADSR output feeding into VCA input 1).
 
+---
+
 ## Quality Standards
+
 All modules follow specific DSP requirements:
+
 - **Smoothing**: All gain/cutoff parameters use linear smoothing to avoid clicks.
 - **Antialiasing**: Oscillators use PolyBLEP for sharp waveforms.
 - **Oversampling**: Nonlinear effects support configurable oversampling (e.g., Distortion offers Off/2x/4x modes).

--- a/docs/fx_modules.md
+++ b/docs/fx_modules.md
@@ -3,9 +3,14 @@
 Technical documentation for the Gravisynth effects suite.
 
 ## Distortion Module
-- **Algorithm**: Nonlinear soft-clipping using a `tanh`-based curve: `f(x) = x / (1 + |x|)`.
-- **Oversampling**: Configurable oversampling mode (Off, 2x, 4x) using polyphase IIR half-band filters to reduce aliasing in the high-frequency spectrum. Controls trade-off between audio quality and CPU usage.
-- **Parameters**: Drive (Intensity), Mix (Wet/Dry), Oversampling (Off/2x/4x).
+- **Algorithm**: Three waveshaper types selectable via the Type parameter:
+  - **Soft** (type 0): Rational waveshaper `f(x) = x * (1 + k) / (1 + k * |x|)` where `k = drive - 1`. Gain-neutral at `k=0`; increasingly compressed at higher drive values. This is NOT a tanh curve.
+  - **Hard** (type 1): Hard clipper — scales input by drive then clips to a threshold that tightens as drive increases.
+  - **Foldback** (type 2): Folds the signal back at a fixed threshold of ±0.8 after scaling by drive.
+- **Oversampling**: Configurable oversampling mode (Off, 2x, 4x) using FIR equiripple half-band filters (`filterHalfBandFIREquiripple`) to reduce aliasing. A latency-compensation delay line keeps the dry signal aligned for wet/dry mixing. Default is 2x (backward-compatible).
+- **Makeup Gain**: Automatic dynamic makeup gain (computed per-block from RMS ratio of dry vs. wet, clamped 0.01–1.0 linear, 50 ms smoothing). Not a user-visible parameter.
+- **Parameters**: Drive (1–20), Mix (0–1), Type (Soft/Hard/Foldback), Oversampling (Off/2x/4x).
+- **CV Inputs**: Drive (ch2), Mix (ch3).
 
 ## Delay Module
 - **Type**: Stereo feedback delay.
@@ -17,3 +22,30 @@ Technical documentation for the Gravisynth effects suite.
 - **Type**: Algorithmic stereo reverb.
 - **Implementation**: Uses standard Schroeder/Freeverb-inspired techniques for lush acoustic simulation.
 - **Parameters**: Room Size, Damping, Width, Mix.
+
+## Chorus Module
+- **Implementation**: `juce::dsp::Chorus<float>`.
+- **CV Modulation**: Rate (ch2) and Depth (ch3). CV is sampled per block (RMS-gated) and added to the smoothed parameter value.
+- **Parameters**: Rate (0.1–10 Hz), Depth (0–1), Centre Delay (1–30 ms), Feedback (-1–1), Mix (0–1).
+
+## Phaser Module
+- **Implementation**: `juce::dsp::Phaser<float>`.
+- **CV Modulation**: Rate (ch2) and Depth (ch3). CV is sampled per block (RMS-gated) and added to the smoothed parameter value.
+- **Parameters**: Rate (0.1–20 Hz), Depth (0–1), Centre Freq (200–10 000 Hz), Feedback (-1–1), Mix (0–1).
+
+## Compressor Module
+- **Implementation**: `juce::dsp::Compressor<float>`.
+- **Makeup Gain**: Manual, user-controlled. Range: -20 to +40 dB, default 0 dB. Applied per-sample with 5 ms smoothing after the compressor. There is no automatic gain compensation.
+- **CV Modulation**: None — no CV input channels.
+- **Parameters**: Threshold (-60–0 dB), Ratio (1–20), Attack (0.1–200 ms), Release (10–1000 ms), Makeup Gain (-20–+40 dB).
+
+## Flanger Module
+- **Implementation**: `juce::dsp::Chorus<float>` configured for flanger character by constraining the centre-delay range to 1–5 ms (versus Chorus's 1–30 ms). Default centre delay is 2 ms.
+- **CV Modulation**: Rate (ch2) and Depth (ch3). CV is sampled per block (RMS-gated) and added to the smoothed parameter value.
+- **Parameters**: Rate (0.05–5 Hz), Depth (0–1), Centre Delay (1–5 ms), Feedback (-1–1), Mix (0–1).
+
+## Limiter Module
+- **Implementation**: Brickwall `juce::dsp::Limiter<float>`.
+- **Input Gain**: Pre-limiter drive parameter. Range: -20 to +20 dB, default 0 dB. Applied per-sample with 5 ms smoothing before the limiter stage.
+- **CV Modulation**: None — no CV input channels.
+- **Parameters**: Threshold (-20–0 dB, default -1 dB), Release (1–500 ms), Input Gain (-20–+20 dB).

--- a/docs/layout.md
+++ b/docs/layout.md
@@ -170,6 +170,10 @@ The application chrome is carved out of `MainComponent::resized()` — the singl
 └─────────────────────────────────┘
 ```
 
+### ToolbarComponent `paint()`
+
+`paint()` fills the toolbar background with `theme.colors.bg0` via a `dynamic_cast<GravisynthLookAndFeel*>`. When the cast returns null (headless tests or non-themed context), it falls back to the hardcoded colour `0xff0B0D10`.
+
 ### Toolbar FlexBox layout (`ToolbarComponent`)
 
 `ToolbarComponent::layoutButtons(bounds)` runs a single `juce::FlexBox` (row, align-center):
@@ -213,6 +217,55 @@ The following `Metrics` struct fields govern chrome layout. They are **not parse
 
 `Main.cpp` `MainWindow` ctor calls `setResizeLimits(480, 400, 8192, 8192)` — a hard platform floor on the `DocumentWindow` before `centreWithSize(1600, 900)`. This prevents the window from shrinking below the minimum where toolbar buttons could clip to zero width. `Metrics::minWindowWidth`/`minWindowHeight` carry the same values as layout constants for use in `ToolbarComponent`'s narrow threshold and tests.
 
+### StatusBarComponent
+
+The status bar (`Source/UI/StatusBarComponent.h/.cpp`) is a 24 px high strip rendered at the bottom of `MainComponent`.
+
+**Layout:**
+- Patch name: left-aligned (padded 6 px from left edge)
+- CPU %: centre section, drawn in `theme.colors.warning` when above 80 %, otherwise `textMuted`
+- Voice count: right-aligned before the mute button slot
+- `masterMuteButton_` (`DrawableButton`): positioned in `resized()` at `(w-28, 2, 20, h-4)`
+
+**Update contract:**
+`update(float cpuPct, int voices, const juce::String& patch)` is gated — it only calls `repaint()` when any value changes by a visible amount (cpu delta > 0.5 %, voice count changed, or patch name changed). It contains **zero `writeToLog` calls**.
+
+**Polling rate:**
+The status bar polls at 5 Hz, driven by `MainComponent`'s 10 Hz timer via an every-other-tick guard (`statusBarTickCount_`).
+
+**Static format helpers** (headless-testable, no JUCE GUI deps):
+- `formatCpu(float fraction)` — fraction is 0..1; `0.756f → "75.6%"`
+- `formatVoices(int n)` — `0 → "0 voices"`, `1 → "1 voice"`, `8 → "8 voices"`
+- `formatPatch(const juce::String& s)` — empty or whitespace-only → `"Untitled"`
+
+### ModuleLibraryComponent section headers
+
+Each category section-header entry in `ModuleLibraryComponent::paint()` draws a 16×16 category icon at `x=10` using `lf->peekIcon(catIcon)`, then shifts the header text to `x=30`. This is null-guarded: when the `GravisynthLookAndFeel` cast returns null (headless tests or assets absent), no icon is drawn and header text falls back to the original `x=10` position.
+
+### ModMatrixComponent chrome
+
+`Source/UI/ModMatrixComponent.h/.cpp` paints rows with the following visual rules:
+
+- **Row height**: `static constexpr int kRowHeight = 48` (was 40)
+- **Zebra striping**: odd rows (`isZebraRow(rowIndex)` — `rowIndex % 2 == 1`) are tinted with `theme.colors.surfaceHi.withAlpha(0.45f)`; even rows are transparent (parent background shows through)
+- **Hover highlight**: the currently hovered row is tinted with `theme.colors.accent.withAlpha(0.10f)`, overriding the zebra base
+- **Hover tracking**: `ModRow::mouseEnter` calls `owner.setHoveredRow(rowIndex)`; `ModRow::mouseExit` calls `owner.setHoveredRow(-1)` only when that row still owns the hover, avoiding races when the cursor moves between rows. The `hoveredRow_` member defaults to `-1` (no hover)
+- **Static helper**: `static bool isZebraRow(int rowIndex) noexcept` — exposed for unit tests
+
+### ModuleComponent header button layout
+
+The header area of each module card (`Source/UI/ModuleComponent.cpp`) contains three `DrawableButton` instances (not `TextButton`), positioned in `resized()`:
+
+| Button | Bounds | Action |
+|---|---|---|
+| `deleteButton` | `(w-26, 2, 22, 20)` | Calls `owner.requestDeleteModule(nodeId)` |
+| `bypassButton` | `(w-50, 2, 22, 20)` | Toggles bypass state |
+| `muteButton` | `(w-74, 2, 22, 20)` | Toggles mute state |
+
+`requestDeleteModule(NodeID)` is the canonical delete entry point — `deleteButton.onClick` delegates here.
+
+`applyHeaderButtonIcons()` retints all three buttons from the active `GravisynthLookAndFeel`. It is null-guarded: when the LnF cast fails (headless tests), the function returns early and buttons remain imageless but functional. `lookAndFeelChanged()` calls `applyHeaderButtonIcons()` so icons update on theme switch.
+
 ### Panel collapse and persistence
 
 Library sidebar and AI panel can each be fully hidden (width = 0). State persists across launches via `ApplicationProperties`:
@@ -250,6 +303,30 @@ kColumnStride = kSingleWidth + kLayerGapX = 280 + 80 = 360 px
 
 `computeAutoArrange` uses the `sizeOf` callback to query each module's pixel width. For a Sequencer node the callback returns `{kDoubleWidth, 380}`, so `layerWidth` for that column becomes 560 and the next column starts at `x += 560 + 80 = 640`. Downstream modules are pushed rightward correctly without overlap.
 
+### Preset column/row model (authoritative: `Source/PresetManager.cpp` lines 38–81)
+
+Factory preset positions follow a fixed column/row grid. The **column x-positions** are not uniformly strided — they reflect actual module widths plus a ≥12 px collision gap:
+
+| Column | x | Contents |
+|---|---|---|
+| Col 0 | 10 | IO nodes, Sequencer, MIDI Keyboard |
+| Col 1 | 350 | Oscillator |
+| Col 2 | 650 | Filter |
+| Col 3 | 950 | VCA |
+| Col 4 | 1250 | FX chain (Distortion / Delay / Reverb) |
+| Col 5 | 1560 | Audio Output |
+
+The stride between columns is ~300 px and variable — **not** the uniform 360 px value. (`kColumnStride = 360` is the auto-arrange algorithm's column advance for single-width modules, a separate concept.)
+
+**Row y-positions:**
+
+| Row | y | Contents |
+|---|---|---|
+| Signal row | 10 | Osc, Filter, VCA, FX chain |
+| Sequencer row | 560 | Sequencer (bottom edge = 940) |
+| Modulator row | 600 | AmpEnv, FilterEnv, LFO |
+| Keyboard row | 960 | MIDI Keyboard |
+
 ### Preset position rebake (presets 0, 1, 5)
 
 Factory presets 0, 1, and 5 contain a Sequencer at x=10 (right edge = 570). After switching the Sequencer to `kDoubleWidth = 560`, the AmpEnv and FilterEnv positions were rebaked to avoid overlap:
@@ -258,6 +335,10 @@ Factory presets 0, 1, and 5 contain a Sequencer at x=10 (right edge = 570). Afte
 - **FilterEnv**: x=870 → x=**880** (584 + 280 + 12 gap + 4 grid ceil)
 
 Presets 2, 3, 4, 6 have no Sequencer-adjacent envelopes and required no rebake. The `AllFactoryPresetsLoadWithoutOverlap` test and the `estimateModuleSize` mirror in `Tests/PresetManagerTests.cpp` are updated atomically with the preset data change to keep the test green.
+
+### Poly Pad preset routing (case 6)
+
+The Poly Pad factory preset routes **Amp Env → VCA per-voice CV** (PolyBus, VCA ports 8–15) only. There is **no** Amp Env → Osc Level (ch12) DirectCV connection in this preset.
 
 ---
 
@@ -419,3 +500,57 @@ after `updateComponents()` builds it. This means the final position uses the mod
 component size** (not the size estimate) for the anti-overlap collision test, so tall modules
 like Oscillator (530 px) or Filter (570 px) always land correctly even if the ghost preview used
 a slightly different footprint.
+
+---
+
+## 9. Visualizer Components
+
+Two in-module visualizer components provide real-time signal display inside module cards.
+
+### FrequencyResponseComponent (`Source/UI/FrequencyResponseComponent.h`)
+
+Serum-style frequency-response curve with an optional FFT spectrum overlay, used by `FilterModule` cards.
+
+**Phase 4 paint additions:**
+- Hz axis labels at 100 Hz, 1 kHz, 10 kHz — drawn 3 px right of each vertical frequency gridline (10 kHz label is right-justified to stay within bounds at narrow widths)
+- dB axis labels at −20, 0, +20 dB — drawn at the left edge of each horizontal dB gridline
+- Resonance peak marker: filled dot (accent cyan `0xff00b4d8`) with a dark outline ring, plus a small text callout label using `formatHzLabel` at the magnitude peak; callout is skipped when component width < 44 px
+
+**Public static helpers** (headless-testable, no component state needed):
+
+| Helper | Signature | Notes |
+|---|---|---|
+| `findPeakBin` | `static int findPeakBin(const float* mags, int numBins)` | Returns index of maximum value; returns -1 for null/empty |
+| `formatHzLabel` | `static juce::String formatHzLabel(float hz)` | `100 → "100Hz"`, `1000 → "1kHz"`, `10000 → "10kHz"` |
+| `freqToXStatic` | `static float freqToXStatic(float freq, float width)` | Log-scaled freq → x pixel; mirrors private `freqToX` (minFreq=20, maxFreq=20000) |
+| `dbToYStatic` | `static float dbToYStatic(float db, float height)` | dB → y pixel; mirrors private `dbToY` (minDb=−40, maxDb=50) |
+
+### ScopeComponent (`Source/UI/ScopeComponent.h`)
+
+Oscilloscope waveform display used by all modules that have a `VisualBuffer`.
+
+**Phase 4 paint additions:**
+- Horizontal amplitude grid lines at ±0.5 and ±1.0 (drawn in `theme.colors.border` at 0.6 alpha)
+- Centre (0.0) grid line — slightly brighter (`border.brighter(0.3f)`) to serve as the waveform baseline
+- Centred "No Signal" empty-state text (in `textDisabled` colour) when the buffer peak ≤ 0.02 — replaces the waveform path draw entirely; `return` is early so no waveform is drawn on silence
+
+**Public static helpers** (headless-testable):
+
+| Helper | Signature | Notes |
+|---|---|---|
+| `isNoSignal` | `static bool isNoSignal(float peak) noexcept` | Returns `true` when `peak <= 0.02f` |
+| `amplitudeToY` | `static float amplitudeToY(float amp, juce::Rectangle<float> bounds) noexcept` | Maps amplitude [-1,1] → y pixel; amp=+1 → top, amp=-1 → bottom, amp=0 → centre; uses 45% height per side |
+
+**Themed colours**: resolved via `dynamic_cast<GravisynthLookAndFeel*>` — `border` for grid, `textDisabled` for no-signal label, `accent` for the waveform. When the cast fails (headless), hardcoded fallbacks are used (`0xff2A2F38`, `0xff5C6470`, limegreen).
+
+---
+
+## 10. UI Rendering Performance
+
+Guidelines to preserve smooth frame rates:
+
+- **`ModuleComponent` uses `setBufferedToImage(true)`**. Each module card is composited as a cached image. The `GraphEditor` 30 Hz connection animation blits these cached images rather than re-running JUCE text layout and parameter read on every animation frame. **Do not reintroduce unconditional `repaint()` calls in `timerCallback` on module components or their always-visible children.**
+- **Gated 15 Hz repaint**: `ModuleComponent::timerCallback` repaints only when the display needs to change — specifically when RMS level changes, active modulation routing changes, or the sequencer step index changes. The timer runs at 15 Hz (`startTimerHz(15)`).
+- **Single re-skin pass on theme switch**: `GravisynthLookAndFeel::applyTheme()` → `sendLookAndFeelChangeMessage()` → one `repaint()`. No timer is started and no continuous repaint is added during or after a theme switch.
+- **`applyToolbarIcons()` is gated**: cloning `Drawable` objects is expensive. The call is restricted to narrow-mode transitions in `MainComponent::resized()` — not executed on every resize frame. See §5 for the gate logic.
+- **Status bar polls at 5 Hz** and repaints only itself (`repaint()` on `StatusBarComponent` only). There are zero `writeToLog` calls in the status-polling path.

--- a/docs/modulation.md
+++ b/docs/modulation.md
@@ -20,6 +20,21 @@ enum class RoutingKind { AttenuverterChain, DirectCV, PolyBus };
 
 ---
 
+## AttenuverterModule Internals
+
+`AttenuverterModule` is the intermediary node inserted by `AudioEngine::addModRouting()`. Key internals:
+
+- **Constructor default Amount = 0.0.** The `amountParam` (`AudioParameterFloat`, range −1.0 to 1.0) is initialised to `0.0f`.
+- **`addModRouting` sets Amount to 1.0.** After inserting the node, `AudioEngine::addModRouting()` finds the amount parameter by index and calls `setValueNotifyingHost(1.0f)`. This means a freshly connected modulation path immediately passes the full signal.
+- **`addEmptyModRouting` leaves Amount at 0.0.** This method adds an `AttenuverterModule` node without wiring it or adjusting its parameter. The amount stays at the constructor default of `0.0`.
+- **UI visualization atomics.** After each `processBlock`, the module writes two `std::atomic<float>` members for the UI to read lock-free:
+  - `lastOutputPeak` — peak absolute value over the processed block (used to drive activity display).
+  - `lastModValue` — the mid-block sample value (`audioData[numSamples / 2]`), providing a near-instantaneous signal reading for modulation rings.
+  Both are exposed via `getLastOutputPeak()` and `getLastModValue()`.
+- **Bypass behavior.** When bypassed, `lastOutputPeak` and `lastModValue` are both set to `0.0f` and all channels are cleared (no pass-through — an attenuverter in bypass silences its output).
+
+---
+
 ## `AudioEngine::getModulationRoutings()`
 
 ```cpp
@@ -75,6 +90,17 @@ virtual LogicalPort mapOutputChannel(int rawChannel) const;
 
 Poly-capable modules override these to describe fans. The default base implementation clamps any out-of-range channel to the last visible jack and marks `isPolyGroupHead` based on whether `rawChannel < getVisible*PortCount()`.
 
+### Port Labels
+
+`ModuleBase` also declares virtual port-label accessors:
+
+```cpp
+virtual juce::String getInputPortLabel(int channelIndex) const;   // default: "In <N>"
+virtual juce::String getOutputPortLabel(int channelIndex) const;  // default: "Out <N>"
+```
+
+Modules override these to supply human-readable jack names shown in the UI (e.g. `AttenuverterModule` returns `"Signal"` / `"Amount"` for its two inputs and `"Out"` for its output). The UI reads these labels to annotate jack tooltips and connection indicators with descriptive names rather than raw channel numbers.
+
 ### How GraphEditor uses the logical-port API
 
 1. For every connection in the graph, GraphEditor calls `mapOutputChannel` on the source and `mapInputChannel` on the destination to get `LogicalPort` values.
@@ -124,3 +150,20 @@ The Amp Env module runs in poly mode (8 outputs, one per voice). The VCA runs in
 The preset also connects ADSR output ch0 (voice 0's envelope) directly to Oscillator input ch12 (the shared Level CV). This is a `DirectCV` routing: a single connection from one raw channel to one raw channel, without an attenuverter, and without a poly fan. `getModulationRoutings()` returns it as `DirectCV` with `voiceCount = 1`. GraphEditor draws it as a normal single wire without a badge. All 8 oscillator voices share the same level modulation (the voice-0 envelope signal).
 
 This combination — PolyBus for per-voice gate control, DirectCV for a shared timbre parameter — is a common pattern when building poly patches.
+
+---
+
+## Modulation Rings on Knobs (ModuleComponent)
+
+`ModuleComponent` renders Serum-style modulation rings on knobs for any active modulation targeting that module. It calls `AudioEngine::getModulationRoutings()` (via the `GraphEditor`'s cached snapshot) to find which knobs have live modulation and paints a ring overlay proportional to the routed signal value. This gives a real-time visual indication of modulation depth directly on the parameter knob.
+
+---
+
+## Visual Signal Flow
+
+`GraphEditor` draws animated signal-flow visualisation on top of all connections:
+
+- **Animated dots on wires.** Three evenly-spaced dots travel along every wire's bezier curve, riding the exact same cubic path as the drawn wire. Audio connection dots use the `audioWire` theme colour token (a light near-white in built-in themes); modulation connection dots use the `modWire` colour token (a bright cyan-blue in the Obsidian and Neon themes). Wire colours are theme-dependent — the dot colour always matches its wire's theme colour.
+- **Pulsing modulation lines.** Modulation wires pulse in brightness based on the live `modSignalPeak` from `ModulationRouting`, giving a visual sense of signal activity.
+- **Activity glow on modules.** `ModuleComponent` drives an activity glow (painted at 15 Hz) that brightens when the module's RMS output changes meaningfully or when it has active incoming modulation.
+- **Data source and cache rate.** `GraphEditor::timerCallback()` fires at **30 Hz** (`startTimerHz(30)`). Each tick it calls `AudioEngine::getModulationRoutings()` and `AudioEngine::getModulationDisplayInfo()` and stores the results in `cachedModRoutings` and `cachedModDisplayInfo`. The paint pass reads these cached values so animated dots and pulsing wires are driven by up-to-date signal state without hitting the audio engine on every paint frame.

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -10,6 +10,7 @@ Detailed specifications for Gravisynth's primary synthesis modules.
     - MIDI-to-Frequency tracking with unison and detune support.
     - Integrated visual buffer for real-time waveform display.
 - **Poly mode**: 8 voices driven by pitch CV (Hz). See [Poly Channel Layout](#poly-channel-layout) for channel details.
+- **Poly `processBlock` CV-save order**: In poly mode, both the per-voice pitch CVs (ch0-7) and the shared mod CVs (ch8-12) are copied into pre-allocated `std::array` caches (`pitchCVCache`, `waveformCVCache`, `octaveCVCache`, `coarseCVCache`, `fineCVCache`, `levelCVCache`) **before** the output buffer is cleared. This is necessary because ch0-7 carry both output audio (written after the clear) and input pitch CV, so they must be read first.
 - **Buffer aliasing note**: Declared with 14 output channels so JUCE's `AudioProcessorGraph` correctly copies shared mod-CV input channels (8-13) when they fan out to multiple downstream nodes. Channels 8-13 of the output are silent pass-throughs.
 
 ## Filter Module
@@ -19,6 +20,7 @@ Detailed specifications for Gravisynth's primary synthesis modules.
 - **CV inputs (mono mode)**: Cutoff = ch1, Resonance = ch2, Drive = ch3.
 - **CV inputs (poly mode)**: Cutoff = ch8, Resonance = ch9, Drive = ch10.
 - **Poly mode**: 8 per-voice audio inputs (ch0-7) + 3 shared CV inputs (ch8-10). Shared CV is computed once per block and applied to all active voices.
+- **Atomic modulated params**: `modulatedCutoff`, `modulatedResonance`, and `modulatedDrive` are `std::atomic<float>` members updated every `processBlock` (before voice processing in poly mode; per-sample in mono mode). `FrequencyResponseComponent` reads `getCurrentCutoff()` / `getModulatedResonance()` on the UI thread without locks.
 - **`isAutoPromotableModTarget`**: Returns `false` in poly mode (poly CV connections stay plain `DirectCV`, not auto-wrapped in attenuverters).
 
 ## ADSR (Envelope) Module
@@ -39,6 +41,7 @@ Detailed specifications for Gravisynth's primary synthesis modules.
 - **Allocation**: Least Recently Used (LRU) algorithm.
 - **Outputs**: 16 total channels — ch0-7 = per-voice pitch (Hz), ch8-15 = per-voice gate (0/1).
 - **Visible ports**: 1 output jack ("Poly Out") representing the entire poly bus.
+- **Voice mask atomic**: `voiceMaskAtomic_` (`std::atomic<uint8_t>`) is written at the end of every `processBlock` with `std::memory_order_relaxed` — one bit per voice (bit 0 = voice 0, … bit 7 = voice 7), set when `voices[i].active` is true. `AudioEngine::getDisplayVoiceCount()` reads it lock-free and counts set bits via `std::popcount` (C++20 `<bit>`).
 
 ## Voice Mixer Module
 - **Purpose**: Explicit 8-to-stereo voice summing with level control and soft saturation. An alternative to VCA's internal poly summing for patches that need a separate mix stage.
@@ -53,6 +56,43 @@ Detailed specifications for Gravisynth's primary synthesis modules.
     - **Octave Shift**: Shift the keyboard range by ±2 octaves.
     - **Visual Feedback**: Real-time display of pressed keys.
     - **MIDI Output**: Generates standard MIDI messages for driving oscillators or other MIDI-capable modules.
+
+## LFO Module
+- **Source file**: `Source/Modules/LFOModule.h`
+- **Waveforms**: 5 shapes — Sine, Triangle, Sawtooth, Square, S&H (Sample-and-Hold).
+- **Rate modes**:
+    - **Hz mode**: Free-running, 0.01–20.0 Hz (default 1.0 Hz, skewed range).
+    - **Sync mode**: Tempo-locked to host BPM (falls back to 120 BPM if no PlayHead). Subdivisions: 1/1, 1/2, 1/4 (default), 1/8, 1/16, 1/32.
+- **Parameters**: Shape (choice), Sync (bool mode toggle), Rate Hz (float), Sync Rate (choice), Bipolar (bool, default true), Retrig (bool), Level (0.0–1.0, default 1.0), Glide (0.0–1.0, S&H only).
+- **Bipolar/Unipolar**: When `Bipolar` is true, output range is −1 to +1. When false (unipolar), mapped to 0 to +1.
+- **S&H Glide**: On each phase wrap a new random value is drawn; `Glide > 0` ramps to it over up to 0.5 s using `juce::LinearSmoothedValue`.
+- **Retrig**: A MIDI Note On resets the phase to 0.0 when `Retrig` is enabled.
+- **Output**: Single CV channel (ch0). Pushes to `VisualBuffer` for scope display.
+- **Width**: SINGLE (280 px). See [docs/layout.md](layout.md).
+
+## Sequencer Module
+- **Source file**: `Source/Modules/SequencerModule.h`
+- **Purpose**: 8-step monophonic step sequencer. Generates MIDI messages (Note On/Off + CC) — it does **not** output a raw CV pitch channel.
+- **Parameters**:
+    - `Run` (bool) — starts/stops sequencer; sends Note Off for the active note on stop.
+    - `BPM` (30–300, default 120) — internal tempo.
+    - `Pitch 1–8` (`AudioParameterInt`, 0–127, MIDI note number) — per-step pitch. Displayed as note names (e.g. "F3"). Default sequence: F3 F4 Gb3 Db4 F3 A3 Gb3 C4.
+    - `Gate 1–8` (0.1–1.0, default 0.5) — gate length as fraction of one beat.
+    - `F.Env 1–8` (0.0–1.0, default 0.5) — per-step filter envelope amount, sent as MIDI CC 74.
+- **Timing**: One step per beat at the configured BPM. `currentActiveStep` (`std::atomic<int>`) is written each block for UI step-highlight.
+- **Width**: DOUBLE (560 px). See [docs/layout.md](layout.md).
+
+## Poly Sequencer Module
+- **Source file**: `Source/Modules/PolySequencerModule.h`
+- **Purpose**: 8-step polyphonic chord sequencer. Generates MIDI chord events — it does **not** output per-voice pitch CV channels.
+- **Parameters**:
+    - `Run` (bool) — starts/stops; sends Note Off for all active chord notes on stop.
+    - `BPM` (30–300, default 120) — internal tempo.
+    - `Step 1–8 Root` (`AudioParameterInt`, 0–127) — root note for the step. Defaults: C3 E3 G3 C4 C3 G3 E3 C4.
+    - `Step 1–8 Chord` (choice) — chord voicing: Unison, Major (0/4/7), Minor (0/3/7), Maj7 (0/4/7/11), Min7 (0/3/7/10), 5ths (0/7), Octs (0/12), Random (±12 semitones).
+    - `Gate 1–8` (0.1–1.0, default 0.5) — gate length as fraction of one beat.
+- **Timing**: One step per beat. `currentActiveStep` (`std::atomic<int>`) written each block for UI step-highlight.
+- **Width**: DOUBLE (560 px). See [docs/layout.md](layout.md).
 
 ## Attenuverter Module (Hidden)
 - **Purpose**: Invisible gain/polarity stage automatically inserted on every mono CV connection routed via the mod matrix.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,6 +1,6 @@
 # Testing Guide
 
-All tests use GoogleTest and run headless (no audio device, no GUI window). ~519 tests across ~67 suites.
+All tests use GoogleTest and run headless (no audio device, no GUI window). ~523 tests across ~68 suites.
 
 ```bash
 # Run all tests (ENABLE_TESTS defaults OFF — must be passed explicitly)
@@ -193,6 +193,72 @@ The `AudioRenderingTests` suite compares rendered audio against "golden" referen
   ```
 - **To listen**: Use `scripts/play-reference.sh <filename>` (requires `ffplay` or `aplay`).
 
-## CI
+## Build
 
-Tests run automatically on every PR across Ubuntu, macOS, and Windows. Coverage is enforced at 85% on the Ubuntu Debug build. See [CLAUDE.md](../CLAUDE.md) for full CI details.
+```bash
+cmake -S . -B build
+cmake --build build
+```
+
+`ENABLE_TESTS` defaults `OFF` — pass `-DENABLE_TESTS=ON` to generate the `GravisynthTests` target. `ENABLE_COVERAGE` is a separate opt-in flag used by the Ubuntu CI job and `scripts/coverage.sh`.
+
+## Git Hooks
+
+Install once per clone (hooks are **not** auto-installed):
+
+```bash
+bash scripts/install-hooks.sh
+```
+
+Two hooks are registered:
+
+- **pre-commit** (`scripts/pre-commit-lint.sh`): runs `clang-format --dry-run --Werror` on staged `Source/` and `Tests/` C/C++ files. Fast; mirrors the CI Lint job.
+- **pre-push** (`scripts/pre-push-release-test.sh`): runs clang-format lint on all C/C++ sources, then a Release build + full test suite. The first push configures the `build-release/` directory; subsequent pushes are fast incremental rebuilds. This catches UB and segfaults that Debug mode hides (zero-initialized memory masks use-after-free).
+
+Bypass a single invocation with `--no-verify`:
+
+```bash
+git commit --no-verify
+git push --no-verify
+```
+
+Run manually at any time:
+
+```bash
+bash scripts/pre-commit-lint.sh        # lint staged files
+bash scripts/pre-push-release-test.sh  # lint + Release build + tests
+```
+
+**clang-format version note:** CI installs clang-format as an unpinned `apt` package — currently clang-format 18 via `ubuntu-24.04`, but that will drift as GitHub updates the runner. Match the same major version locally to avoid "hook passes but CI fails" situations. The pre-commit script will warn if `clang-format` is missing from `PATH`.
+
+## CI Pipeline
+
+CI runs via `.github/workflows/ci.yml` on pull requests to `main` only, path-filtered to changes under `Source/**`, `Tests/**`, `CMakeLists.txt`, `Tests/CMakeLists.txt`, `scripts/**`, or either workflow file (`ci.yml` / `build-artifacts.yml`).
+
+There are **five jobs**:
+
+| Job | Runner | Config | Notes |
+|-----|--------|--------|-------|
+| **Lint** | `ubuntu-latest` | — | Installs `clang-format` as an unpinned apt package (currently 18 on ubuntu-24.04); runs `--dry-run --Werror` over `Source/` and `Tests/`. Fast (~30 s) — gives formatting feedback without waiting for a full build. |
+| **Build, Test, and Coverage** | `ubuntu-latest` | Debug + clang + `ENABLE_COVERAGE=ON` | Runs tests, then `bash scripts/coverage.sh --report-only` (skips re-build; only merges profdata and checks the 85% line-coverage threshold). |
+| **Build and Test (ASAN)** | `ubuntu-latest` | `RelWithDebInfo` + `-fsanitize=address` | **Label-gated** — only runs when the PR carries the `run-asan` label. `ASAN_OPTIONS=detect_leaks=0`. |
+| **Build and Test (macOS)** | `macos-latest` | Release | Catches UB/segfaults and cross-platform issues. |
+| **Build and Test (Windows)** | `windows-latest` | Release | Catches UB/segfaults and cross-platform issues. |
+
+### Optimizations
+
+- **ccache**: Compiler cache avoids recompiling unchanged files. `CMAKE_C/CXX_COMPILER_LAUNCHER=ccache`, 500 MB max size, cached at `~/.ccache` (Linux) / `~/Library/Caches/ccache` (macOS) / `C:\Users\runneradmin\AppData\Local\ccache` (Windows), keyed by commit SHA with prefix restore.
+- **FetchContent caching**: `build/_deps` (JUCE 8.0.3 + GoogleTest 1.14.0) cached by `actions/cache`, keyed on `CMakeLists.txt` + `Tests/CMakeLists.txt` hashes.
+- **`JUCE_WEB_BROWSER=0`**: Drops unused WebBrowserComponent and removes WebKit/libsoup deps on Linux.
+- **Separate lint job**: Instant formatting feedback without waiting for a full build.
+- **apt package caching**: `awalsh128/cache-apt-pkgs-action` caches Ubuntu packages across runs.
+- **`coverage.sh --report-only`**: In CI, skips redundant configure/build/test steps and only merges profdata + generates the report.
+
+### What didn't work
+
+- **Unity builds** (`CMAKE_UNITY_BUILD`): Incompatible with JUCE — Obj-C++ `.mm` files cannot be merged into C++ unity translation units.
+- **Precompiled headers**: JUCE module `.cpp` files have guards against being pre-included; on macOS, `.mm` files also require Obj-C++ mode which conflicts with a C++ PCH.
+
+### Post-merge artifact builds
+
+After a merge to `main`, `.github/workflows/build-artifacts.yml` triggers automatically. It builds and packages the app on Ubuntu, macOS, and Windows (no tests — CI already ran them on the PR) using **Ninja on all three platforms** (Windows via the MSVC dev environment), so the build path matches the PR CI exactly; it then bumps the version tag and creates a GitHub release with all three platform artifacts. The tag-and-release step runs **only on `push` to `main`** — a manual `workflow_dispatch` run is a build-only dry-run, useful for validating the matrix (including the Windows build) before merging.

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -122,6 +122,15 @@ them by name.
 > you intend to ship the theme as a launch default.
 Any other name falls back to the JUCE system sans-serif.
 
+> **Implementation note — typeface pre-creation.** `GravisynthLookAndFeel`'s constructor
+> pre-creates embedded typefaces for all six built-in font families (Inter, JetBrains Mono,
+> Manrope, Space Mono, IBM Plex Sans, IBM Plex Mono) and populates the per-instance
+> `typefaceCache` before any text is rendered. Creating an embedded typeface for the first time
+> via `juce::Typeface::createSystemTypefaceFor` *after* the app has already rendered with another
+> font is what triggers the JUCE 8 + CoreText global text corruption. Pre-loading all typefaces
+> at startup means `getTypefaceForFont` only ever returns cached instances — a live theme switch
+> never triggers a runtime typeface creation, so font switching stays clean.
+
 ### Treatment (`treatment`) — all optional
 
 | Token | Default | Type | Meaning |
@@ -358,8 +367,12 @@ Set to `0` (Obsidian/Warm) for no bloom. Set to `0.85` (Neon) for vivid neon glo
 
 ### `shadow` (float, 0–1)
 
-Drop-shadow strength under module cards. Uses `juce::DropShadow` with a radius of 10px and a
-4px downward offset. `0` = no shadow; `0.65` = Obsidian default.
+Drop-shadow strength under module cards. Implemented as a stack of three translucent,
+downward-offset, expanding rounded rectangles — **not** `juce::DropShadow`. `juce::DropShadow`
+re-rasterizes a per-paint gaussian blur every time a buffered card is re-rendered at a new zoom
+scale, which was the dominant cost behind zoom lag. The layered-fill approximation is visually
+close and a fraction of the cost (plain fills, no blur), so zooming stays smooth.
+`0` = no shadow; `0.6` = Obsidian default.
 
 ### `blur` (float, 0–1)
 
@@ -445,3 +458,50 @@ The following stock-widget overrides are now fully implemented in `GravisynthLoo
 
 - **`Icon::TransportPlay`** — SVG asset and enum value are present (scaffolding), but no `DrawableButton` is wired to it. Reserved for a future transport affordance.
 - **`AIChatComponent.cpp`** — chat bubble palette + debug console (hardcoded)
+
+---
+
+## 10. Developer implementation notes
+
+### `Theme.h` data model
+
+`Theme.h` (`Source/UI/Theme/Theme.h`) has **no JUCE GUI dependencies** beyond `juce::Colour` and
+`juce::String` (pulled in via `juce_graphics`). This makes it fully headless-testable without
+linking the UI modules. The file also defines the `ThemeStyle` enum (`Flat`, `Glass`,
+`Textured`) used by `Treatment::style`.
+
+### `ThemeLoader` public API
+
+`ThemeLoader` (`Source/UI/Theme/ThemeLoader.h`) exposes the following public helpers beyond the
+main `parseTheme` / `themeToJson` pair:
+
+| Method | Description |
+|---|---|
+| `parseHexColour(const juce::String&)` | Parse `"#RGB"` / `"#RRGGBB"` / `"#AARRGGBB"` → `std::optional<juce::Colour>`. Returns `nullopt` on malformed input. |
+| `parseStyle(const juce::String&)` | Map `"flat"` / `"glass"` / `"textured"` (case-insensitive) → `std::optional<ThemeStyle>`. |
+| `styleToString(ThemeStyle)` | Reverse: `ThemeStyle` → canonical lowercase string for serialization. |
+| `getLastError()` | Returns the error reason from the most recent `parseTheme` failure on the calling thread (empty string on success). Used by callers to emit the single "Skipped …" log line. |
+
+### Knob sweep arc constants
+
+`GravisynthLookAndFeel` declares two `static constexpr float` constants that define the 270°
+rotary sweep arc shared by knob drawing (`drawRotarySlider`) and modulation ring drawing
+(`drawModulationRing`):
+
+```cpp
+static constexpr float kRotaryStart = -juce::MathConstants<float>::pi * 0.75f; // ≈ –135°
+static constexpr float kRotaryEnd   =  juce::MathConstants<float>::pi * 0.75f; // ≈ +135°
+```
+
+Both helpers read these constants directly instead of using the `rotaryStartAngle` /
+`rotaryEndAngle` arguments passed by JUCE, ensuring the ring and the knob arc are always
+co-aligned regardless of what the `Slider` component was configured with.
+
+### Toolbar icon gating
+
+`applyToolbarIcons()` clones `Drawable` instances from `GravisynthLookAndFeel` and assigns them
+to each toolbar `DrawableButton` — this is non-trivial Drawable clone work. To avoid repeating
+it on every resize frame, `MainComponent::resized()` gates the call: `applyToolbarIcons()` is
+only called when the toolbar transitions **into** narrow mode (detected by comparing the new
+`isNarrowMode()` result against the previous value). Normal resize events that do not cross the
+480 px threshold skip the Drawable clone work entirely.


### PR DESCRIPTION
## Summary

Slim `CLAUDE.md` (175 → 58 lines) into a lean orientation layer — project, commands, planning rules, critical invariants, and a docs map — and migrate its deep file-by-file reference detail into the `docs/` set, correcting stale/wrong facts during the move. **Docs-only; no source changes.**

This started as a CLAUDE.md currency audit (64 claims verified against source: 57 accurate, 6 stale, 1 wrong) and grew into a restructure once the detail was confirmed to belong in `docs/`.

## Changes

- **CLAUDE.md** → 58 lines; all 12 doc links verified to resolve.
- **architecture.md** — expanded from a stub: Project Structure (two CMake targets), ModuleBase (logical-port API, **bypass/mute contract + source-module exception**), AudioEngine routing/master-mute, GraphEditor, brief core-class entries.
- **fx_modules.md** — added Chorus / Phaser / Compressor / Flanger / Limiter; **corrected Distortion to a rational waveshaper (not tanh)** + FIR-equiripple oversampling + Type param.
- **modules.md** — added LFO / Sequencer / Poly Sequencer (correctly as MIDI generators) + oscillator CV-save, filter atomics, poly-MIDI voice-mask details.
- **layout.md** — StatusBar / ModMatrix / ModuleComponent chrome, Visualizer Components, UI-rendering perf; **corrected preset coords to y=10 / y=600** and **Poly Pad routing (no ch12 DirectCV)**.
- **testing.md** — test count **523/68**; full CI section (**5 jobs incl. label-gated ASAN**, **unpinned clang-format on ubuntu-latest**), Git Hooks, Build.
- **modulation.md** — Port Labels, Attenuverter atomics, modulation rings, Visual Signal Flow.
- **AI_Engine.md** — AIChatComponent logging gotcha (**Debug-only**) + `aiPanelVisible`.
- **Module_Development_Guide.md** — 🐞 **fixed the `processBlock` template** that taught `clear()`-on-bypass (the root cause of the Oscillator/Poly MIDI pattern).
- **theming.md** — `kRotaryStart/End`, ctor typeface pre-creation, **corrected drop-shadow description** (layered fill, not `juce::DropShadow`), ThemeLoader API.

## Test Plan

- [x] All existing tests pass — no source changed; CI path-filter skips docs-only PRs
- [ ] New tests added for new functionality — N/A (documentation only)
- [ ] Tested locally (build + run) — N/A (documentation only); every `CLAUDE.md` doc link verified to resolve
- [x] Documentation updated (CLAUDE.md, docs/) to reflect any new files, architecture changes, or conventions

## Screenshots

N/A
