### PR TITLE
feat: UI Phase 5 — onboarding & micro-interactions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ Every implementation plan **must** include:
 
 - **Bypass/mute contract** — in every signal-processing `processBlock`, use **two separate branches**: `isBypassed()` → dry pass-through (return early WITHOUT touching audio channels; clear only CV channels ≥2 so mod CV doesn't leak as audio); `isMuted()` → `buffer.clear()` then return. Never `if (isBypassed() || isMuted()) buffer.clear()` — that mutes on bypass instead of passing the signal through. **Exception:** pure source modules with no audio input (Oscillator, Poly MIDI) clear on bypass — no dry signal to pass. → [`docs/architecture.md`](docs/architecture.md)
 - **No high-frequency logging** — AIChatComponent registers a global `juce::Logger` (Debug builds only) that pipes `writeToLog` into a UI-thread console. Never add per-sample / per-frame / per-parameter / per-connection logs (one caused a multi-second freeze; guarded by `AIStateMapperTest.PresetLoadDoesNotSpamLogger`). → [`docs/AI_Engine.md`](docs/AI_Engine.md)
-- **No unconditional per-tick repaint** — `ModuleComponent` is `setBufferedToImage(true)` with a gated 15 Hz timer; the 30 Hz GraphEditor animation composites cached images. A theme switch is exactly one re-skin pass. → [`docs/layout.md`](docs/layout.md)
+- **No unconditional per-tick repaint** — `ModuleComponent` is `setBufferedToImage(true)` with a gated 15 Hz timer; the 30 Hz GraphEditor animation composites cached images. A theme switch is exactly one re-skin pass. All UI animations use `AnimationDriver` (VBlank-driven, **time-bounded** — stops at `t=1`); never add free-running or continuous repaints. Exception: the AI thinking spinner pulses only while a request is in flight, confined to its region. → [`docs/layout.md §10–11`](docs/layout.md)
 - **Themes don't swap fonts** — all built-ins share Inter + JetBrains Mono; swapping the embedded typeface *family* at runtime corrupts text (JUCE 8 + CoreText). Themes differ by colour/treatment/glow only. → [`docs/theming.md`](docs/theming.md)
 
 ## Docs map
@@ -52,7 +52,7 @@ Every implementation plan **must** include:
 - [`docs/modules.md`](docs/modules.md) — per-module specs + poly channel layouts (Oscillator, Filter, VCA, ADSR, LFO, Sequencer, Poly MIDI, Voice Mixer …)
 - [`docs/fx_modules.md`](docs/fx_modules.md) — FX specs (Distortion, Delay, Reverb, Chorus, Phaser, Compressor, Flanger, Limiter)
 - [`docs/modulation.md`](docs/modulation.md) — routing model, logical-port API, poly-bus wires, attenuverters, visual signal flow
-- [`docs/layout.md`](docs/layout.md) — grid/snap/auto-arrange, toolbar & status-bar chrome, width buckets, visualizer components, UI perf
+- [`docs/layout.md`](docs/layout.md) — grid/snap/auto-arrange, toolbar & status-bar chrome, width buckets, visualizer components, UI perf, animation system (UIAnimation.h, AnimationDriver, micro-interactions)
 - [`docs/theming.md`](docs/theming.md) — theme tokens, SVG icons, JSON user themes, LookAndFeel, font limitation
 - [`docs/testing.md`](docs/testing.md) — test layers, build/test commands, CI pipeline, git hooks, coverage
 - [`docs/Module_Development_Guide.md`](docs/Module_Development_Guide.md) — step-by-step guide to adding a module

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,11 +177,12 @@ juce_add_binary_data(GravisynthAssets SOURCES
     assets/fonts/IBMPlexSans-SemiBold.ttf
     assets/fonts/IBMPlexMono-Regular.ttf
     assets/fonts/IBMPlexMono-Medium.ttf
-    # Icons (22 SVGs, hyphen-named; BinaryData symbols: e.g. transport_play_svg)
+    # Icons (23 SVGs, hyphen-named; BinaryData symbols: e.g. transport_play_svg)
     assets/icons/transport-play.svg
     assets/icons/transport-stop.svg
     assets/icons/action-undo.svg
     assets/icons/action-redo.svg
+    assets/icons/action-new.svg
     assets/icons/action-save.svg
     assets/icons/action-load.svg
     assets/icons/action-settings.svg

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,7 @@ target_link_libraries(GravisynthCore PUBLIC
     juce::juce_audio_utils
     juce::juce_gui_basics
     juce::juce_gui_extra
+    juce::juce_animation
     juce::juce_dsp
 )
 
@@ -230,6 +231,7 @@ target_sources(Gravisynth PRIVATE
     Source/UI/SettingsWindow.h
     Source/UI/AppearanceSettingsTab.cpp
     Source/UI/AppearanceSettingsTab.h
+    Source/UI/ShortcutsSettingsTab.cpp
     Source/ShortcutManager.h
 )
 
@@ -243,6 +245,7 @@ target_link_libraries(Gravisynth PRIVATE
     juce::juce_data_structures
     juce::juce_gui_basics
     juce::juce_gui_extra
+    juce::juce_animation
     juce::juce_audio_basics
     juce::juce_audio_devices
     juce::juce_audio_formats

--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -540,7 +540,7 @@ void MainComponent::applyToolbarIcons() {
     };
 
     setIcon(toggleLibraryButton, Icon::ToggleLibrary);
-    // newButton: no dedicated ActionNew SVG in the current icon set; button uses text label only.
+    setIcon(newButton, Icon::ActionNew);
     setIcon(saveButton, Icon::ActionSave);
     setIcon(loadButton, Icon::ActionLoad);
     setIcon(settingsButton, Icon::ActionSettings);

--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -104,6 +104,10 @@ void MainComponent::initialiseCommon(std::unique_ptr<gsynth::AIProvider> provide
     addAndMakeVisible(statusBar);
 
     // Buttons
+    addAndMakeVisible(newButton);
+    newButton.setComponentID("newButton");
+    newButton.onClick = [this] { commandManager.invokeDirectly(GravisynthCommands::newPatch, true); };
+
     addAndMakeVisible(saveButton);
     saveButton.setComponentID("saveButton");
     saveButton.onClick = [this] {
@@ -238,8 +242,8 @@ void MainComponent::initialiseCommon(std::unique_ptr<gsynth::AIProvider> provide
     // ORDERING CONTRACT: setButtons() MUST be called BEFORE setSize() so that the first
     // resized() -> layoutButtons() pass finds the registered buttons and positions them.
     // Calling setSize() before setButtons() leaves all buttons with zero bounds on first launch.
-    toolbar.setButtons({&toggleLibraryButton, &saveButton, &loadButton, &settingsButton, &undoButton, &redoButton,
-                        &autoArrangeButton, &toggleModMatrixButton, &toggleAiPanelButton});
+    toolbar.setButtons({&toggleLibraryButton, &newButton, &saveButton, &loadButton, &settingsButton, &undoButton,
+                        &redoButton, &autoArrangeButton, &toggleModMatrixButton, &toggleAiPanelButton});
 
     // Now that buttons are registered, trigger the first layout pass. resized() calls
     // toolbar.layoutButtons() which positions the buttons using their registered pointers.
@@ -352,9 +356,9 @@ void MainComponent::paint(juce::Graphics& g) {
 
 void MainComponent::getAllCommands(juce::Array<juce::CommandID>& commands) {
     commands.addArray({GravisynthCommands::openSettings, GravisynthCommands::savePreset, GravisynthCommands::openPreset,
-                       GravisynthCommands::undo, GravisynthCommands::redo, GravisynthCommands::toggleModMatrix,
-                       GravisynthCommands::toggleAiPanel, GravisynthCommands::autoArrange,
-                       GravisynthCommands::toggleLibrary});
+                       GravisynthCommands::newPatch, GravisynthCommands::undo, GravisynthCommands::redo,
+                       GravisynthCommands::toggleModMatrix, GravisynthCommands::toggleAiPanel,
+                       GravisynthCommands::autoArrange, GravisynthCommands::toggleLibrary});
 }
 
 void MainComponent::getCommandInfo(juce::CommandID commandID, juce::ApplicationCommandInfo& result) {
@@ -374,6 +378,12 @@ void MainComponent::getCommandInfo(juce::CommandID commandID, juce::ApplicationC
     case GravisynthCommands::openPreset: {
         result.setInfo("Open Preset", "Open a preset file", "General", 0);
         auto kp = shortcutManager.getBinding("openPreset");
+        result.addDefaultKeypress(kp.getKeyCode(), kp.getModifiers());
+        break;
+    }
+    case GravisynthCommands::newPatch: {
+        result.setInfo("New Patch", "Clear the canvas and start a new patch", "General", 0);
+        auto kp = shortcutManager.getBinding("newPatch");
         result.addDefaultKeypress(kp.getKeyCode(), kp.getModifiers());
         break;
     }
@@ -430,6 +440,11 @@ bool MainComponent::perform(const InvocationInfo& info) {
         return true;
     case GravisynthCommands::openPreset:
         openPresetFromFile();
+        return true;
+    case GravisynthCommands::newPatch:
+        graphEditor.newPatch();
+        setCurrentPatchName("Untitled");
+        statusBar.showMessage("New patch");
         return true;
     case GravisynthCommands::undo:
         if (undoManager.canUndo())
@@ -525,6 +540,7 @@ void MainComponent::applyToolbarIcons() {
     };
 
     setIcon(toggleLibraryButton, Icon::ToggleLibrary);
+    // newButton: no dedicated ActionNew SVG in the current icon set; button uses text label only.
     setIcon(saveButton, Icon::ActionSave);
     setIcon(loadButton, Icon::ActionLoad);
     setIcon(settingsButton, Icon::ActionSettings);
@@ -540,6 +556,7 @@ void MainComponent::applyToolbarIcons() {
             statusBar.getMasterMuteButton().setImages(d.get());
 
     // Text: cleared in narrow mode; stateful for the toggles in wide mode.
+    newButton.setButtonText(iconOnly ? "" : "New");
     saveButton.setButtonText(iconOnly ? "" : "Save");
     loadButton.setButtonText(iconOnly ? "" : "Load Presets");
     settingsButton.setButtonText(iconOnly ? "" : "Settings");
@@ -557,6 +574,7 @@ void MainComponent::applyToolbarIcons() {
             base, ShortcutManager::keyPressToDisplayString(shortcutManager.getBinding(action)));
     };
 
+    newButton.setTooltip(hint("New patch", "newPatch"));
     saveButton.setTooltip(hint("Save preset", "savePreset"));
     loadButton.setTooltip(hint("Load preset", "openPreset"));
     settingsButton.setTooltip(hint("Open settings", "openSettings"));

--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -113,8 +113,10 @@ void MainComponent::initialiseCommon(std::unique_ptr<gsynth::AIProvider> provide
         fileChooser->launchAsync(flags, [this](const juce::FileChooser& fc) {
             auto file = fc.getResult();
             if (file != juce::File{}) {
+                statusBar.showMessage("Saving...");
                 graphEditor.savePreset(file);
                 setCurrentPatchName(file.getFileNameWithoutExtension());
+                statusBar.showMessage("Saved: " + file.getFileNameWithoutExtension());
             }
         });
     };
@@ -140,10 +142,12 @@ void MainComponent::initialiseCommon(std::unique_ptr<gsynth::AIProvider> provide
             if (result == 1000) {
                 openPresetFromFile();
             } else if (result > 0) {
+                statusBar.showMessage("Loading preset...");
                 // loadFactoryPreset detaches existing components (stopping scope timers) before the graph
                 // is cleared — avoids a use-after-free where a ScopeComponent reads a freed VisualBuffer.
                 graphEditor.loadFactoryPreset(result - 1);
                 setCurrentPatchName(presets[result - 1].name);
+                statusBar.showMessage("Loaded: " + presets[result - 1].name);
             }
         });
     };
@@ -171,13 +175,30 @@ void MainComponent::initialiseCommon(std::unique_ptr<gsynth::AIProvider> provide
     addAndMakeVisible(toggleAiPanelButton);
     toggleAiPanelButton.setComponentID("toggleAiPanel");
     toggleAiPanelButton.onClick = [this] {
-        isAiPanelVisible = !isAiPanelVisible;
-        aiChatComponent.setVisible(isAiPanelVisible);
-        // Persist BEFORE resized() so a crash during layout doesn't lose the user's choice.
+        const bool newVisible = !isAiPanelVisible;
+        isAiPanelVisible = newVisible;
+        // Persist BEFORE animation so a crash during layout doesn't lose the user's choice.
         appProperties.getUserSettings()->setValue("aiPanelVisible", isAiPanelVisible ? "1" : "0");
         appProperties.getUserSettings()->saveIfNeeded();
         applyToolbarIcons();
+
+        auto fromResult = computePanelBounds(isLibraryVisible, !newVisible); // previous layout
+        if (newVisible) {
+            // Showing: make visible before animating in.
+            aiChatComponent.setVisible(true);
+            if (fromResult.aiPanelBounds.isEmpty())
+                fromResult.aiPanelBounds =
+                    juce::Rectangle<int>(fromResult.graphEditorBounds.getRight(), fromResult.graphEditorBounds.getY(),
+                                         0, fromResult.graphEditorBounds.getHeight());
+        }
+        // Apply the FINAL layout immediately so headless tests (no VBlank) see correct bounds.
+        // The animation below is cosmetic only — it starts from fromResult and converges to the
+        // same toResult that resized() already applied.
+        auto toResult = computePanelBounds(isLibraryVisible, newVisible);
         resized();
+        if (!newVisible)
+            aiChatComponent.setVisible(false);
+        animatePanelTransition(fromResult, toResult, /*hideLib=*/false, /*hideAi=*/!newVisible);
     };
 
     addAndMakeVisible(toggleModMatrixButton);
@@ -314,8 +335,10 @@ void MainComponent::openPresetFromFile() {
     fileChooser->launchAsync(flags, [this](const juce::FileChooser& fc) {
         auto file = fc.getResult();
         if (file != juce::File{}) {
+            statusBar.showMessage("Loading preset...");
             graphEditor.loadPreset(file);
             setCurrentPatchName(file.getFileNameWithoutExtension());
+            statusBar.showMessage("Loaded: " + file.getFileNameWithoutExtension());
         }
     });
 }
@@ -528,23 +551,135 @@ void MainComponent::applyToolbarIcons() {
     toggleAiPanelButton.setButtonText(iconOnly ? "" : (isAiPanelVisible ? "Hide AI" : "Show AI"));
     toggleLibraryButton.setButtonText(iconOnly ? "" : (isLibraryVisible ? "Hide Library" : "Show Library"));
 
-    // Tooltips remain available even in icon-only mode.
-    toggleLibraryButton.setTooltip(isLibraryVisible ? "Hide Library" : "Show Library");
-    toggleAiPanelButton.setTooltip(isAiPanelVisible ? "Hide AI Panel" : "Show AI Panel");
-    toggleModMatrixButton.setTooltip(graphEditor.isModMatrixVisible() ? "Hide Mod Matrix" : "Show Mod Matrix");
+    // Tooltips remain available even in icon-only mode; include shortcut hints where applicable.
+    auto hint = [&](const juce::String& base, const juce::String& action) {
+        return gravisynth::ui::formatShortcutHint(
+            base, ShortcutManager::keyPressToDisplayString(shortcutManager.getBinding(action)));
+    };
+
+    saveButton.setTooltip(hint("Save preset", "savePreset"));
+    loadButton.setTooltip(hint("Load preset", "openPreset"));
+    settingsButton.setTooltip(hint("Open settings", "openSettings"));
+    undoButton.setTooltip(hint("Undo", "undo"));
+    redoButton.setTooltip(hint("Redo", "redo"));
+    autoArrangeButton.setTooltip(hint("Auto-arrange modules", "autoArrange"));
+
+    const juce::String matrixBase = graphEditor.isModMatrixVisible() ? "Hide Mod Matrix" : "Show Mod Matrix";
+    toggleModMatrixButton.setTooltip(hint(matrixBase, "toggleModMatrix"));
+
+    const juce::String aiBase = isAiPanelVisible ? "Hide AI Panel" : "Show AI Panel";
+    toggleAiPanelButton.setTooltip(hint(aiBase, "toggleAiPanel"));
+
+    const juce::String libBase = isLibraryVisible ? "Hide Library" : "Show Library";
+    toggleLibraryButton.setTooltip(hint(libBase, "toggleLibrary"));
 }
 
-// ---- Collapsible library sidebar (persisted) ----
+// ---- Pure panel-bounds geometry helper ----
+MainComponent::PanelBoundsResult MainComponent::computePanelBounds(bool libVisible, bool aiVisible) const {
+    int tbH = 36, sbH = 24;
+    int libW = libVisible ? 200 : 0;
+    int aiW = aiVisible ? 300 : 0;
+    if (auto* lf = dynamic_cast<const gsynth::theme::GravisynthLookAndFeel*>(&getLookAndFeel())) {
+        const auto& m = lf->getTheme().metrics;
+        tbH = m.toolbarHeight;
+        sbH = m.statusBarHeight;
+        libW = libVisible ? m.librarySidebarWidth : m.sidebarCollapsedWidth;
+        aiW = aiVisible ? m.aiPanelWidth : 0;
+    }
+
+    auto bounds = getLocalBounds();
+    bounds.removeFromTop(tbH);    // toolbar
+    bounds.removeFromBottom(sbH); // status bar
+
+    PanelBoundsResult result;
+    if (aiVisible)
+        result.aiPanelBounds = bounds.removeFromRight(aiW);
+    if (libVisible)
+        result.libraryBounds = bounds.removeFromLeft(libW);
+    result.graphEditorBounds = bounds;
+    return result;
+}
+
+// ---- Animated panel transition ----
+void MainComponent::animatePanelTransition(const PanelBoundsResult& fromResult, const PanelBoundsResult& toResult,
+                                           bool hideLibraryOnComplete, bool hideAiPanelOnComplete) {
+    // Snapshot from-bounds for the lambdas.
+    libraryAnimFrom = fromResult.libraryBounds.isEmpty() ? toResult.libraryBounds : fromResult.libraryBounds;
+    aiPanelAnimFrom = fromResult.aiPanelBounds.isEmpty() ? toResult.aiPanelBounds : fromResult.aiPanelBounds;
+    graphEditorAnimFrom = fromResult.graphEditorBounds;
+
+    const auto libTo = toResult.libraryBounds.isEmpty() ? libraryAnimFrom : toResult.libraryBounds;
+    const auto aiTo = toResult.aiPanelBounds.isEmpty() ? aiPanelAnimFrom : toResult.aiPanelBounds;
+    const auto graphTo = toResult.graphEditorBounds;
+
+    // Stop both animators first — we're doing a single coordinated anim on aiPanelAnim,
+    // with libraryAnim as backup for the library bounds.
+    libraryAnim.stop(vblankUpdater);
+    aiPanelAnim.stop(vblankUpdater);
+
+    // Capture for lambdas.
+    auto libFrom = libraryAnimFrom;
+    auto aipFrom = aiPanelAnimFrom;
+    auto graphFrom = graphEditorAnimFrom;
+
+    // Single animator drives all three panels.
+    aiPanelAnim.start(
+        vblankUpdater,
+        190.0, // ~190 ms — within the 160–220 ms spec
+        gravisynth::ui::easeInOutCubic,
+        [this, libFrom, libTo, aipFrom, aiTo, graphFrom, graphTo](float t) {
+            if (!libFrom.isEmpty() || !libTo.isEmpty())
+                moduleLibrary.setBounds(gravisynth::ui::AnimationDriver::lerpBounds(libFrom, libTo, t));
+            if (!aipFrom.isEmpty() || !aiTo.isEmpty())
+                aiChatComponent.setBounds(gravisynth::ui::AnimationDriver::lerpBounds(aipFrom, aiTo, t));
+            graphEditor.setBounds(gravisynth::ui::AnimationDriver::lerpBounds(graphFrom, graphTo, t));
+        },
+        [this, hideLibraryOnComplete, hideAiPanelOnComplete, libTo, aiTo, graphTo]() {
+            // Snap to exact final bounds and apply visibility.
+            if (!libTo.isEmpty())
+                moduleLibrary.setBounds(libTo);
+            if (!aiTo.isEmpty())
+                aiChatComponent.setBounds(aiTo);
+            graphEditor.setBounds(graphTo);
+            if (hideLibraryOnComplete)
+                moduleLibrary.setVisible(false);
+            if (hideAiPanelOnComplete)
+                aiChatComponent.setVisible(false);
+        });
+}
+
+// ---- Collapsible library sidebar (animated, persisted) ----
 void MainComponent::setLibraryVisible(bool v) {
     isLibraryVisible = v;
-    moduleLibrary.setVisible(v);
-    toggleLibraryButton.setTooltip(v ? "Hide Library" : "Show Library");
     appProperties.getUserSettings()->setValue("librarySidebarVisible", v ? "1" : "0");
     appProperties.getUserSettings()->saveIfNeeded();
-    // Refresh the toggle button's wide-mode label, then re-lay-out.
+    // Refresh the toggle button's wide-mode label and tooltip.
     if (!toolbarNarrowMode_)
         toggleLibraryButton.setButtonText(v ? "Hide Library" : "Show Library");
+    toggleLibraryButton.setTooltip(gravisynth::ui::formatShortcutHint(
+        v ? "Hide Library" : "Show Library",
+        ShortcutManager::keyPressToDisplayString(shortcutManager.getBinding("toggleLibrary"))));
+
+    // Compute from/to layouts.
+    auto fromResult = computePanelBounds(!v, isAiPanelVisible); // previous layout
+    if (v) {
+        // Showing: make visible at the from-position before animating.
+        moduleLibrary.setVisible(true);
+        if (fromResult.libraryBounds.isEmpty())
+            fromResult.libraryBounds =
+                juce::Rectangle<int>(fromResult.graphEditorBounds.getX(), fromResult.graphEditorBounds.getY(), 0,
+                                     fromResult.graphEditorBounds.getHeight());
+    }
+    auto toResult = computePanelBounds(v, isAiPanelVisible);
+
+    // Apply the FINAL layout immediately so headless tests (no VBlank) see correct bounds.
+    // The animation below is cosmetic only — it starts from fromResult and converges to the
+    // same toResult that resized() already applied.
     resized();
+    if (!v)
+        moduleLibrary.setVisible(false);
+
+    animatePanelTransition(fromResult, toResult, /*hideLib=*/!v, /*hideAi=*/false);
 }
 
 // ---- Patch name (status bar) ----

--- a/Source/MainComponent.h
+++ b/Source/MainComponent.h
@@ -71,6 +71,10 @@ public:
     GraphEditor& getGraphEditor() { return graphEditor; }
     ToolbarComponent& getToolbar() { return toolbar; }
     StatusBarComponent& getStatusBar() { return statusBar; }
+    void simulateNewPatchClick() {
+        if (newButton.onClick)
+            newButton.onClick();
+    }
     void simulateUndoClick() {
         if (undoButton.onClick)
             undoButton.onClick();
@@ -142,8 +146,9 @@ private:
     // remain direct children of MainComponent so existing getChildren() accessors still work.
     ToolbarComponent toolbar;
 
-    // The 9 toolbar buttons (8 actions + toggleLibrary). DrawableButton so they carry SVG
+    // The 10 toolbar buttons (9 actions + toggleLibrary). DrawableButton so they carry SVG
     // icons; ButtonParameterAttachment / .onClick wiring works on the juce::Button base.
+    juce::DrawableButton newButton{"new", juce::DrawableButton::ImageAboveTextLabel};
     juce::DrawableButton saveButton{"save", juce::DrawableButton::ImageAboveTextLabel};
     juce::DrawableButton loadButton{"load", juce::DrawableButton::ImageAboveTextLabel};
     juce::DrawableButton settingsButton{"settings", juce::DrawableButton::ImageAboveTextLabel};

--- a/Source/MainComponent.h
+++ b/Source/MainComponent.h
@@ -12,6 +12,7 @@
 #include "UI/Theme/GravisynthLookAndFeel.h"
 #include "UI/Theme/ThemeManager.h"
 #include "UI/ToolbarComponent.h"
+#include "UI/UIAnimation.h"
 #include <juce_audio_utils/juce_audio_utils.h>
 #include <juce_gui_basics/juce_gui_basics.h>
 #include <memory>
@@ -106,8 +107,17 @@ private:
     // dynamic_casts the LnF and no-ops the icon assignment when null (headless tests).
     void applyToolbarIcons();
 
-    // Collapse/expand the library sidebar. Persists "librarySidebarVisible" and re-lays out.
+    // Collapse/expand the library sidebar. Animates to the target layout.
     void setLibraryVisible(bool v);
+
+    // Compute the target bounds for the library and AI panel in the current layout.
+    // Pure geometry — no side effects; used by animation and tests.
+    struct PanelBoundsResult {
+        juce::Rectangle<int> libraryBounds; // empty rect when hidden
+        juce::Rectangle<int> aiPanelBounds; // empty rect when hidden
+        juce::Rectangle<int> graphEditorBounds;
+    };
+    PanelBoundsResult computePanelBounds(bool libVisible, bool aiVisible) const;
 
     // Update the displayed patch name (status bar). Immediate repaint, no timer delay.
     void setCurrentPatchName(const juce::String& name);
@@ -167,6 +177,27 @@ private:
 
     ShortcutManager shortcutManager;
     juce::ApplicationCommandManager commandManager;
+
+    // ---- Panel slide animations (time-bounded, auto-stop) ----
+    // One VBlankAnimatorUpdater shared by both panel animations (driven by MainComponent).
+    juce::VBlankAnimatorUpdater vblankUpdater{this};
+    gravisynth::ui::AnimationDriver libraryAnim;
+    gravisynth::ui::AnimationDriver aiPanelAnim;
+
+    // During animation, track the "from" bounds so lerpBounds() can interpolate.
+    juce::Rectangle<int> libraryAnimFrom;
+    juce::Rectangle<int> aiPanelAnimFrom;
+    juce::Rectangle<int> graphEditorAnimFrom;
+
+    // Start a coordinated bounds animation for library + AI panel + graph editor.
+    // fromResult is the current layout; toResult is the target layout.
+    void animatePanelTransition(const PanelBoundsResult& fromResult, const PanelBoundsResult& toResult,
+                                bool hideLibraryOnComplete, bool hideAiPanelOnComplete);
+
+    // Provides native-style tooltips for any child Component that has a tooltip
+    // string set via setTooltip(). Constructed last so all child components exist.
+    // Do NOT set tooltips on controls here; each feature owner does that.
+    juce::TooltipWindow tooltipWindow{this};
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MainComponent)
 };

--- a/Source/ShortcutManager.h
+++ b/Source/ShortcutManager.h
@@ -7,6 +7,7 @@ enum CommandIDs {
     openSettings = 0x100,
     savePreset,
     openPreset,
+    newPatch,
     undo,
     redo,
     toggleModMatrix,
@@ -22,6 +23,8 @@ inline juce::CommandID getCommandForAction(const juce::String& actionId) {
         return savePreset;
     if (actionId == "openPreset")
         return openPreset;
+    if (actionId == "newPatch")
+        return newPatch;
     if (actionId == "undo")
         return undo;
     if (actionId == "redo")
@@ -100,6 +103,7 @@ public:
         bindings["openSettings"] = juce::KeyPress(',', juce::ModifierKeys::commandModifier, 0);
         bindings["savePreset"] = juce::KeyPress('s', juce::ModifierKeys::commandModifier, 0);
         bindings["openPreset"] = juce::KeyPress('o', juce::ModifierKeys::commandModifier, 0);
+        bindings["newPatch"] = juce::KeyPress('n', juce::ModifierKeys::commandModifier, 0);
         bindings["undo"] = juce::KeyPress('z', juce::ModifierKeys::commandModifier, 0);
         bindings["redo"] =
             juce::KeyPress('z', juce::ModifierKeys::commandModifier | juce::ModifierKeys::shiftModifier, 0);
@@ -163,6 +167,8 @@ public:
             return "Save Preset";
         if (actionId == "openPreset")
             return "Open Preset";
+        if (actionId == "newPatch")
+            return "New Patch";
         if (actionId == "undo")
             return "Undo";
         if (actionId == "redo")
@@ -197,8 +203,8 @@ private:
     std::map<juce::String, juce::KeyPress> bindings;
     juce::ApplicationProperties* appProperties = nullptr;
 
-    juce::StringArray actionIds{"openSettings",    "savePreset",    "openPreset",  "undo",         "redo",
-                                "toggleModMatrix", "toggleAiPanel", "autoArrange", "toggleLibrary"};
+    juce::StringArray actionIds{"openSettings", "savePreset",      "openPreset",    "newPatch",    "undo",
+                                "redo",         "toggleModMatrix", "toggleAiPanel", "autoArrange", "toggleLibrary"};
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(ShortcutManager)
 };

--- a/Source/UI/AIChatComponent.cpp
+++ b/Source/UI/AIChatComponent.cpp
@@ -203,13 +203,34 @@ AIChatComponent::AIChatComponent(AIIntegrationService& service, juce::Applicatio
     inputField.onReturnKey = [this]() { sendButtonClicked(); };
     inputField.addListener(this);
     inputField.setTextToShowWhenEmpty("Ask AI to create or modify a patch...", juce::Colours::grey);
+    inputField.setTooltip("Type a message and press Enter or Send");
 
     addAndMakeVisible(sendButton);
     sendButton.setButtonText("Send");
     sendButton.onClick = [this]() { sendButtonClicked(); };
+    sendButton.setTooltip("Send message to AI  (Enter)");
+
+    // Cancel button — hidden until a request is in flight.
+    cancelButton.setButtonText("Cancel");
+    cancelButton.setColour(juce::TextButton::buttonColourId, juce::Colours::darkred);
+    cancelButton.onClick = [this]() {
+        cancelRequest();
+        messages.push_back({"assistant", "Cancelled.", ""});
+        updateChatDisplay();
+        inputField.grabKeyboardFocus();
+    };
+    cancelButton.setTooltip("Cancel the in-flight AI request");
+    cancelButton.setVisible(false);
+    addChildComponent(cancelButton);
+
+    // Spinner dot — 8×8 ellipse, hidden until waiting.
+    spinnerDot.setSize(8, 8);
+    spinnerDot.setVisible(false);
+    addChildComponent(spinnerDot);
 
     addAndMakeVisible(newChatButton);
     newChatButton.setButtonText("New Chat");
+    newChatButton.setTooltip("Start a new conversation (clears history)");
     newChatButton.onClick = [this]() {
         aiService.clearHistory();
         messages.clear();
@@ -217,6 +238,7 @@ AIChatComponent::AIChatComponent(AIIntegrationService& service, juce::Applicatio
     };
 
     addAndMakeVisible(modelPicker);
+    modelPicker.setTooltip("Select the AI model to use");
     modelPicker.onChange = [this]() {
         juce::String model = modelPicker.getText();
         aiService.setModel(model);
@@ -249,20 +271,34 @@ AIChatComponent::AIChatComponent(AIIntegrationService& service, juce::Applicatio
 
 AIChatComponent::~AIChatComponent() {
     stopTimer();
+    // Stop any running pulse animation before members are destroyed.
+    spinnerDot.stopPulse(vblankUpdater);
 #ifndef NDEBUG
     juce::Logger::setCurrentLogger(nullptr);
 #endif
 }
 
 void AIChatComponent::timerCallback() {
-    // If the timer fires, the request has timed out
-    stopTimer();
-    sendButton.setEnabled(true);
-    inputField.setReadOnly(false);
-    isWaitingForResponse = false;
+    // The 120 s timer fired — request has timed out.
+    cancelRequest();
     messages.push_back({"assistant", "Error: Request timed out after 2 minutes.", ""});
     updateChatDisplay();
     inputField.grabKeyboardFocus();
+}
+
+void AIChatComponent::cancelRequest() {
+    // Stop the timeout timer.
+    stopTimer();
+
+    // Stop the pulse animation and hide the spinner.
+    spinnerDot.stopPulse(vblankUpdater);
+    spinnerDot.setVisible(false);
+
+    // Hide the cancel button, restore normal input state.
+    cancelButton.setVisible(false);
+    sendButton.setEnabled(true);
+    inputField.setReadOnly(false);
+    isWaitingForResponse = false;
 }
 
 void AIChatComponent::resized() {
@@ -274,10 +310,22 @@ void AIChatComponent::resized() {
 
     auto bottomArea = b.removeFromBottom(70); // Increased height for both rows
 
-    // Bottom row: Input + Send
+    // Bottom row: Input + Send (+ Cancel when waiting + spinner dot)
     auto inputRow = bottomArea.removeFromBottom(40);
-    sendButton.setBounds(inputRow.removeFromRight(60));
+
+    // Cancel button occupies the same slot as Send — only one is visible at a time.
+    // We size both identically so the layout is stable regardless of visibility.
+    const auto sendCancelBounds = inputRow.removeFromRight(60);
+    sendButton.setBounds(sendCancelBounds);
+    cancelButton.setBounds(sendCancelBounds);
+
     inputRow.removeFromRight(10);
+
+    // Spinner dot: 8×8, vertically centred on the right edge of the input area.
+    const int spinnerSize = 8;
+    spinnerDot.setBounds(inputRow.removeFromRight(spinnerSize).withSizeKeepingCentre(spinnerSize, spinnerSize));
+    inputRow.removeFromRight(4); // gap between spinner and input field
+
     inputField.setBounds(inputRow);
 
     // Middle row (above input): Model Picker
@@ -341,6 +389,11 @@ void AIChatComponent::sendButtonClicked() {
     sendButton.setEnabled(false);
     inputField.setReadOnly(true);
 
+    // Show cancel affordance and start the pulse spinner.
+    cancelButton.setVisible(true);
+    spinnerDot.setVisible(true);
+    spinnerDot.startPulse(vblankUpdater);
+
     // Start timeout timer (120 seconds)
     startTimer(120000);
 
@@ -357,10 +410,7 @@ void AIChatComponent::sendButtonClicked() {
                     return;
                 } // Ignore late responses if a timeout already occurred
 
-                self->stopTimer(); // Cancel timeout
-                self->isWaitingForResponse = false;
-                self->sendButton.setEnabled(true);
-                self->inputField.setReadOnly(false);
+                self->cancelRequest(); // stops timer, spinner, cancel btn, restores input
 
                 if (success) {
                     juce::String json;

--- a/Source/UI/AIChatComponent.h
+++ b/Source/UI/AIChatComponent.h
@@ -1,7 +1,9 @@
 #pragma once
 
 #include "../AI/AIIntegrationService.h"
+#include "UIAnimation.h"
 #include <atomic>
+#include <juce_animation/juce_animation.h>
 #include <juce_gui_basics/juce_gui_basics.h>
 #include <juce_gui_extra/juce_gui_extra.h>
 
@@ -10,6 +12,12 @@ namespace gsynth {
 /**
  * @class AIChatComponent
  * @brief Enhanced chat interface with collapsible patch cards and loading indicators.
+ *
+ * Phase 5 additions:
+ *  - Cancel button: visible only while waiting; aborts in-flight request.
+ *  - Animated pulse indicator: a small dot that throbs while waiting, stops on
+ *    completion or cancel.  Confined to the input row — no per-tick global repaint.
+ *  - Tooltips on all interactive controls.
  */
 class AIChatComponent
     : public juce::Component
@@ -30,10 +38,81 @@ public:
     void sendButtonClicked();
     void triggerSend() { sendButtonClicked(); }
 
+    // Testing hook: directly invokes the cancel action synchronously (mirrors triggerSend).
+    // Use in headless tests instead of cancelButton->triggerClick(), which posts async.
+    void simulateCancelClick() {
+        cancelRequest();
+        messages.push_back({"assistant", "Cancelled.", ""});
+        updateChatDisplay();
+    }
+
+    // Testing hook: returns true if the cancel button is currently visible.
+    bool isCancelVisible() const { return cancelButton.isVisible(); }
+
+    // Testing hook: returns the current isWaitingForResponse flag.
+    bool isWaiting() const { return isWaitingForResponse; }
+
 private:
     void timerCallback() override;
+
+    // Stops the in-flight request and resets all waiting state.
+    // Called both by the cancel button and by the timeout path.
+    void cancelRequest();
+
     class MessageBubble;
     class PatchCard;
+
+    // ---- Spinner component -----------------------------------------------
+    // A tiny 8×8 dot that pulses (alpha 0.3→1.0→0.3) via AnimationDriver.
+    // Confined to a fixed region in the input row.  Only animates while
+    // isWaitingForResponse is true.  ABSOLUTELY NO writeToLog/DBG inside paint().
+    class SpinnerDot : public juce::Component {
+    public:
+        SpinnerDot() = default;
+
+        void paint(juce::Graphics& g) override {
+            g.setColour(juce::Colours::lightblue.withAlpha(currentAlpha));
+            g.fillEllipse(getLocalBounds().toFloat().reduced(1.0f));
+        }
+
+        // Call once to start pulsing.  Caller must hold vblankUpdater alive for the
+        // entire pulsing lifetime.  The pointer is stored so the recursive onComplete
+        // callback can restart without a dangling reference to the function parameter.
+        void startPulse(juce::VBlankAnimatorUpdater& updater) {
+            updaterPtr = &updater;
+            pulseAnim.start(
+                updater,
+                600.0,                     // 600 ms per half-cycle
+                [](float t) { return t; }, // linear — easing handled below
+                [this](float t) {
+                    // Ping-pong: 0→1 on even passes, 1→0 on odd passes.
+                    currentAlpha = pingPongPhase ? juce::jmap(t, 1.0f, 0.3f) : juce::jmap(t, 0.3f, 1.0f);
+                    repaint();
+                },
+                [this]() {
+                    pingPongPhase = !pingPongPhase;
+                    // Only keep pulsing while waiting; caller sets visible(false) on stop.
+                    if (isVisible() && updaterPtr != nullptr)
+                        startPulse(*updaterPtr);
+                });
+        }
+
+        void stopPulse(juce::VBlankAnimatorUpdater& updater) {
+            updaterPtr = nullptr;
+            pulseAnim.stop(updater);
+            currentAlpha = 0.0f;
+            repaint();
+        }
+
+    private:
+        gravisynth::ui::AnimationDriver pulseAnim;
+        juce::VBlankAnimatorUpdater* updaterPtr = nullptr;
+        float currentAlpha = 0.3f;
+        bool pingPongPhase = false;
+
+        JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(SpinnerDot)
+    };
+    // ----------------------------------------------------------------------
 
     AIIntegrationService& aiService;
     juce::ApplicationProperties& appProperties;
@@ -43,8 +122,14 @@ private:
     juce::Component messageList;
     juce::TextEditor inputField;
     juce::TextButton sendButton;
+    juce::TextButton cancelButton; // Visible ONLY while waiting
     juce::TextButton newChatButton;
     juce::ComboBox modelPicker;
+
+    // Pulse animation for the "AI is thinking" state indicator.
+    // VBlankAnimatorUpdater is attached to this Component.
+    juce::VBlankAnimatorUpdater vblankUpdater{this};
+    SpinnerDot spinnerDot;
 
     void updateChatDisplay();
     void scrollToBottom();

--- a/Source/UI/GraphEditor.cpp
+++ b/Source/UI/GraphEditor.cpp
@@ -73,6 +73,12 @@ GraphEditor::GraphEditor(AudioEngine& engine, GravisynthUndoManager* undoMgr)
     addAndMakeVisible(content);
     addAndMakeVisible(modMatrix);
     content.setInterceptsMouseClicks(false, true); // Fallback clicks to parent
+
+    // Tooltips on GraphEditor-owned affordances.
+    // The canvas itself hints at pan/zoom. Double-click on an attenuverter knob removes it.
+    setTooltip(gravisynth::ui::formatShortcutHint("Patch canvas - drag modules here to build your patch",
+                                                  "Scroll to zoom | Drag to pan | Double-click mod knob to remove"));
+
     startTimerHz(30);
 }
 
@@ -431,9 +437,35 @@ void GraphEditor::GraphContentComponent::paint(juce::Graphics& g) {
         }
     }
 
-    g.setColour(textMutedColour);
-    g.drawText("Gravisynth (Double click to refresh)", getLocalBounds().removeFromTop(20), juce::Justification::centred,
-               true);
+    // ---- Empty-canvas first-run hint ----
+    // Shown only when there are no modules on the canvas. Vanishes as soon as a module exists.
+    // Uses textMuted token for a subtle, non-distracting appearance. No timer or per-tick repaint added.
+    if (GraphEditor::isCanvasEmpty(static_cast<int>(moduleComponents.size()))) {
+        const juce::Colour hintColour = textMutedColour.withAlpha(0.55f);
+        g.setColour(hintColour);
+
+        // Use the resolved LnF font; fall back to a reasonable default in headless mode.
+        juce::Font hintFont;
+        if (lf != nullptr)
+            hintFont = juce::Font(juce::FontOptions(lf->getTheme().type.h2)).withStyle(juce::Font::plain);
+        else
+            hintFont = juce::Font(13.0f);
+        g.setFont(hintFont);
+
+        const juce::String hintText = "Drag modules here to build your patch";
+        // Draw in the centre of the LOCAL component bounds (the 10000x10000 canvas).
+        // We want the hint visible in the typical viewport, so we offset by the inverse pan to
+        // keep it near the canvas origin area — but the simplest correct approach is to centre
+        // it in the local bounds. Since content is transformed (pan+zoom), paint() is called
+        // in LOCAL (canvas) coordinates, so we use getLocalBounds().
+        auto bounds = getLocalBounds();
+        // Place near visual centre of an 800x600 default viewport (canvas origin is 0,0 with pan).
+        // Use a 400x50 rect centred at (400, 300) so it's clearly visible when canvas is at default pan.
+        const juce::Rectangle<int> hintArea(200, 275, 400, 50);
+        g.drawFittedText(hintText, hintArea, juce::Justification::centred, 1);
+        juce::ignoreUnused(bounds);
+    }
+    // ---- End empty-canvas hint ----
 }
 
 void GraphEditor::GraphContentComponent::resized() {}
@@ -660,16 +692,60 @@ void GraphEditor::paint(juce::Graphics& g) {
 }
 
 void GraphEditor::resized() {
-    if (isMatrixVisible) {
-        modMatrix.setBounds(getWidth() - 600, 0, 600, getHeight());
+    // Only set the mod-matrix bounds when we are not in the middle of an animated show/hide.
+    // If an animation is running, it owns the bounds until it completes; we update the target
+    // but don't interrupt the tween.
+    if (!modMatrixAnim.isRunning()) {
+        if (isMatrixVisible) {
+            modMatrix.setBounds(getWidth() - 600, 0, 600, getHeight());
+        }
+    } else {
+        // Update the stored target so the onComplete callback uses the updated size.
+        modMatrixTargetBounds = isMatrixVisible ? juce::Rectangle<int>(getWidth() - 600, 0, 600, getHeight())
+                                                : juce::Rectangle<int>(getWidth(), 0, 600, getHeight());
     }
     updateTransform();
 }
 
 void GraphEditor::toggleModMatrixVisibility() {
     isMatrixVisible = !isMatrixVisible;
-    modMatrix.setVisible(isMatrixVisible);
-    resized();
+
+    // Always make it visible before the animation so it paints during the tween.
+    // On hide we keep it visible until the animation completes, then hide it.
+    modMatrix.setVisible(true);
+
+    const int panelW = 600;
+    const int editorW = getWidth();
+    const int editorH = getHeight();
+
+    // From-bounds: current position (either fully shown or fully hidden off-screen right).
+    juce::Rectangle<int> fromBounds = modMatrix.getBounds();
+    // If the component has never been laid out, give it a sensible off-screen start.
+    if (fromBounds.isEmpty())
+        fromBounds = {editorW, 0, panelW, editorH};
+
+    // To-bounds: target position.
+    juce::Rectangle<int> toBounds = isMatrixVisible ? juce::Rectangle<int>(editorW - panelW, 0, panelW, editorH)
+                                                    : juce::Rectangle<int>(editorW, 0, panelW, editorH);
+
+    modMatrixTargetBounds = toBounds;
+
+    // Start a 220 ms easeOutCubic tween on modMatrix bounds.
+    const bool hidingAfterAnim = !isMatrixVisible;
+    juce::Component::SafePointer<GraphEditor> safeThis(this);
+    modMatrixAnim.start(
+        vblankUpdater, 220.0, gravisynth::ui::easeOutCubic,
+        [safeThis, fromBounds, toBounds](float t) {
+            if (auto* self = safeThis.getComponent())
+                self->modMatrix.setBounds(gravisynth::ui::AnimationDriver::lerpBounds(fromBounds, toBounds, t));
+        },
+        [safeThis, hidingAfterAnim, toBounds]() {
+            if (auto* self = safeThis.getComponent()) {
+                self->modMatrix.setBounds(toBounds);
+                if (hidingAfterAnim)
+                    self->modMatrix.setVisible(false);
+            }
+        });
 }
 
 void GraphEditor::updateTransform() {
@@ -1197,9 +1273,10 @@ void GraphEditor::itemDropped(const SourceDetails& dragSourceDetails) {
         auto estSize = estimateModuleSize(name);
         auto initialPlaced = resolvePlacement(dropPos, estSize.x, estSize.y, juce::AudioProcessorGraph::NodeID{});
 
-        auto finalizeNewDrop = [this](juce::AudioProcessorGraph::NodeID newNodeId) {
-            // Locate the newly created ModuleComponent and finalize its position using
-            // the real component size (snapped + anti-overlapped from actual dimensions).
+        // finalizeNewDrop: locate the newly created ModuleComponent, compute its
+        // real final position (snapped + anti-overlapped using actual dimensions),
+        // then animate it from the raw drop point to the settled position.
+        auto finalizeNewDrop = [this, initialPlaced](juce::AudioProcessorGraph::NodeID newNodeId) {
             ModuleComponent* newComp = nullptr;
             for (auto* comp : content.getModules()) {
                 if (comp != nullptr && comp->getNodeId() == newNodeId) {
@@ -1207,8 +1284,20 @@ void GraphEditor::itemDropped(const SourceDetails& dragSourceDetails) {
                     break;
                 }
             }
-            if (newComp != nullptr)
-                finalizeModuleDrag(newComp);
+            if (newComp == nullptr)
+                return;
+
+            // Compute final position using the real component size.
+            auto toPos = resolvePlacement(newComp->getPosition(), newComp->getWidth(), newComp->getHeight(),
+                                          newComp->getNodeId());
+
+            // Animate from the estimated initial-placed position to the real final position.
+            // If they are identical, animateDropLanding is a no-op (just settles in place).
+            animateDropLanding(newComp, initialPlaced, toPos);
+
+            // Persist the final position immediately so it survives reload even if the
+            // animation is still in-flight when the user saves.
+            updateModulePosition(newComp);
         };
 
         if (undoManager) {
@@ -1253,6 +1342,14 @@ juce::Point<int> GraphEditor::resolvePlacement(juce::Point<int> desired, int w, 
     return gsynth::LayoutUtil::findFreeSlot(snapped, w, h, boxes, selfId);
 }
 
+// static
+juce::Point<int> GraphEditor::computeDropFinalPosition(juce::Point<int> dropPoint, int w, int h,
+                                                       const std::vector<gsynth::LayoutUtil::Box>& existingBoxes,
+                                                       gsynth::LayoutUtil::NodeID selfId) {
+    auto snapped = gsynth::LayoutUtil::snap(dropPoint);
+    return gsynth::LayoutUtil::findFreeSlot(snapped, w, h, existingBoxes, selfId);
+}
+
 void GraphEditor::finalizeModuleDrag(ModuleComponent* module) {
     if (module == nullptr)
         return;
@@ -1261,6 +1358,43 @@ void GraphEditor::finalizeModuleDrag(ModuleComponent* module) {
     // Persist the snapped/cleared position to graph node properties so it survives reload.
     updateModulePosition(module);
     content.repaint();
+}
+
+void GraphEditor::animateDropLanding(ModuleComponent* module, juce::Point<int> fromPos, juce::Point<int> toPos) {
+    if (module == nullptr)
+        return;
+
+    // If from == to nothing to animate — just ensure the module is at the final position.
+    if (fromPos == toPos)
+        return;
+
+    // Place module at fromPos immediately so the first frame starts correctly.
+    module->setTopLeftPosition(fromPos);
+
+    juce::Component::SafePointer<GraphEditor> safeEditor(this);
+    juce::Component::SafePointer<ModuleComponent> safeModule(module);
+
+    dropLandingAnim.start(
+        vblankUpdater,
+        180.0, // ms — within the 150-220 ms spec
+        gravisynth::ui::easeOutCubic,
+        [safeEditor, safeModule, fromPos, toPos](float t) {
+            if (safeEditor == nullptr || safeModule == nullptr)
+                return;
+            auto pos = gravisynth::ui::AnimationDriver::lerpBounds(juce::Rectangle<int>(fromPos.x, fromPos.y, 0, 0),
+                                                                   juce::Rectangle<int>(toPos.x, toPos.y, 0, 0), t)
+                           .getTopLeft();
+            safeModule->setTopLeftPosition(pos);
+            safeEditor->content.repaint();
+        },
+        [safeEditor, safeModule, toPos]() {
+            // Settle at exact final position and persist to graph properties.
+            if (safeEditor == nullptr || safeModule == nullptr)
+                return;
+            safeModule->setTopLeftPosition(toPos);
+            safeEditor->updateModulePosition(safeModule);
+            safeEditor->content.repaint();
+        });
 }
 
 void GraphEditor::autoArrange() {

--- a/Source/UI/GraphEditor.cpp
+++ b/Source/UI/GraphEditor.cpp
@@ -436,36 +436,6 @@ void GraphEditor::GraphContentComponent::paint(juce::Graphics& g) {
                        /*activity*/ 0.0f, /*fallbackWidth*/ 3.0f);
         }
     }
-
-    // ---- Empty-canvas first-run hint ----
-    // Shown only when there are no modules on the canvas. Vanishes as soon as a module exists.
-    // Uses textMuted token for a subtle, non-distracting appearance. No timer or per-tick repaint added.
-    if (GraphEditor::isCanvasEmpty(static_cast<int>(moduleComponents.size()))) {
-        const juce::Colour hintColour = textMutedColour.withAlpha(0.55f);
-        g.setColour(hintColour);
-
-        // Use the resolved LnF font; fall back to a reasonable default in headless mode.
-        juce::Font hintFont;
-        if (lf != nullptr)
-            hintFont = juce::Font(juce::FontOptions(lf->getTheme().type.h2)).withStyle(juce::Font::plain);
-        else
-            hintFont = juce::Font(13.0f);
-        g.setFont(hintFont);
-
-        const juce::String hintText = "Drag modules here to build your patch";
-        // Draw in the centre of the LOCAL component bounds (the 10000x10000 canvas).
-        // We want the hint visible in the typical viewport, so we offset by the inverse pan to
-        // keep it near the canvas origin area — but the simplest correct approach is to centre
-        // it in the local bounds. Since content is transformed (pan+zoom), paint() is called
-        // in LOCAL (canvas) coordinates, so we use getLocalBounds().
-        auto bounds = getLocalBounds();
-        // Place near visual centre of an 800x600 default viewport (canvas origin is 0,0 with pan).
-        // Use a 400x50 rect centred at (400, 300) so it's clearly visible when canvas is at default pan.
-        const juce::Rectangle<int> hintArea(200, 275, 400, 50);
-        g.drawFittedText(hintText, hintArea, juce::Justification::centred, 1);
-        juce::ignoreUnused(bounds);
-    }
-    // ---- End empty-canvas hint ----
 }
 
 void GraphEditor::GraphContentComponent::resized() {}
@@ -689,6 +659,38 @@ void GraphEditor::updateComponents() {
 void GraphEditor::paint(juce::Graphics& g) {
     // GraphEditor itself can draw a background or overlay if needed
     // But content handles it now.
+}
+
+void GraphEditor::paintOverChildren(juce::Graphics& g) {
+    // ---- Empty-canvas first-run hint ----
+    // Drawn here (OUTER, untransformed GraphEditor local coordinates) so it is ALWAYS
+    // centred in the visible viewport regardless of pan/zoom on the inner canvas.
+    // The inner GraphContentComponent runs in a transformed (pan+zoom) space over a
+    // ~10000x10000 virtual canvas — any rect drawn there would land off-screen once the
+    // user pans or zooms. Drawing here, in getLocalBounds(), guarantees centre alignment.
+    //
+    // Gate: only when canvas is empty. Show/hide is driven by the existing updateComponents()
+    // repaint path — no extra timer or per-tick repaint is added.
+    if (!GraphEditor::isCanvasEmpty(static_cast<int>(content.getModules().size())))
+        return;
+
+    auto* lf = dynamic_cast<gsynth::theme::GravisynthLookAndFeel*>(&getLookAndFeel());
+
+    // textMuted token at ~60% alpha — tasteful, non-distracting.
+    const juce::Colour textMutedColour = lf != nullptr ? lf->getTheme().colors.textMuted : juce::Colours::white;
+    g.setColour(textMutedColour.withAlpha(0.6f));
+
+    // Use the theme h1 font (~18pt) for comfortable legibility; fall back to 16pt headless.
+    juce::Font hintFont;
+    if (lf != nullptr)
+        hintFont = juce::Font(juce::FontOptions(lf->getTheme().type.h1)).withStyle(juce::Font::plain);
+    else
+        hintFont = juce::Font(16.0f);
+    g.setFont(hintFont);
+
+    // Centre in the GraphEditor's visible local bounds (untransformed viewport coordinates).
+    g.drawFittedText("Drag modules here to build your patch", getLocalBounds(), juce::Justification::centred, 1);
+    // ---- End empty-canvas hint ----
 }
 
 void GraphEditor::resized() {

--- a/Source/UI/GraphEditor.cpp
+++ b/Source/UI/GraphEditor.cpp
@@ -1445,6 +1445,25 @@ bool GraphEditor::loadFactoryPreset(int index) {
     return loaded;
 }
 
+void GraphEditor::newPatch() {
+    auto& graph = audioEngine.getGraph();
+
+    auto doClear = [this, &graph] {
+        // Detach BEFORE clearing — same ordering as loadFactoryPreset — so no ScopeComponent
+        // timer fires against a freed VisualBuffer after graph.clear().
+        detachAllModuleComponents();
+        graph.clear();
+        updateComponents(); // reconciles the now-empty view; the empty-canvas hint will show
+    };
+
+    if (undoManager) {
+        undoManager->recordStructuralChange(graph, doClear);
+    } else {
+        doClear();
+    }
+    repaint();
+}
+
 void GraphEditor::loadPreset(juce::File file) {
     auto json = juce::JSON::parse(file);
     if (!json.isObject()) {

--- a/Source/UI/GraphEditor.h
+++ b/Source/UI/GraphEditor.h
@@ -24,6 +24,10 @@ public:
     void detachAllModuleComponents();
 
     void paint(juce::Graphics& g) override;
+    /** Draws the empty-canvas onboarding hint centred in the visible viewport (untransformed
+     *  GraphEditor local coordinates).  Called after all children have painted, so it draws
+     *  on top of the inner canvas without being affected by the content transform. */
+    void paintOverChildren(juce::Graphics& g) override;
     void resized() override;
 
     void timerCallback() override;

--- a/Source/UI/GraphEditor.h
+++ b/Source/UI/GraphEditor.h
@@ -2,6 +2,8 @@
 
 #include "../AudioEngine.h"
 #include "../GravisynthUndoManager.h"
+#include "LayoutUtil.h"
+#include "UIAnimation.h"
 #include <juce_gui_basics/juce_gui_basics.h>
 
 class ModuleComponent;
@@ -10,7 +12,8 @@ class ModuleComponent;
 class GraphEditor
     : public juce::Component
     , public juce::Timer
-    , public juce::DragAndDropTarget {
+    , public juce::DragAndDropTarget
+    , public juce::SettableTooltipClient {
 public:
     GraphEditor(AudioEngine& engine, GravisynthUndoManager* undoMgr = nullptr);
     ~GraphEditor() override;
@@ -61,6 +64,23 @@ public:
     // Test accessors for drag-preview state
     bool isDragPreviewActive() const { return dragPreviewActive; }
     juce::Rectangle<int> getDragPreviewGhost() const { return dragPreviewGhost; }
+
+    // ---- Onboarding / UI Phase 5 helpers (headless-testable) ----
+
+    /** Returns true when the canvas has no modules (empty state). Pure predicate.
+     *  nodeCount is the number of non-Attenuverter nodes rendered as ModuleComponents. */
+    static bool isCanvasEmpty(int nodeCount) noexcept { return nodeCount <= 0; }
+
+    /** Compute the final snapped + anti-overlapped position for a newly dropped module.
+     *  Equivalent to snap(dropPoint) + findFreeSlot.  Pure helper — does not touch GUI state.
+     *  @param dropPoint   Desired top-left in canvas coordinates (will be snapped internally).
+     *  @param w, h        Module footprint in pixels.
+     *  @param existingBoxes  All already-placed module bounding boxes (selfId excluded from collision).
+     *  @param selfId      NodeID of the module being placed (excluded from self-collision).
+     */
+    static juce::Point<int> computeDropFinalPosition(juce::Point<int> dropPoint, int w, int h,
+                                                     const std::vector<gsynth::LayoutUtil::Box>& existingBoxes,
+                                                     gsynth::LayoutUtil::NodeID selfId);
 
     // DragAndDropTarget overrides
     bool isInterestedInDragSource(const SourceDetails& dragSourceDetails) override;
@@ -126,7 +146,22 @@ private:
     std::vector<AudioEngine::ModulationDisplayInfo> cachedModDisplayInfo;
     std::vector<AudioEngine::ModulationRouting> cachedModRoutings;
 
+    // ---- Animation members (UI Phase 5) ----
+    // Drop-landing tween: animates the newly dropped module from drop point to snapped position.
+    // Both must be class members so they outlive the VBlank frame callbacks.
+    juce::VBlankAnimatorUpdater vblankUpdater{this};
+    gravisynth::ui::AnimationDriver dropLandingAnim;
+
+    // Mod-matrix panel ease: animates the panel bounds on show/hide.
+    gravisynth::ui::AnimationDriver modMatrixAnim;
+
+    // Tracks the target bounds for mod-matrix animation so we can set final position on complete.
+    juce::Rectangle<int> modMatrixTargetBounds;
+
     void updateTransform();
+
+    // Internal: start the drop-landing animation for a newly placed module component.
+    void animateDropLanding(ModuleComponent* module, juce::Point<int> fromPos, juce::Point<int> toPos);
 
 public:
     const std::vector<AudioEngine::ModulationDisplayInfo>& getCachedModDisplayInfo() const {

--- a/Source/UI/GraphEditor.h
+++ b/Source/UI/GraphEditor.h
@@ -51,6 +51,11 @@ public:
     // BEFORE the graph is cleared, so no ScopeComponent reads a freed VisualBuffer. Returns true if loaded.
     bool loadFactoryPreset(int index);
 
+    // Clears the canvas to the empty state (New Patch). Detaches module components (stopping scope timers)
+    // BEFORE clearing the graph — same safe ordering as loadFactoryPreset. The clear is recorded as an
+    // undoable structural change when undoManager is present (Cmd+Z restores the prior patch).
+    void newPatch();
+
     // Layout / anti-overlap
     juce::Point<int> resolvePlacement(juce::Point<int> desired, int w, int h, juce::AudioProcessorGraph::NodeID selfId);
     void finalizeModuleDrag(ModuleComponent* module);

--- a/Source/UI/ModuleLibraryComponent.h
+++ b/Source/UI/ModuleLibraryComponent.h
@@ -5,7 +5,8 @@
 
 class ModuleLibraryComponent
     : public juce::Component
-    , public juce::DragAndDropContainer {
+    , public juce::DragAndDropContainer
+    , public juce::SettableTooltipClient {
 public:
     struct Entry {
         juce::String text;
@@ -24,7 +25,59 @@ public:
             {"Dynamics", true},   {"Compressor", false},    {"Limiter", false},
             {"Utility", true},    {"Voice Mixer", false},
         };
+        setMouseCursor(juce::MouseCursor::NormalCursor);
     }
+
+    // -------------------------------------------------------------------------
+    // Pure static helpers — callable headlessly (no GUI / MessageManager needed)
+    // -------------------------------------------------------------------------
+
+    /** Returns a one-line description for a known module name, or a generic
+     *  fallback string for unknown names. */
+    static juce::String descriptionFor(const juce::String& moduleName) {
+        if (moduleName.equalsIgnoreCase("Oscillator"))
+            return "Generates audio waveforms (sine, saw, square, triangle).";
+        if (moduleName.equalsIgnoreCase("LFO"))
+            return "Low-frequency oscillator for slow cyclic modulation.";
+        if (moduleName.equalsIgnoreCase("Sequencer"))
+            return "Step sequencer that outputs pitch and gate CV signals.";
+        if (moduleName.equalsIgnoreCase("MidiKeyboard"))
+            return "On-screen MIDI keyboard for note input.";
+        if (moduleName.equalsIgnoreCase("Poly MIDI"))
+            return "Converts MIDI input into polyphonic pitch and gate signals.";
+        if (moduleName.equalsIgnoreCase("External MIDI"))
+            return "Routes external MIDI device input into the patch graph.";
+        if (moduleName.equalsIgnoreCase("ADSR"))
+            return "Attack-Decay-Sustain-Release envelope generator.";
+        if (moduleName.equalsIgnoreCase("VCA"))
+            return "Voltage-controlled amplifier — controls signal amplitude via CV.";
+        if (moduleName.equalsIgnoreCase("Filter"))
+            return "Multi-mode resonant filter (low-pass, high-pass, band-pass).";
+        if (moduleName.equalsIgnoreCase("Chorus"))
+            return "Adds lush width by layering slightly detuned copies of the signal.";
+        if (moduleName.equalsIgnoreCase("Phaser"))
+            return "Sweeping all-pass phase modulation effect.";
+        if (moduleName.equalsIgnoreCase("Flanger"))
+            return "Short delay feedback comb-filter with a sweeping metallic sound.";
+        if (moduleName.equalsIgnoreCase("Distortion"))
+            return "Waveshaping distortion from soft saturation to hard clipping.";
+        if (moduleName.equalsIgnoreCase("Delay"))
+            return "Tempo-syncable stereo echo / delay line.";
+        if (moduleName.equalsIgnoreCase("Reverb"))
+            return "Algorithmic reverb for adding space and depth.";
+        if (moduleName.equalsIgnoreCase("Compressor"))
+            return "Dynamic range compressor with threshold, ratio, attack and release.";
+        if (moduleName.equalsIgnoreCase("Limiter"))
+            return "Brickwall limiter that prevents the signal from exceeding 0 dBFS.";
+        if (moduleName.equalsIgnoreCase("Voice Mixer"))
+            return "Sums multiple polyphonic voices down to a stereo mix.";
+        // Generic fallback for any unrecognised module name.
+        return "Audio processing module.";
+    }
+
+    // -------------------------------------------------------------------------
+    // Paint
+    // -------------------------------------------------------------------------
 
     void paint(juce::Graphics& g) override {
         // Resolve theme tokens from the active LnF; fall back to plain colors when our LnF
@@ -32,6 +85,7 @@ public:
         juce::Colour bgColour = juce::Colours::darkgrey.darker();
         juce::Colour headerColour = juce::Colours::grey;
         juce::Colour itemColour = juce::Colours::white;
+        juce::Colour accentColour = juce::Colours::lightblue;
 
         auto* lf = dynamic_cast<gsynth::theme::GravisynthLookAndFeel*>(&getLookAndFeel());
         if (lf != nullptr) {
@@ -39,13 +93,14 @@ public:
             bgColour = c.bg0;
             headerColour = c.textMuted;
             itemColour = c.textPrimary;
+            accentColour = c.accent;
         }
 
         g.fillAll(bgColour);
 
         int y = 10;
-        int headerIconOffset = 0; // index into header sequence for icon lookup
-        for (const auto& entry : entries) {
+        for (int i = 0; i < (int)entries.size(); ++i) {
+            const auto& entry = entries[i];
             if (entry.isHeader) {
                 if (y > 10)
                     y += 5; // extra spacing before headers (except first)
@@ -67,13 +122,58 @@ public:
                 }
 
                 y += 25;
-                ++headerIconOffset;
             } else {
+                // Draw hover highlight behind the text (non-header rows only).
+                if (i == hoveredIndex) {
+                    g.setColour(accentColour.withAlpha(0.12f));
+                    g.fillRect(0, y, getWidth(), 32);
+                }
+
                 g.setColour(itemColour);
                 g.setFont(juce::Font(juce::FontOptions(16.0f)));
                 g.drawText(entry.text, 20, y, getWidth() - 40, 28, juce::Justification::centredLeft);
                 y += 32;
             }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Mouse events
+    // -------------------------------------------------------------------------
+
+    void mouseMove(const juce::MouseEvent& e) override {
+        int newIndex = getEntryIndexAt(e.y);
+        // Only non-header entries can be hovered; clamp headers to -1.
+        if (newIndex >= 0 && (int)entries.size() > newIndex && entries[newIndex].isHeader)
+            newIndex = -1;
+
+        if (newIndex != hoveredIndex) {
+            hoveredIndex = newIndex;
+
+            // Update tooltip: the shared TooltipWindow (owned by MainComponent) reads
+            // this component's tooltip string on each hover. Setting it here on hover
+            // change means each draggable row surfaces its per-module description.
+            if (hoveredIndex >= 0 && hoveredIndex < (int)entries.size())
+                setTooltip(descriptionFor(entries[hoveredIndex].text));
+            else
+                setTooltip({});
+
+            repaint();
+        }
+
+        // Update cursor: grab hand for draggable items, normal otherwise.
+        if (hoveredIndex >= 0)
+            setMouseCursor(juce::MouseCursor::DraggingHandCursor);
+        else
+            setMouseCursor(juce::MouseCursor::NormalCursor);
+    }
+
+    void mouseExit(const juce::MouseEvent&) override {
+        if (hoveredIndex != -1) {
+            hoveredIndex = -1;
+            setTooltip({});
+            setMouseCursor(juce::MouseCursor::NormalCursor);
+            repaint();
         }
     }
 
@@ -83,13 +183,23 @@ public:
             juce::Image dragImage(juce::Image::ARGB, 150, 30, true);
             juce::Graphics dg(dragImage);
             dg.setColour(juce::Colours::white);
-            dg.setFont(juce::Font(16.0f));
+            dg.setFont(juce::Font(juce::FontOptions(16.0f)));
             dg.drawText(entries[index].text, dragImage.getBounds(), juce::Justification::centred, false);
 
             if (auto* container = juce::DragAndDropContainer::findParentDragContainerFor(this))
                 container->startDragging(entries[index].text, this, dragImage);
         }
     }
+
+    // -------------------------------------------------------------------------
+    // Test / inspection helpers
+    // -------------------------------------------------------------------------
+
+    /** Returns the currently hovered entry index, or -1 when nothing is hovered. */
+    int getHoveredIndex() const noexcept { return hoveredIndex; }
+
+    /** Total number of entries (headers + items). */
+    int getEntryCount() const noexcept { return (int)entries.size(); }
 
 private:
     // Map a category header string to its Icon enum value.
@@ -112,6 +222,7 @@ private:
         return gsynth::theme::Icon::CatUtility;
     }
 
+    /** Returns the entry index whose row contains mouseY, or -1 if none. */
     int getEntryIndexAt(int mouseY) const {
         int y = 10;
         for (int i = 0; i < (int)entries.size(); ++i) {
@@ -133,4 +244,5 @@ private:
     }
 
     std::vector<Entry> entries;
+    int hoveredIndex = -1; // -1 = no hover; updated on mouseMove/mouseExit only
 };

--- a/Source/UI/SettingsWindow.cpp
+++ b/Source/UI/SettingsWindow.cpp
@@ -2,6 +2,7 @@
 #include "../AI/OllamaProvider.h"
 #include "../ShortcutManager.h"
 #include "AppearanceSettingsTab.h"
+#include "ShortcutsSettingsTab.h"
 
 //==============================================================================
 // AISettingsTab - AI configuration interface
@@ -76,204 +77,6 @@ private:
 };
 
 //==============================================================================
-// GeneralSettingsTab - Keyboard shortcuts reference panel
-//==============================================================================
-class GeneralSettingsTab : public juce::Component {
-public:
-    GeneralSettingsTab(ShortcutManager& sm)
-        : shortcutManager(sm) {
-        setWantsKeyboardFocus(true);
-
-        addAndMakeVisible(titleLabel);
-        titleLabel.setText("Keyboard Shortcuts", juce::dontSendNotification);
-        titleLabel.setFont(juce::FontOptions(18.0f, juce::Font::bold));
-        titleLabel.setColour(juce::Label::textColourId, juce::Colours::white);
-
-        for (auto& actionId : shortcutManager.getActionIds()) {
-            actionIds.add(actionId);
-
-            auto descLabel = std::make_unique<juce::Label>();
-            descLabel->setText(ShortcutManager::getActionDescription(actionId), juce::dontSendNotification);
-            descLabel->setFont(juce::FontOptions(14.0f));
-            descLabel->setColour(juce::Label::textColourId, juce::Colours::white);
-            addAndMakeVisible(*descLabel);
-            descLabels.push_back(std::move(descLabel));
-
-            auto bindButton = std::make_unique<juce::TextButton>();
-            bindButton->setButtonText(ShortcutManager::keyPressToDisplayString(shortcutManager.getBinding(actionId)));
-            bindButton->setColour(juce::TextButton::buttonColourId, juce::Colours::darkgrey);
-            bindButton->setColour(juce::TextButton::textColourOffId, juce::Colours::white);
-            int index = static_cast<int>(bindButtons.size());
-            bindButton->onClick = [this, index] { startListening(index); };
-            addAndMakeVisible(*bindButton);
-            bindButtons.push_back(std::move(bindButton));
-        }
-
-        addAndMakeVisible(resetButton);
-        resetButton.setButtonText("Reset to Defaults");
-        resetButton.setColour(juce::TextButton::buttonColourId, juce::Colour(0xffcc3333));
-        resetButton.setColour(juce::TextButton::textColourOffId, juce::Colours::white);
-        resetButton.onClick = [this] {
-            auto options = juce::MessageBoxOptions()
-                               .withIconType(juce::MessageBoxIconType::WarningIcon)
-                               .withTitle("Reset Shortcuts")
-                               .withMessage("Are you sure you want to reset all keyboard shortcuts to their defaults?")
-                               .withButton("Reset")
-                               .withButton("Cancel");
-            juce::AlertWindow::showAsync(options, [this](int result) {
-                if (result == 1) {
-                    shortcutManager.resetToDefaults();
-                    shortcutManager.saveToProperties();
-                    refreshBindingLabels();
-                }
-            });
-        };
-
-        addAndMakeVisible(exportButton);
-        exportButton.setButtonText("Export...");
-        exportButton.setColour(juce::TextButton::buttonColourId, juce::Colours::darkgrey);
-        exportButton.setColour(juce::TextButton::textColourOffId, juce::Colours::white);
-        exportButton.onClick = [this] {
-            fileChooser = std::make_unique<juce::FileChooser>(
-                "Export Shortcuts", juce::File::getSpecialLocation(juce::File::userDocumentsDirectory), "*.json");
-            auto flags = juce::FileBrowserComponent::saveMode | juce::FileBrowserComponent::canSelectFiles;
-            fileChooser->launchAsync(flags, [this](const juce::FileChooser& fc) {
-                auto file = fc.getResult();
-                if (file != juce::File{}) {
-                    juce::DynamicObject::Ptr obj = new juce::DynamicObject();
-                    for (auto& actionId : shortcutManager.getActionIds()) {
-                        auto binding = shortcutManager.getBinding(actionId);
-                        auto value = ShortcutManager::encodeKeyPress(binding);
-                        obj->setProperty(actionId, value);
-                    }
-                    auto json = juce::JSON::toString(juce::var(obj.get()));
-                    file.replaceWithText(json);
-                }
-            });
-        };
-
-        addAndMakeVisible(importButton);
-        importButton.setButtonText("Import...");
-        importButton.setColour(juce::TextButton::buttonColourId, juce::Colours::darkgrey);
-        importButton.setColour(juce::TextButton::textColourOffId, juce::Colours::white);
-        importButton.onClick = [this] {
-            fileChooser = std::make_unique<juce::FileChooser>(
-                "Import Shortcuts", juce::File::getSpecialLocation(juce::File::userDocumentsDirectory), "*.json");
-            auto flags = juce::FileBrowserComponent::openMode | juce::FileBrowserComponent::canSelectFiles;
-            fileChooser->launchAsync(flags, [this](const juce::FileChooser& fc) {
-                auto file = fc.getResult();
-                if (file != juce::File{}) {
-                    auto json = juce::JSON::parse(file.loadFileAsString());
-                    if (auto* obj = json.getDynamicObject()) {
-                        for (auto& actionId : shortcutManager.getActionIds()) {
-                            if (obj->hasProperty(actionId)) {
-                                auto value = obj->getProperty(actionId).toString();
-                                auto kp = ShortcutManager::parseKeyPress(value);
-                                if (kp.isValid())
-                                    shortcutManager.setBinding(actionId, kp);
-                            }
-                        }
-                        shortcutManager.saveToProperties();
-                        refreshBindingLabels();
-                    }
-                }
-            });
-        };
-    }
-
-    void paint(juce::Graphics& g) override { g.fillAll(findColour(juce::ResizableWindow::backgroundColourId)); }
-
-    void resized() override {
-        auto bounds = getLocalBounds().reduced(15);
-        titleLabel.setBounds(bounds.removeFromTop(30));
-        bounds.removeFromTop(10);
-
-        for (size_t i = 0; i < descLabels.size(); ++i) {
-            auto row = bounds.removeFromTop(28);
-            descLabels[i]->setBounds(row.removeFromLeft(180));
-            bindButtons[i]->setBounds(row);
-            bounds.removeFromTop(4);
-        }
-
-        bounds.removeFromTop(15);
-        auto buttonRow = bounds.removeFromTop(28);
-        exportButton.setBounds(buttonRow.removeFromLeft(100));
-        buttonRow.removeFromLeft(8);
-        importButton.setBounds(buttonRow.removeFromLeft(100));
-        buttonRow.removeFromLeft(8);
-        resetButton.setBounds(buttonRow.removeFromLeft(160));
-    }
-
-    bool keyPressed(const juce::KeyPress& key) override {
-        if (listeningIndex < 0)
-            return false;
-
-        if (key == juce::KeyPress::escapeKey) {
-            cancelListening();
-            return true;
-        }
-
-        // Ignore modifier-only keypresses
-        if (key.getKeyCode() == 0)
-            return true;
-
-        auto actionId = actionIds[listeningIndex];
-        auto conflicting = shortcutManager.getConflictingAction(actionId, key);
-
-        if (conflicting.isNotEmpty()) {
-            // Swap: assign the old binding of this action to the conflicting action
-            auto oldBinding = shortcutManager.getBinding(actionId);
-            shortcutManager.setBinding(conflicting, oldBinding);
-        }
-
-        shortcutManager.setBinding(actionId, key);
-        shortcutManager.saveToProperties();
-        listeningIndex = -1;
-        refreshBindingLabels();
-        return true;
-    }
-
-    int getShortcutCount() const { return static_cast<int>(bindButtons.size()); }
-
-private:
-    void startListening(int index) {
-        listeningIndex = index;
-        bindButtons[static_cast<size_t>(index)]->setButtonText("Press a key...");
-        bindButtons[static_cast<size_t>(index)]->setColour(juce::TextButton::buttonColourId, juce::Colours::orange);
-        grabKeyboardFocus();
-    }
-
-    void cancelListening() {
-        if (listeningIndex >= 0) {
-            refreshBindingLabels();
-            listeningIndex = -1;
-        }
-    }
-
-    void refreshBindingLabels() {
-        for (size_t i = 0; i < bindButtons.size(); ++i) {
-            auto actionId = actionIds[static_cast<int>(i)];
-            bindButtons[i]->setButtonText(
-                ShortcutManager::keyPressToDisplayString(shortcutManager.getBinding(actionId)));
-            bindButtons[i]->setColour(juce::TextButton::buttonColourId, juce::Colours::darkgrey);
-        }
-    }
-
-    ShortcutManager& shortcutManager;
-    juce::Label titleLabel;
-    juce::StringArray actionIds;
-    std::vector<std::unique_ptr<juce::Label>> descLabels;
-    std::vector<std::unique_ptr<juce::TextButton>> bindButtons;
-    juce::TextButton resetButton;
-    juce::TextButton exportButton;
-    juce::TextButton importButton;
-    std::unique_ptr<juce::FileChooser> fileChooser;
-    int listeningIndex = -1;
-
-    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(GeneralSettingsTab)
-};
-
-//==============================================================================
 // SettingsWindow - Consolidated tabbed settings interface
 //==============================================================================
 SettingsWindow::SettingsWindow(juce::AudioDeviceManager& deviceManager, juce::ApplicationProperties& appProperties,
@@ -290,8 +93,8 @@ SettingsWindow::SettingsWindow(juce::AudioDeviceManager& deviceManager, juce::Ap
     auto* aiSettingsTab = new AISettingsTab(appProperties, aiService, aiChatComponent);
     tabs.addTab("AI", juce::Colours::darkgrey, aiSettingsTab, true);
 
-    auto* generalSettingsTab = new GeneralSettingsTab(shortcutManager);
-    tabs.addTab("General", juce::Colours::darkgrey, generalSettingsTab, true);
+    auto* shortcutsSettingsTab = new ShortcutsSettingsTab(shortcutManager);
+    tabs.addTab("Keyboard Shortcuts", juce::Colours::darkgrey, shortcutsSettingsTab, true);
 
     auto* appearanceSettingsTab = new AppearanceSettingsTab(themeManager);
     tabs.addTab("Appearance", juce::Colours::darkgrey, appearanceSettingsTab, true);

--- a/Source/UI/ShortcutsSettingsTab.cpp
+++ b/Source/UI/ShortcutsSettingsTab.cpp
@@ -1,0 +1,194 @@
+#include "ShortcutsSettingsTab.h"
+
+ShortcutsSettingsTab::ShortcutsSettingsTab(ShortcutManager& sm)
+    : shortcutManager(sm) {
+    setWantsKeyboardFocus(true);
+
+    addAndMakeVisible(titleLabel);
+    titleLabel.setText("Keyboard Shortcuts", juce::dontSendNotification);
+    titleLabel.setFont(juce::FontOptions(18.0f, juce::Font::bold));
+    titleLabel.setColour(juce::Label::textColourId, juce::Colours::white);
+
+    for (auto& actionId : shortcutManager.getActionIds()) {
+        actionIds.add(actionId);
+
+        auto descLabel = std::make_unique<juce::Label>();
+        descLabel->setText(ShortcutManager::getActionDescription(actionId), juce::dontSendNotification);
+        descLabel->setFont(juce::FontOptions(14.0f));
+        descLabel->setColour(juce::Label::textColourId, juce::Colours::white);
+        addAndMakeVisible(*descLabel);
+        descLabels.push_back(std::move(descLabel));
+
+        auto bindButton = std::make_unique<juce::TextButton>();
+        bindButton->setButtonText(ShortcutManager::keyPressToDisplayString(shortcutManager.getBinding(actionId)));
+        bindButton->setColour(juce::TextButton::buttonColourId, juce::Colours::darkgrey);
+        bindButton->setColour(juce::TextButton::textColourOffId, juce::Colours::white);
+        bindButton->setTooltip("Click, then press a key to rebind");
+        int index = static_cast<int>(bindButtons.size());
+        bindButton->onClick = [this, index] { startListening(index); };
+        addAndMakeVisible(*bindButton);
+        bindButtons.push_back(std::move(bindButton));
+    }
+
+    addAndMakeVisible(resetButton);
+    resetButton.setButtonText("Reset to Defaults");
+    resetButton.setColour(juce::TextButton::buttonColourId, juce::Colour(0xffcc3333));
+    resetButton.setColour(juce::TextButton::textColourOffId, juce::Colours::white);
+    resetButton.setTooltip("Reset all keyboard shortcuts to their factory defaults");
+    resetButton.onClick = [this] {
+        auto options = juce::MessageBoxOptions()
+                           .withIconType(juce::MessageBoxIconType::WarningIcon)
+                           .withTitle("Reset Shortcuts")
+                           .withMessage("Are you sure you want to reset all keyboard shortcuts to their defaults?")
+                           .withButton("Reset")
+                           .withButton("Cancel");
+        juce::AlertWindow::showAsync(options, [this](int result) {
+            if (result == 1) {
+                shortcutManager.resetToDefaults();
+                shortcutManager.saveToProperties();
+                refreshBindingLabels();
+            }
+        });
+    };
+
+    addAndMakeVisible(exportButton);
+    exportButton.setButtonText("Export...");
+    exportButton.setColour(juce::TextButton::buttonColourId, juce::Colours::darkgrey);
+    exportButton.setColour(juce::TextButton::textColourOffId, juce::Colours::white);
+    exportButton.setTooltip("Export current shortcuts to a JSON file");
+    exportButton.onClick = [this] {
+        fileChooser = std::make_unique<juce::FileChooser>(
+            "Export Shortcuts", juce::File::getSpecialLocation(juce::File::userDocumentsDirectory), "*.json");
+        auto flags = juce::FileBrowserComponent::saveMode | juce::FileBrowserComponent::canSelectFiles;
+        fileChooser->launchAsync(flags, [this](const juce::FileChooser& fc) {
+            auto file = fc.getResult();
+            if (file != juce::File{}) {
+                juce::DynamicObject::Ptr obj = new juce::DynamicObject();
+                for (auto& actionId : shortcutManager.getActionIds()) {
+                    auto binding = shortcutManager.getBinding(actionId);
+                    auto value = ShortcutManager::encodeKeyPress(binding);
+                    obj->setProperty(actionId, value);
+                }
+                auto json = juce::JSON::toString(juce::var(obj.get()));
+                file.replaceWithText(json);
+            }
+        });
+    };
+
+    addAndMakeVisible(importButton);
+    importButton.setButtonText("Import...");
+    importButton.setColour(juce::TextButton::buttonColourId, juce::Colours::darkgrey);
+    importButton.setColour(juce::TextButton::textColourOffId, juce::Colours::white);
+    importButton.setTooltip("Import shortcuts from a JSON file");
+    importButton.onClick = [this] {
+        fileChooser = std::make_unique<juce::FileChooser>(
+            "Import Shortcuts", juce::File::getSpecialLocation(juce::File::userDocumentsDirectory), "*.json");
+        auto flags = juce::FileBrowserComponent::openMode | juce::FileBrowserComponent::canSelectFiles;
+        fileChooser->launchAsync(flags, [this](const juce::FileChooser& fc) {
+            auto file = fc.getResult();
+            if (file != juce::File{}) {
+                auto json = juce::JSON::parse(file.loadFileAsString());
+                if (auto* obj = json.getDynamicObject()) {
+                    for (auto& actionId : shortcutManager.getActionIds()) {
+                        if (obj->hasProperty(actionId)) {
+                            auto value = obj->getProperty(actionId).toString();
+                            auto kp = ShortcutManager::parseKeyPress(value);
+                            if (kp.isValid())
+                                shortcutManager.setBinding(actionId, kp);
+                        }
+                    }
+                    shortcutManager.saveToProperties();
+                    refreshBindingLabels();
+                }
+            }
+        });
+    };
+}
+
+void ShortcutsSettingsTab::paint(juce::Graphics& g) {
+    g.fillAll(findColour(juce::ResizableWindow::backgroundColourId));
+}
+
+void ShortcutsSettingsTab::resized() {
+    auto bounds = getLocalBounds().reduced(15);
+    titleLabel.setBounds(bounds.removeFromTop(30));
+    bounds.removeFromTop(10);
+
+    for (size_t i = 0; i < descLabels.size(); ++i) {
+        auto row = bounds.removeFromTop(28);
+        descLabels[i]->setBounds(row.removeFromLeft(180));
+        bindButtons[i]->setBounds(row);
+        bounds.removeFromTop(4);
+    }
+
+    bounds.removeFromTop(15);
+    auto buttonRow = bounds.removeFromTop(28);
+    exportButton.setBounds(buttonRow.removeFromLeft(100));
+    buttonRow.removeFromLeft(8);
+    importButton.setBounds(buttonRow.removeFromLeft(100));
+    buttonRow.removeFromLeft(8);
+    resetButton.setBounds(buttonRow.removeFromLeft(160));
+}
+
+bool ShortcutsSettingsTab::keyPressed(const juce::KeyPress& key) {
+    if (listeningIndex < 0)
+        return false;
+
+    if (key == juce::KeyPress::escapeKey) {
+        cancelListening();
+        return true;
+    }
+
+    // Ignore modifier-only keypresses
+    if (key.getKeyCode() == 0)
+        return true;
+
+    auto actionId = actionIds[listeningIndex];
+    auto conflicting = shortcutManager.getConflictingAction(actionId, key);
+
+    if (conflicting.isNotEmpty()) {
+        // Swap: assign the old binding of this action to the conflicting action
+        auto oldBinding = shortcutManager.getBinding(actionId);
+        shortcutManager.setBinding(conflicting, oldBinding);
+    }
+
+    shortcutManager.setBinding(actionId, key);
+    shortcutManager.saveToProperties();
+    listeningIndex = -1;
+    refreshBindingLabels();
+    return true;
+}
+
+juce::String ShortcutsSettingsTab::getRowDescription(int index) const {
+    if (index < 0 || index >= static_cast<int>(descLabels.size()))
+        return {};
+    return descLabels[static_cast<size_t>(index)]->getText();
+}
+
+juce::String ShortcutsSettingsTab::getRowBindingText(int index) const {
+    if (index < 0 || index >= static_cast<int>(bindButtons.size()))
+        return {};
+    return bindButtons[static_cast<size_t>(index)]->getButtonText();
+}
+
+void ShortcutsSettingsTab::startListening(int index) {
+    listeningIndex = index;
+    bindButtons[static_cast<size_t>(index)]->setButtonText("Press a key...");
+    bindButtons[static_cast<size_t>(index)]->setColour(juce::TextButton::buttonColourId, juce::Colours::orange);
+    grabKeyboardFocus();
+}
+
+void ShortcutsSettingsTab::cancelListening() {
+    if (listeningIndex >= 0) {
+        refreshBindingLabels();
+        listeningIndex = -1;
+    }
+}
+
+void ShortcutsSettingsTab::refreshBindingLabels() {
+    for (size_t i = 0; i < bindButtons.size(); ++i) {
+        auto actionId = actionIds[static_cast<int>(i)];
+        bindButtons[i]->setButtonText(ShortcutManager::keyPressToDisplayString(shortcutManager.getBinding(actionId)));
+        bindButtons[i]->setColour(juce::TextButton::buttonColourId, juce::Colours::darkgrey);
+    }
+}

--- a/Source/UI/ShortcutsSettingsTab.h
+++ b/Source/UI/ShortcutsSettingsTab.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include "../ShortcutManager.h"
+#include <juce_gui_basics/juce_gui_basics.h>
+
+// The Settings "Keyboard Shortcuts" tab.
+//
+// Displays one row per registered action: description label on the left,
+// rebind button on the right.  Clicking a button enters listening mode
+// (button turns orange with "Press a key..."); pressing any key (except
+// Escape) commits the new binding.  If the key is already used by another
+// action the bindings are swapped.  Reset-to-defaults is guarded by a
+// confirmation dialog.  JSON export/import round-trips all bindings via
+// ShortcutManager::encodeKeyPress / parseKeyPress.
+//
+// NOTE: ShortcutsSettingsTab.cpp MUST be added to BOTH the app target AND
+// the test target in CMakeLists.txt (consolidation pass).
+class ShortcutsSettingsTab : public juce::Component {
+public:
+    explicit ShortcutsSettingsTab(ShortcutManager& shortcutManager);
+    ~ShortcutsSettingsTab() override = default;
+
+    void paint(juce::Graphics& g) override;
+    void resized() override;
+    bool keyPressed(const juce::KeyPress& key) override;
+
+    // Testing hooks ---------------------------------------------------------
+    // Returns the number of action rows (== ShortcutManager::getActionIds().size()).
+    int getShortcutCount() const { return static_cast<int>(bindButtons.size()); }
+
+    // Returns the description text of row [index].
+    juce::String getRowDescription(int index) const;
+
+    // Returns the binding display string currently shown on row [index].
+    juce::String getRowBindingText(int index) const;
+
+    // Programmatically starts listening mode on row [index] (used by tests
+    // to simulate a button click without needing a mouse event).
+    void startListeningForTest(int index) { startListening(index); }
+
+private:
+    void startListening(int index);
+    void cancelListening();
+    void refreshBindingLabels();
+
+    ShortcutManager& shortcutManager;
+
+    juce::Label titleLabel;
+    juce::StringArray actionIds;
+    std::vector<std::unique_ptr<juce::Label>> descLabels;
+    std::vector<std::unique_ptr<juce::TextButton>> bindButtons;
+    juce::TextButton resetButton;
+    juce::TextButton exportButton;
+    juce::TextButton importButton;
+    std::unique_ptr<juce::FileChooser> fileChooser;
+    int listeningIndex = -1;
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(ShortcutsSettingsTab)
+};

--- a/Source/UI/StatusBarComponent.cpp
+++ b/Source/UI/StatusBarComponent.cpp
@@ -21,6 +21,21 @@ void StatusBarComponent::update(float cpuPct, int voices, const juce::String& pa
 }
 
 // ---------------------------------------------------------------------------
+void StatusBarComponent::showMessage(const juce::String& msg) {
+    transientMessage_ = msg;
+    repaint();
+    // (Re-)start the single-shot auto-clear timer: 2500 ms, fires once.
+    startTimer(2500);
+}
+
+// ---------------------------------------------------------------------------
+void StatusBarComponent::timerCallback() {
+    stopTimer();
+    transientMessage_ = {};
+    repaint();
+}
+
+// ---------------------------------------------------------------------------
 void StatusBarComponent::paint(juce::Graphics& g) {
     using namespace gsynth::theme;
 
@@ -60,21 +75,31 @@ void StatusBarComponent::paint(juce::Graphics& g) {
     const int muteSlotWidth = 28;
     const int rightEdge = getWidth() - muteSlotWidth - padH;
 
-    // Patch name — left-aligned
-    const juce::String patchStr = formatPatch(patchName_);
-    g.setColour(textPrimary);
     g.setFont(juce::Font(11.0f));
-    g.drawText(patchStr, padH, textY, 160, textH, juce::Justification::centredLeft, true);
 
-    // CPU — after patch name, warning colour if > 80 %
-    const juce::String cpuStr = formatCpu(cpuPct_ / 100.0f);
-    g.setColour(cpuPct_ > 80.0f ? warningColour : textMuted);
-    g.drawText(cpuStr, 170, textY, 60, textH, juce::Justification::centredLeft, true);
+    if (transientMessage_.isNotEmpty()) {
+        // Transient message overrides the normal status text — draw it centred across the
+        // full available width (left pad to right edge before the mute button slot).
+        g.setColour(textPrimary);
+        g.drawText(transientMessage_, padH, textY, rightEdge - padH, textH, juce::Justification::centredLeft, true);
+    } else {
+        // Normal status: patch name, CPU, voice count.
 
-    // Voice count — right-aligned before mute button
-    const juce::String voiceStr = formatVoices(voices_);
-    g.setColour(textMuted);
-    g.drawText(voiceStr, rightEdge - 80, textY, 80, textH, juce::Justification::centredRight, true);
+        // Patch name — left-aligned
+        const juce::String patchStr = formatPatch(patchName_);
+        g.setColour(textPrimary);
+        g.drawText(patchStr, padH, textY, 160, textH, juce::Justification::centredLeft, true);
+
+        // CPU — after patch name, warning colour if > 80 %
+        const juce::String cpuStr = formatCpu(cpuPct_ / 100.0f);
+        g.setColour(cpuPct_ > 80.0f ? warningColour : textMuted);
+        g.drawText(cpuStr, 170, textY, 60, textH, juce::Justification::centredLeft, true);
+
+        // Voice count — right-aligned before mute button
+        const juce::String voiceStr = formatVoices(voices_);
+        g.setColour(textMuted);
+        g.drawText(voiceStr, rightEdge - 80, textY, 80, textH, juce::Justification::centredRight, true);
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/Source/UI/StatusBarComponent.h
+++ b/Source/UI/StatusBarComponent.h
@@ -10,13 +10,22 @@
 //
 // update() is gated — it only calls repaint() when the displayed values actually change
 // (cpu delta > 0.5 %, voices changed, or patch name changed). Zero writeToLog calls.
-class StatusBarComponent : public juce::Component {
+//
+// showMessage() displays a transient status message that auto-clears after ~2.5 s.
+// While active it overrides the normal patch/cpu/voice text in the centre of the bar.
+class StatusBarComponent
+    : public juce::Component
+    , private juce::Timer {
 public:
     StatusBarComponent();
 
     // Called at ~5 Hz from MainComponent::timerCallback (via every-other tick guard).
     // Gated: only repaints if any value changed by a visible amount.
     void update(float cpuPct, int voices, const juce::String& patch);
+
+    // Display a transient message (e.g. "Saving...", "Loaded: Bright Pad") for ~2.5 s,
+    // then auto-clear and restore normal status. Safe to call from any message-thread code.
+    void showMessage(const juce::String& msg);
 
     void paint(juce::Graphics& g) override;
     void resized() override;
@@ -32,6 +41,12 @@ public:
     static juce::String formatPatch(const juce::String& s);
 
 private:
+    // juce::Timer override — fires once after ~2.5 s to clear the transient message.
+    void timerCallback() override;
+
+    // Transient message state. Empty string means no transient message is active.
+    juce::String transientMessage_;
+
     // Last-rendered values, used for gated-repaint comparison.
     float lastCpu_{-1.f};
     int lastVoices_{-1};

--- a/Source/UI/Theme/IconLibrary.cpp
+++ b/Source/UI/Theme/IconLibrary.cpp
@@ -60,6 +60,7 @@ std::pair<const void*, int> IconLibrary::binaryDataForIcon(Icon id) {
         {BinaryData::actionredo_svg, BinaryData::actionredo_svgSize},
         {BinaryData::actionsave_svg, BinaryData::actionsave_svgSize},
         {BinaryData::actionload_svg, BinaryData::actionload_svgSize},
+        {BinaryData::actionnew_svg, BinaryData::actionnew_svgSize},
         {BinaryData::actionsettings_svg, BinaryData::actionsettings_svgSize},
         {BinaryData::actionautoarrange_svg, BinaryData::actionautoarrange_svgSize},
         {BinaryData::toggleai_svg, BinaryData::toggleai_svgSize},

--- a/Source/UI/Theme/IconLibrary.h
+++ b/Source/UI/Theme/IconLibrary.h
@@ -7,7 +7,7 @@
 
 namespace gsynth::theme {
 
-// The canonical Gravisynth icon set. Exactly 26 SVG glyphs, white-filled and tinted
+// The canonical Gravisynth icon set. Exactly 27 SVG glyphs, white-filled and tinted
 // programmatically at theme-apply time. Backed by GravisynthAssets BinaryData (see
 // CMakeLists.txt) when GRAVISYNTH_HAS_FONT_ASSETS is defined; otherwise every entry is a
 // null fallback so headless tests (no asset library) still link and run.
@@ -22,6 +22,7 @@ enum class Icon : int {
     ActionRedo,
     ActionSave,
     ActionLoad,
+    ActionNew,
     ActionSettings,
     ActionAutoArrange,
     ToggleAI,

--- a/Source/UI/ToolbarComponent.cpp
+++ b/Source/UI/ToolbarComponent.cpp
@@ -14,6 +14,7 @@ void ToolbarComponent::layoutButtons(juce::Rectangle<int> bounds) {
     static constexpr float kNarrowPref = 32.0f;
     const std::array<float, NumSlots> widePref = {
         96.0f,  // Library
+        88.0f,  // New
         112.0f, // Save
         116.0f, // Load
         96.0f,  // Settings

--- a/Source/UI/ToolbarComponent.h
+++ b/Source/UI/ToolbarComponent.h
@@ -20,7 +20,19 @@ class ToolbarComponent : public juce::Component {
 public:
     // Logical slot order — matches the left group [Library..AutoArrange] + right group
     // [ToggleModMatrix, ToggleAiPanel]. NumSlots is the array size.
-    enum Slot { Library = 0, Save, Load, Settings, Undo, Redo, AutoArrange, ToggleModMatrix, ToggleAiPanel, NumSlots };
+    enum Slot {
+        Library = 0,
+        New,
+        Save,
+        Load,
+        Settings,
+        Undo,
+        Redo,
+        AutoArrange,
+        ToggleModMatrix,
+        ToggleAiPanel,
+        NumSlots
+    };
 
     // Inject the (non-owning) button pointers. Buttons remain children of MainComponent.
     void setButtons(std::array<juce::DrawableButton*, NumSlots> btns);

--- a/Source/UI/UIAnimation.h
+++ b/Source/UI/UIAnimation.h
@@ -1,0 +1,193 @@
+#pragma once
+
+// ============================================================================
+// UIAnimation.h — Shared animation utilities for Gravisynth UI Phase 5
+//
+// Namespace: gravisynth::ui
+//
+// Three sections:
+//   1. Pure easing math   — <cmath> only, headless-testable, no JUCE/GUI deps.
+//   2. AnimationDriver    — time-bounded 0→1 tween built on juce_animation.
+//   3. formatShortcutHint — pure string helper, headless-testable.
+//
+// Section 1 and 3 are #include-able from headless (non-GUI) translation units.
+// Section 2 requires juce_animation + juce_gui_basics (VBlankAttachment).
+// ============================================================================
+
+#include <cmath>
+#include <juce_animation/juce_animation.h>
+#include <juce_gui_basics/juce_gui_basics.h>
+
+namespace gravisynth::ui {
+
+// ============================================================================
+// Section 1 — Pure easing functions
+//   Input t in [0, 1].  f(0) == 0, f(1) == 1.
+//   All are constexpr-friendly (no external state).
+// ============================================================================
+
+/** Cubic ease-out: starts fast, decelerates to rest. */
+inline float easeOutCubic(float t) noexcept {
+    const float u = 1.0f - t;
+    return 1.0f - u * u * u;
+}
+
+/** Cubic ease-in-out: slow start, fast middle, slow finish. */
+inline float easeInOutCubic(float t) noexcept {
+    if (t < 0.5f)
+        return 4.0f * t * t * t;
+    const float u = -2.0f * t + 2.0f;
+    return 1.0f - u * u * u / 2.0f;
+}
+
+/** Ease-out-back: overshoots slightly then settles (c1 ≈ 1.70158). */
+inline float easeOutBack(float t) noexcept {
+    constexpr float c1 = 1.70158f;
+    constexpr float c3 = c1 + 1.0f;
+    const float u = t - 1.0f;
+    return 1.0f + c3 * u * u * u + c1 * u * u;
+}
+
+// ============================================================================
+// Section 2 — AnimationDriver
+//
+// Drives a normalised value 0→1 over a given duration (ms) with a caller-
+// supplied easing, calling onUpdate(easedValue) each VBlank frame and
+// onComplete() once when the animation finishes.
+//
+// AUTO-STOPS when progress reaches 1.0 — never loops.
+//
+// OWNERSHIP REQUIREMENT (CRITICAL):
+//   The caller MUST keep the AnimationDriver instance alive for the entire
+//   duration of the animation (it owns the juce::Animator via shared_ptr).
+//   Storing it as a class member is the correct pattern.
+//
+// VBLANK REQUIREMENT:
+//   The caller MUST also keep a juce::VBlankAnimatorUpdater alive that is
+//   associated with a visible Component.  AnimationDriver::start() registers
+//   the animator with the provided updater.
+//
+// Minimal caller member declarations:
+//
+//     juce::VBlankAnimatorUpdater vblankUpdater { this };   // 'this' = a juce::Component
+//     gravisynth::ui::AnimationDriver someAnim;
+//
+// Usage:
+//
+//     someAnim.start(vblankUpdater, 300.0,
+//                    gravisynth::ui::easeOutCubic,
+//                    [this](float t) { setAlpha(t); },
+//                    [this]()        { /* done */ });
+//
+// To animate a Component's bounds between two Rectangles, use the static helper:
+//
+//     auto lerped = AnimationDriver::lerpBounds(from, to, t);
+//     myComponent.setBounds(lerped);
+//
+// ============================================================================
+
+class AnimationDriver {
+public:
+    AnimationDriver() = default;
+
+    // Non-copyable: the animator captures lambdas that reference 'this' indirectly.
+    AnimationDriver(const AnimationDriver&) = delete;
+    AnimationDriver& operator=(const AnimationDriver&) = delete;
+
+    // Movable.
+    AnimationDriver(AnimationDriver&&) = default;
+    AnimationDriver& operator=(AnimationDriver&&) = default;
+
+    ~AnimationDriver() = default;
+
+    // -------------------------------------------------------------------------
+    /** Start a new time-bounded animation.
+     *
+     *  @param updater          A VBlankAnimatorUpdater already attached to a
+     *                          visible Component (must outlive the animation).
+     *  @param durationMs       Total animation duration in milliseconds (> 0).
+     *  @param easingFn         A function float(float) mapping [0,1]→~[0,1].
+     *                          Use any of the free functions above, or a lambda.
+     *  @param onUpdate         Called each frame with the eased progress value.
+     *                          MUST be safe to call on the message thread.
+     *  @param onComplete       Optional; called once when progress reaches 1.0.
+     *
+     *  Calling start() while an animation is already running replaces it; the
+     *  old animator is removed from the updater before the new one is added.
+     */
+    void start(juce::VBlankAnimatorUpdater& updater, double durationMs, std::function<float(float)> easingFn,
+               std::function<void(float)> onUpdate, std::function<void()> onComplete = {}) {
+        // Stop / remove previous animation if any.
+        stop(updater);
+
+        animator = juce::ValueAnimatorBuilder{}
+                       .withDurationMs(durationMs)
+                       .withEasing(std::move(easingFn))
+                       .withValueChangedCallback(std::move(onUpdate))
+                       .withOnCompleteCallback(std::move(onComplete))
+                       .build();
+
+        updater.addAnimator(*animator);
+        animator->start();
+    }
+
+    // -------------------------------------------------------------------------
+    /** Immediately stop a running animation and remove it from the updater.
+     *  Safe to call even if no animation is in progress.
+     */
+    void stop(juce::VBlankAnimatorUpdater& updater) {
+        if (animator.has_value()) {
+            updater.removeAnimator(*animator);
+            animator.reset();
+        }
+    }
+
+    /** Returns true if an animation is currently in progress. */
+    bool isRunning() const noexcept { return animator.has_value(); }
+
+    // -------------------------------------------------------------------------
+    /** Linearly interpolate between two rectangles by normalised t ∈ [0,1].
+     *
+     *  Intended for use inside the onUpdate callback to tween a Component's
+     *  bounds.  The caller then calls component.setBounds(lerped).
+     *
+     *  Example:
+     *      driver.start(updater, 250.0, easeOutCubic,
+     *          [this, from = getBounds(), to = targetBounds](float t) {
+     *              setBounds(AnimationDriver::lerpBounds(from, to, t));
+     *          });
+     */
+    static juce::Rectangle<int> lerpBounds(juce::Rectangle<int> from, juce::Rectangle<int> to, float t) noexcept {
+        auto lerp = [t](int a, int b) -> int {
+            return a + static_cast<int>(std::round(static_cast<float>(b - a) * t));
+        };
+        return {lerp(from.getX(), to.getX()), lerp(from.getY(), to.getY()), lerp(from.getWidth(), to.getWidth()),
+                lerp(from.getHeight(), to.getHeight())};
+    }
+
+private:
+    // The Animator is held as optional so we can cheaply test "is active".
+    // The shared_ptr inside Animator keeps the underlying impl alive.
+    std::optional<juce::Animator> animator;
+};
+
+// ============================================================================
+// Section 3 — formatShortcutHint
+//   Pure, no JUCE/GUI deps (only juce::String).
+// ============================================================================
+
+/** Returns a tooltip string combining a description and an optional shortcut.
+ *
+ *  - If shortcutDisplay is empty, returns base unchanged.
+ *  - Otherwise returns  base + "  (" + shortcutDisplay + ")"
+ *
+ *  Example: formatShortcutHint("Save", "Cmd+S") -> "Save  (Cmd+S)"
+ *           formatShortcutHint("Save", "")       -> "Save"
+ */
+inline juce::String formatShortcutHint(const juce::String& base, const juce::String& shortcutDisplay) {
+    if (shortcutDisplay.isEmpty())
+        return base;
+    return base + "  (" + shortcutDisplay + ")";
+}
+
+} // namespace gravisynth::ui

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -47,6 +47,7 @@ add_executable(GravisynthTests
     OscillatorCVModulationTests.cpp
     SettingsWindowTests.cpp
     ShortcutManagerTests.cpp
+    ShortcutsSettingsTabTests.cpp
     AudioRenderingTests.cpp
     LogicalPortTests.cpp
     StateRoundTripTests.cpp
@@ -57,6 +58,10 @@ add_executable(GravisynthTests
     StatusBarTests.cpp
     FrequencyResponseTests.cpp
     ScopeTests.cpp
+    UIAnimationTests.cpp
+    GraphEditorOnboardingTests.cpp
+    ModuleLibraryComponentTests.cpp
+    PanelAnimationAndLoadingTests.cpp
     ../Source/MainComponent.cpp
     ../Source/UI/GraphEditor.cpp
     ../Source/UI/ModMatrixComponent.cpp
@@ -64,6 +69,7 @@ add_executable(GravisynthTests
     ../Source/UI/ModuleComponent.cpp
     ../Source/UI/SettingsWindow.cpp
     ../Source/UI/AppearanceSettingsTab.cpp
+    ../Source/UI/ShortcutsSettingsTab.cpp
 )
 
 target_link_libraries(GravisynthTests PRIVATE

--- a/Tests/GraphEditorOnboardingTests.cpp
+++ b/Tests/GraphEditorOnboardingTests.cpp
@@ -1,0 +1,199 @@
+// GraphEditorOnboardingTests.cpp
+// gtest coverage for UI Phase 5 onboarding deliverables in GraphEditor:
+//   1. isCanvasEmpty pure predicate
+//   2. computeDropFinalPosition pure helper (snap + anti-overlap + idempotence)
+//   3. Paint smoke tests (empty canvas and non-empty canvas — must not crash)
+//
+// Mirrors the setup of existing Tests/*.cpp (ScopedJuceInitialiser_GUI lives
+// in TestMain.cpp and applies globally — no per-file setup needed).
+// This file is NOT registered in CMakeLists.txt (per OWNER instructions).
+
+#include "../Source/Modules/OscillatorModule.h"
+#include "../Source/UI/GraphEditor.h"
+#include "../Source/UI/LayoutUtil.h"
+#include <gtest/gtest.h>
+#include <juce_gui_basics/juce_gui_basics.h>
+
+// ============================================================================
+// 1. isCanvasEmpty — pure predicate
+// ============================================================================
+
+TEST(GraphEditorOnboarding, IsCanvasEmptyReturnsTrueForZero) { EXPECT_TRUE(GraphEditor::isCanvasEmpty(0)); }
+
+TEST(GraphEditorOnboarding, IsCanvasEmptyReturnsTrueForNegative) {
+    // Defensive: negative count treated as empty (guard against underflow callers).
+    EXPECT_TRUE(GraphEditor::isCanvasEmpty(-1));
+}
+
+TEST(GraphEditorOnboarding, IsCanvasEmptyReturnsFalseForOne) { EXPECT_FALSE(GraphEditor::isCanvasEmpty(1)); }
+
+TEST(GraphEditorOnboarding, IsCanvasEmptyReturnsFalseForMany) { EXPECT_FALSE(GraphEditor::isCanvasEmpty(5)); }
+
+// ============================================================================
+// 2. computeDropFinalPosition — snap + anti-overlap + idempotence
+// ============================================================================
+
+TEST(GraphEditorOnboarding, ComputeDropFinalPositionSnapsToGrid) {
+    // Drop at a non-grid coordinate with no existing modules.
+    const std::vector<gsynth::LayoutUtil::Box> empty;
+    gsynth::LayoutUtil::NodeID nullId{};
+
+    auto result = GraphEditor::computeDropFinalPosition({103, 97}, // neither multiple of kGridSize=8
+                                                        280, 300, empty, nullId);
+
+    EXPECT_EQ(result.x % gsynth::LayoutUtil::kGridSize, 0)
+        << "x=" << result.x << " must be a multiple of kGridSize=" << gsynth::LayoutUtil::kGridSize;
+    EXPECT_EQ(result.y % gsynth::LayoutUtil::kGridSize, 0)
+        << "y=" << result.y << " must be a multiple of kGridSize=" << gsynth::LayoutUtil::kGridSize;
+}
+
+TEST(GraphEditorOnboarding, ComputeDropFinalPositionEmptyBoxesReturnSnapped) {
+    // With no existing modules the result should equal snap(dropPoint).
+    const std::vector<gsynth::LayoutUtil::Box> empty;
+    gsynth::LayoutUtil::NodeID nullId{};
+
+    const juce::Point<int> drop{200, 200};
+    auto result = GraphEditor::computeDropFinalPosition(drop, 280, 300, empty, nullId);
+    auto expected = gsynth::LayoutUtil::snap(drop);
+    EXPECT_EQ(result, expected);
+}
+
+TEST(GraphEditorOnboarding, ComputeDropFinalPositionAvoidsExistingBox) {
+    // Existing module occupies the snapped drop position.
+    gsynth::LayoutUtil::NodeID existingId{1};
+    gsynth::LayoutUtil::NodeID newId{}; // new module (no NodeID yet)
+
+    juce::Rectangle<int> existingRect{200, 200, 280, 300};
+    std::vector<gsynth::LayoutUtil::Box> boxes = {{existingId, existingRect}};
+
+    auto result = GraphEditor::computeDropFinalPosition({200, 200}, 280, 300, boxes, newId);
+
+    // Must not overlap the existing box (with collision gap).
+    const int gap = gsynth::LayoutUtil::kCollisionGap;
+    auto resultRect = juce::Rectangle<int>(result.x, result.y, 280, 300);
+    EXPECT_FALSE(resultRect.expanded(gap / 2).intersects(existingRect.expanded(gap / 2)))
+        << "Result (" << resultRect.toString() << ") overlaps existing box (" << existingRect.toString()
+        << ") with gap=" << gap;
+}
+
+TEST(GraphEditorOnboarding, ComputeDropFinalPositionResultIsOnGrid) {
+    // Even after collision resolution the result stays on-grid.
+    gsynth::LayoutUtil::NodeID existingId{1};
+    gsynth::LayoutUtil::NodeID newId{};
+
+    juce::Rectangle<int> existingRect{200, 200, 280, 300};
+    std::vector<gsynth::LayoutUtil::Box> boxes = {{existingId, existingRect}};
+
+    auto result = GraphEditor::computeDropFinalPosition({203, 197}, 280, 300, boxes, newId);
+
+    EXPECT_EQ(result.x % gsynth::LayoutUtil::kGridSize, 0) << "Post-collision x=" << result.x << " must stay on grid";
+    EXPECT_EQ(result.y % gsynth::LayoutUtil::kGridSize, 0) << "Post-collision y=" << result.y << " must stay on grid";
+}
+
+TEST(GraphEditorOnboarding, ComputeDropFinalPositionIdempotent) {
+    // Calling the function a second time with the result of the first call (adding the
+    // first result as a placed box) must return the same position (the slot is clear).
+    gsynth::LayoutUtil::NodeID idA{1};
+    gsynth::LayoutUtil::NodeID idNew{};
+
+    std::vector<gsynth::LayoutUtil::Box> emptyBoxes;
+    auto firstResult = GraphEditor::computeDropFinalPosition({100, 100}, 280, 300, emptyBoxes, idNew);
+
+    // Re-run: this time the module is already placed at firstResult (idNew box).
+    // Use idNew as selfId so it is excluded from self-collision.
+    std::vector<gsynth::LayoutUtil::Box> withSelf = {
+        {idNew, juce::Rectangle<int>(firstResult.x, firstResult.y, 280, 300)}};
+    auto secondResult = GraphEditor::computeDropFinalPosition(firstResult, 280, 300, withSelf, idNew);
+
+    EXPECT_EQ(secondResult, firstResult) << "Re-placing an already-placed module should not move it;"
+                                         << " firstResult=" << firstResult.toString()
+                                         << " secondResult=" << secondResult.toString();
+}
+
+TEST(GraphEditorOnboarding, ComputeDropFinalPositionSelfIdExcludedFromCollision) {
+    // The module being placed must be excluded from its own collision check.
+    // If selfId's box is in existingBoxes at the exact drop position, the result
+    // should still land at that position (it does not collide with itself).
+    gsynth::LayoutUtil::NodeID selfId{42};
+    juce::Point<int> snappedDrop = gsynth::LayoutUtil::snap({200, 200});
+    juce::Rectangle<int> selfBox{snappedDrop.x, snappedDrop.y, 280, 300};
+    std::vector<gsynth::LayoutUtil::Box> boxes = {{selfId, selfBox}};
+
+    auto result = GraphEditor::computeDropFinalPosition(snappedDrop, 280, 300, boxes, selfId);
+
+    EXPECT_EQ(result, snappedDrop) << "Self-collision must be excluded; module should land at its own position."
+                                   << " Expected=" << snappedDrop.toString() << " Got=" << result.toString();
+}
+
+// ============================================================================
+// 3. Paint smoke tests — exercise paint() without crashing.
+//    Requires a running MessageManager (provided by ScopedJuceInitialiser_GUI
+//    in TestMain.cpp).
+// ============================================================================
+
+TEST(GraphEditorOnboarding, PaintSmokeEmptyCanvas) {
+    AudioEngine engine;
+    GraphEditor editor(engine);
+    editor.setSize(800, 600);
+
+    // An empty GraphEditor (no modules) should call paint without crashing.
+    // The empty-canvas hint path is exercised here.
+    juce::Image img(juce::Image::ARGB, 800, 600, true);
+    juce::Graphics g(img);
+    EXPECT_NO_THROW(editor.paint(g));
+    EXPECT_NO_THROW(editor.resized());
+}
+
+TEST(GraphEditorOnboarding, PaintSmokeNonEmptyCanvas) {
+    AudioEngine engine;
+    GraphEditor editor(engine);
+    editor.setSize(800, 600);
+
+    // Add a module so the canvas is non-empty (hint must disappear).
+    auto oscNode = engine.getGraph().addNode(std::make_unique<OscillatorModule>());
+    oscNode->properties.set("x", 100);
+    oscNode->properties.set("y", 100);
+    editor.updateComponents();
+
+    juce::Image img(juce::Image::ARGB, 800, 600, true);
+    juce::Graphics g(img);
+    EXPECT_NO_THROW(editor.paint(g));
+    EXPECT_NO_THROW(editor.resized());
+}
+
+TEST(GraphEditorOnboarding, PaintSmokeContentComponentEmpty) {
+    // Directly paint the GraphContentComponent child with zero modules.
+    // Exercises the empty-canvas hint branch in GraphContentComponent::paint().
+    AudioEngine engine;
+    GraphEditor editor(engine);
+    editor.setSize(800, 600);
+
+    // The first child of GraphEditor is GraphContentComponent.
+    auto* contentComp = editor.getChildComponent(0);
+    ASSERT_NE(contentComp, nullptr) << "GraphEditor must have a GraphContentComponent child";
+    contentComp->setSize(800, 600);
+
+    juce::Image img(juce::Image::ARGB, 800, 600, true);
+    juce::Graphics g(img);
+    EXPECT_NO_THROW(contentComp->paint(g));
+}
+
+TEST(GraphEditorOnboarding, PaintSmokeContentComponentNonEmpty) {
+    // Directly paint the GraphContentComponent child with one module.
+    AudioEngine engine;
+    GraphEditor editor(engine);
+    editor.setSize(800, 600);
+
+    auto oscNode = engine.getGraph().addNode(std::make_unique<OscillatorModule>());
+    oscNode->properties.set("x", 50);
+    oscNode->properties.set("y", 50);
+    editor.updateComponents();
+
+    auto* contentComp = editor.getChildComponent(0);
+    ASSERT_NE(contentComp, nullptr);
+    contentComp->setSize(800, 600);
+
+    juce::Image img(juce::Image::ARGB, 800, 600, true);
+    juce::Graphics g(img);
+    EXPECT_NO_THROW(contentComp->paint(g));
+}

--- a/Tests/GraphEditorOnboardingTests.cpp
+++ b/Tests/GraphEditorOnboardingTests.cpp
@@ -164,7 +164,8 @@ TEST(GraphEditorOnboarding, PaintSmokeNonEmptyCanvas) {
 
 TEST(GraphEditorOnboarding, PaintSmokeContentComponentEmpty) {
     // Directly paint the GraphContentComponent child with zero modules.
-    // Exercises the empty-canvas hint branch in GraphContentComponent::paint().
+    // Exercises the background/wire drawing branch in GraphContentComponent::paint()
+    // (the empty-canvas hint has moved to GraphEditor::paintOverChildren).
     AudioEngine engine;
     GraphEditor editor(engine);
     editor.setSize(800, 600);
@@ -197,6 +198,43 @@ TEST(GraphEditorOnboarding, PaintSmokeContentComponentNonEmpty) {
     juce::Image img(juce::Image::ARGB, 800, 600, true);
     juce::Graphics g(img);
     EXPECT_NO_THROW(contentComp->paint(g));
+}
+
+// ============================================================================
+// 3b. paintOverChildren smoke tests — exercise the viewport-centred hint.
+//     GraphEditor::paintOverChildren is called by JUCE during a full component
+//     paint pass.  We trigger it via a full repaint into an offscreen image so
+//     the hint code runs through the JUCE paint dispatch.
+// ============================================================================
+
+TEST(GraphEditorOnboarding, PaintOverChildrenSmokeEmptyCanvas) {
+    // An empty editor (no modules) must exercise the paintOverChildren hint path
+    // without crashing.  The hint is drawn centred in getLocalBounds().
+    AudioEngine engine;
+    GraphEditor editor(engine);
+    editor.setSize(800, 600);
+
+    // Trigger a full paint pass (parent + children + paintOverChildren).
+    juce::Image img(juce::Image::ARGB, 800, 600, true);
+    juce::Graphics g(img);
+    EXPECT_NO_THROW(editor.paintEntireComponent(g, false));
+}
+
+TEST(GraphEditorOnboarding, PaintOverChildrenSmokeNonEmptyCanvas) {
+    // A non-empty editor must NOT draw the hint — paintOverChildren returns early.
+    // Must not crash either way.
+    AudioEngine engine;
+    GraphEditor editor(engine);
+    editor.setSize(800, 600);
+
+    auto oscNode = engine.getGraph().addNode(std::make_unique<OscillatorModule>());
+    oscNode->properties.set("x", 100);
+    oscNode->properties.set("y", 100);
+    editor.updateComponents();
+
+    juce::Image img(juce::Image::ARGB, 800, 600, true);
+    juce::Graphics g(img);
+    EXPECT_NO_THROW(editor.paintEntireComponent(g, false));
 }
 
 // ============================================================================

--- a/Tests/GraphEditorOnboardingTests.cpp
+++ b/Tests/GraphEditorOnboardingTests.cpp
@@ -8,6 +8,7 @@
 // in TestMain.cpp and applies globally — no per-file setup needed).
 // This file is NOT registered in CMakeLists.txt (per OWNER instructions).
 
+#include "../Source/GravisynthUndoManager.h"
 #include "../Source/Modules/OscillatorModule.h"
 #include "../Source/UI/GraphEditor.h"
 #include "../Source/UI/LayoutUtil.h"
@@ -196,4 +197,81 @@ TEST(GraphEditorOnboarding, PaintSmokeContentComponentNonEmpty) {
     juce::Image img(juce::Image::ARGB, 800, 600, true);
     juce::Graphics g(img);
     EXPECT_NO_THROW(contentComp->paint(g));
+}
+
+// ============================================================================
+// 4. newPatch() — clear canvas action (headless, no undoManager)
+// ============================================================================
+
+TEST(GraphEditorOnboarding, NewPatchClearsGraph) {
+    // Construct engine + editor without an undoManager (headless path).
+    AudioEngine engine;
+    GraphEditor editor(engine); // undoManager = nullptr
+    editor.setSize(800, 600);
+
+    // Add one module so the canvas is non-empty.
+    auto oscNode = engine.getGraph().addNode(std::make_unique<OscillatorModule>());
+    oscNode->properties.set("x", 100);
+    oscNode->properties.set("y", 100);
+    editor.updateComponents();
+
+    // Confirm non-empty before calling newPatch.
+    const int nodesBefore = (int)engine.getGraph().getNodes().size();
+    EXPECT_GT(nodesBefore, 0) << "Pre-condition: graph must have at least one node before newPatch";
+    EXPECT_FALSE(GraphEditor::isCanvasEmpty(editor.getModuleComponents().size()))
+        << "Pre-condition: canvas must be non-empty before newPatch";
+
+    // Act.
+    EXPECT_NO_THROW(editor.newPatch());
+
+    // After newPatch the graph must have zero nodes.
+    const int nodesAfter = (int)engine.getGraph().getNodes().size();
+    EXPECT_EQ(nodesAfter, 0) << "newPatch must clear all graph nodes";
+
+    // And the GraphEditor's module-component list must be empty (detachAllModuleComponents was called).
+    EXPECT_EQ(editor.getModuleComponents().size(), 0) << "newPatch must detach all module components";
+
+    // isCanvasEmpty must reflect the cleared state.
+    EXPECT_TRUE(GraphEditor::isCanvasEmpty((int)editor.getModuleComponents().size()))
+        << "isCanvasEmpty must return true after newPatch";
+}
+
+TEST(GraphEditorOnboarding, NewPatchOnEmptyCanvasIsNoop) {
+    // Calling newPatch on an already-empty canvas must not crash.
+    AudioEngine engine;
+    GraphEditor editor(engine);
+    editor.setSize(800, 600);
+
+    EXPECT_NO_THROW(editor.newPatch());
+    EXPECT_EQ(engine.getGraph().getNodes().size(), 0u);
+    EXPECT_TRUE(GraphEditor::isCanvasEmpty((int)editor.getModuleComponents().size()));
+}
+
+TEST(GraphEditorOnboarding, NewPatchWithUndoManagerIsUndoable) {
+    // With an undoManager present, newPatch must be undoable (Cmd+Z restores the graph).
+    AudioEngine engine;
+    GravisynthUndoManager undoManager;
+    GraphEditor editor(engine, &undoManager);
+    undoManager.setGraphEditor(&editor);
+    editor.setSize(800, 600);
+
+    // Add a module so there is something to restore on undo.
+    auto oscNode = engine.getGraph().addNode(std::make_unique<OscillatorModule>());
+    oscNode->properties.set("x", 120);
+    oscNode->properties.set("y", 120);
+    editor.updateComponents();
+
+    EXPECT_FALSE(GraphEditor::isCanvasEmpty((int)editor.getModuleComponents().size()));
+
+    // Perform newPatch — must be recorded in the undo stack.
+    editor.newPatch();
+    EXPECT_EQ(engine.getGraph().getNodes().size(), 0u) << "Canvas must be empty after newPatch";
+    EXPECT_TRUE(undoManager.canUndo()) << "newPatch must push an undoable action when undoManager is present";
+
+    // Undo must restore the graph to its prior non-empty state.
+    undoManager.undo();
+    // After undo the graph has nodes again — call updateComponents to reconcile the editor.
+    editor.updateComponents();
+    EXPECT_FALSE(GraphEditor::isCanvasEmpty((int)editor.getModuleComponents().size()))
+        << "Undo of newPatch must restore prior module components";
 }

--- a/Tests/IconLibraryTests.cpp
+++ b/Tests/IconLibraryTests.cpp
@@ -256,13 +256,13 @@ TEST(IconLibraryTest, WaveformIconBinaryDataSymbols) {
 // 11. WaveformIconEnumCountCoversNewIcons
 // ---------------------------------------------------------------------------
 TEST(IconLibraryTest, WaveformIconEnumCountCoversNewIcons) {
-    // The enum must now contain 26 entries (22 Phase-3 + 4 waveform). The static_assert in
-    // IconLibrary.cpp enforces kTable alignment at compile time; this runtime check catches
-    // any mismatch that slips through without a rebuild.
-    EXPECT_EQ((int)Icon::kCount, 26);
-    // Spot-check ordinal positions of the new waveform icons.
-    EXPECT_EQ((int)Icon::WaveformSine, 22);
-    EXPECT_EQ((int)Icon::WaveformSaw, 23);
-    EXPECT_EQ((int)Icon::WaveformSquare, 24);
-    EXPECT_EQ((int)Icon::WaveformTriangle, 25);
+    // The enum must now contain 27 entries (22 Phase-3 + ActionNew + 4 waveform). The
+    // static_assert in IconLibrary.cpp enforces kTable alignment at compile time; this runtime
+    // check catches any mismatch that slips through without a rebuild.
+    EXPECT_EQ((int)Icon::kCount, 27);
+    // Spot-check ordinal positions of the new waveform icons (shifted +1 by ActionNew at index 6).
+    EXPECT_EQ((int)Icon::WaveformSine, 23);
+    EXPECT_EQ((int)Icon::WaveformSaw, 24);
+    EXPECT_EQ((int)Icon::WaveformSquare, 25);
+    EXPECT_EQ((int)Icon::WaveformTriangle, 26);
 }

--- a/Tests/MainComponentTests.cpp
+++ b/Tests/MainComponentTests.cpp
@@ -104,10 +104,10 @@ TEST_F(MainComponentTest, CommandManagerHasCommands) {
     MainComponent mainComp(std::make_unique<MockProvider>());
     auto& cm = mainComp.getCommandManager();
     juce::ignoreUnused(cm);
-    // Verify all 9 commands are registered (5 original + 2 toggles + Auto Arrange + Toggle Library)
+    // Verify all 10 commands are registered (5 original + New Patch + 2 toggles + Auto Arrange + Toggle Library)
     juce::Array<juce::CommandID> commands;
     mainComp.getAllCommands(commands);
-    EXPECT_EQ(commands.size(), 9);
+    EXPECT_EQ(commands.size(), 10);
 }
 
 TEST_F(MainComponentTest, RedoShortcutViaKeyPressed) {

--- a/Tests/ModuleLibraryComponentTests.cpp
+++ b/Tests/ModuleLibraryComponentTests.cpp
@@ -1,0 +1,194 @@
+// ModuleLibraryComponentTests.cpp
+// Headless unit tests for ModuleLibraryComponent (UI Phase 5):
+//   • descriptionFor — known modules return non-empty, distinct strings; unknown → generic fallback
+//   • getEntryIndexAt — maps y-coordinates to entry indices, including header rows
+//   • paint smoke test — construct, setSize, paint; simulate a hovered index and paint again
+
+#include "../Source/UI/ModuleLibraryComponent.h"
+#include <gtest/gtest.h>
+#include <juce_gui_basics/juce_gui_basics.h>
+
+// ============================================================================
+// descriptionFor — pure static helper, no GUI needed
+// ============================================================================
+
+TEST(ModuleLibraryDescriptionFor, KnownModulesReturnNonEmpty) {
+    const char* known[] = {"Oscillator", "LFO",   "Sequencer", "MidiKeyboard", "Poly MIDI", "External MIDI",
+                           "ADSR",       "VCA",   "Filter",    "Chorus",       "Phaser",    "Flanger",
+                           "Distortion", "Delay", "Reverb",    "Compressor",   "Limiter",   "Voice Mixer"};
+    for (const char* name : known) {
+        juce::String desc = ModuleLibraryComponent::descriptionFor(name);
+        EXPECT_FALSE(desc.isEmpty()) << "descriptionFor(\"" << name << "\") must not be empty";
+    }
+}
+
+TEST(ModuleLibraryDescriptionFor, KnownModulesReturnDistinctStrings) {
+    const char* known[] = {"Oscillator", "LFO",   "Sequencer", "MidiKeyboard", "Poly MIDI", "External MIDI",
+                           "ADSR",       "VCA",   "Filter",    "Chorus",       "Phaser",    "Flanger",
+                           "Distortion", "Delay", "Reverb",    "Compressor",   "Limiter",   "Voice Mixer"};
+    std::vector<juce::String> descs;
+    for (const char* name : known)
+        descs.push_back(ModuleLibraryComponent::descriptionFor(name));
+
+    for (size_t i = 0; i < descs.size(); ++i)
+        for (size_t j = i + 1; j < descs.size(); ++j)
+            EXPECT_NE(descs[i], descs[j]) << "descriptionFor(\"" << known[i] << "\") == descriptionFor(\"" << known[j]
+                                          << "\") — descriptions should be distinct";
+}
+
+TEST(ModuleLibraryDescriptionFor, UnknownNameReturnsGenericFallback) {
+    juce::String desc = ModuleLibraryComponent::descriptionFor("UnknownXYZModule");
+    EXPECT_FALSE(desc.isEmpty()) << "Unknown module name must return a non-empty fallback";
+    // Verify it is the documented generic string (not a module-specific one).
+    // All known-module strings contain at least one comma, dash, or parenthesis.
+    // The generic fallback is intentionally short and plain.
+    EXPECT_EQ(desc, juce::String("Audio processing module."));
+}
+
+TEST(ModuleLibraryDescriptionFor, LookupIsCaseInsensitive) {
+    // "oscillator" (lowercase) should match the same description as "Oscillator".
+    EXPECT_EQ(ModuleLibraryComponent::descriptionFor("oscillator"),
+              ModuleLibraryComponent::descriptionFor("Oscillator"));
+    EXPECT_EQ(ModuleLibraryComponent::descriptionFor("FILTER"), ModuleLibraryComponent::descriptionFor("Filter"));
+}
+
+// ============================================================================
+// Hover index mapping — tests the y-to-entry-index logic exposed by the
+// component's public getEntryIndexAt (via mouseMove). We test it indirectly
+// through a real component instance, exercising getHoveredIndex() after
+// synthesising MouseEvent y-coordinates.
+//
+// The layout (from the constructor):
+//   y=10: header  "Sources"          h=25  (y 10..34)
+//   y=35: item    "Oscillator"       h=32  (y 35..66)
+//   y=67: item    "LFO"              h=32  (y 67..98)
+//   y=98: header  "Sequencing"       h=25  (extra 5px gap -> y starts at 103)
+//   actually layout: after the first header (y=10, h=25) y becomes 35.
+//   Second header gets an extra 5px gap so: y=35+32=67, 67+32=99; then gap: 99+5=104, header h=25.
+//
+// The exact y values are verified by the component's own getEntryIndexAt
+// logic. These tests exercise known-good and boundary points.
+// ============================================================================
+
+// Helper: simulate a mouse-move at a given y into the component.
+// We construct a minimal MouseEvent from scratch.
+static void simulateMouseMoveAt(ModuleLibraryComponent& comp, int y) {
+    juce::MouseInputSource src = juce::Desktop::getInstance().getMainMouseSource();
+    juce::MouseEvent evt(src, juce::Point<float>(5.0f, (float)y), juce::ModifierKeys(),
+                         1.0f,                   // pressure
+                         0.0f, 0.0f, 0.0f, 0.0f, // tilt, rotation, etc.
+                         &comp, &comp, juce::Time::getCurrentTime(), juce::Point<float>(5.0f, (float)y),
+                         juce::Time::getCurrentTime(), 1, false);
+    comp.mouseMove(evt);
+}
+
+static void simulateMouseExit(ModuleLibraryComponent& comp) {
+    juce::MouseInputSource src = juce::Desktop::getInstance().getMainMouseSource();
+    juce::MouseEvent evt(src, juce::Point<float>(-1.0f, -1.0f), juce::ModifierKeys(), 1.0f, 0.0f, 0.0f, 0.0f, 0.0f,
+                         &comp, &comp, juce::Time::getCurrentTime(), juce::Point<float>(-1.0f, -1.0f),
+                         juce::Time::getCurrentTime(), 0, false);
+    comp.mouseExit(evt);
+}
+
+TEST(ModuleLibraryHoverIndex, HoverOnHeaderRowIsMinusOne) {
+    ModuleLibraryComponent comp;
+    comp.setSize(200, 600);
+
+    // The very first header starts at y=10 (height 25, so rows 10..34).
+    simulateMouseMoveAt(comp, 12);
+    // Headers never get a hover index.
+    EXPECT_EQ(comp.getHoveredIndex(), -1) << "Hovering over a header row must not set a positive hover index";
+}
+
+TEST(ModuleLibraryHoverIndex, HoverOnFirstItemRow) {
+    ModuleLibraryComponent comp;
+    comp.setSize(200, 600);
+
+    // First item ("Oscillator") starts at y=35 (after header h=25 from y=10).
+    // Row height = 32, so it occupies y=35..66.
+    simulateMouseMoveAt(comp, 40);
+    int idx = comp.getHoveredIndex();
+    EXPECT_GE(idx, 0) << "Hovering inside first item row must set a non-negative index";
+    EXPECT_LT(idx, comp.getEntryCount()) << "Hovered index must be within valid range";
+    // The entry at that index must not be a header.
+}
+
+TEST(ModuleLibraryHoverIndex, MouseExitClearsHoverIndex) {
+    ModuleLibraryComponent comp;
+    comp.setSize(200, 600);
+
+    // First hover over a valid item row.
+    simulateMouseMoveAt(comp, 40);
+    ASSERT_GE(comp.getHoveredIndex(), 0);
+
+    // Then exit.
+    simulateMouseExit(comp);
+    EXPECT_EQ(comp.getHoveredIndex(), -1) << "mouseExit must reset hovered index to -1";
+}
+
+TEST(ModuleLibraryHoverIndex, HoverBelowAllEntriesIsMinusOne) {
+    ModuleLibraryComponent comp;
+    comp.setSize(200, 600);
+
+    // y=9999 is well past all entries.
+    simulateMouseMoveAt(comp, 9999);
+    EXPECT_EQ(comp.getHoveredIndex(), -1) << "y beyond all entries must give hoveredIndex -1";
+}
+
+TEST(ModuleLibraryHoverIndex, HoverAboveFirstEntryIsMinusOne) {
+    ModuleLibraryComponent comp;
+    comp.setSize(200, 600);
+
+    // y=5 is above the first row which starts at y=10.
+    simulateMouseMoveAt(comp, 5);
+    EXPECT_EQ(comp.getHoveredIndex(), -1) << "y above first entry must give hoveredIndex -1";
+}
+
+// ============================================================================
+// Paint smoke tests — construct, setSize, paint into a juce::Image; no crash.
+// Exercises the repaint-on-hover code path as well.
+// ============================================================================
+
+TEST(ModuleLibraryPaintSmoke, PaintWithNoHoverNoCrash) {
+    ModuleLibraryComponent comp;
+    comp.setSize(200, 600);
+
+    juce::Image img(juce::Image::ARGB, 200, 600, true);
+    juce::Graphics g(img);
+    EXPECT_NO_THROW(comp.paint(g));
+
+    // Must produce at least one non-transparent pixel.
+    bool hasPixel = false;
+    for (int y = 0; y < img.getHeight() && !hasPixel; ++y)
+        for (int x = 0; x < img.getWidth() && !hasPixel; ++x)
+            if (img.getPixelAt(x, y).getAlpha() > 0)
+                hasPixel = true;
+    EXPECT_TRUE(hasPixel) << "paint() should produce at least one visible pixel";
+}
+
+TEST(ModuleLibraryPaintSmoke, PaintWithHoveredIndexNoCrash) {
+    ModuleLibraryComponent comp;
+    comp.setSize(200, 600);
+
+    // Simulate hovering over the first item row (y=40).
+    simulateMouseMoveAt(comp, 40);
+    ASSERT_GE(comp.getHoveredIndex(), 0);
+
+    juce::Image img(juce::Image::ARGB, 200, 600, true);
+    juce::Graphics g(img);
+    // This exercises the highlight-fill branch in paint().
+    EXPECT_NO_THROW(comp.paint(g));
+}
+
+TEST(ModuleLibraryPaintSmoke, PaintAfterMouseExitNoCrash) {
+    ModuleLibraryComponent comp;
+    comp.setSize(200, 600);
+
+    simulateMouseMoveAt(comp, 40);
+    simulateMouseExit(comp);
+    ASSERT_EQ(comp.getHoveredIndex(), -1);
+
+    juce::Image img(juce::Image::ARGB, 200, 600, true);
+    juce::Graphics g(img);
+    EXPECT_NO_THROW(comp.paint(g));
+}

--- a/Tests/PanelAnimationAndLoadingTests.cpp
+++ b/Tests/PanelAnimationAndLoadingTests.cpp
@@ -1,0 +1,308 @@
+// PanelAnimationAndLoadingTests.cpp
+//
+// Headless gtest coverage for UI Phase 5 deliverables owned by Owner D:
+//   1. Panel target-bounds geometry (pure, no animation)
+//   2. AI cancel state-transition (waiting → cancel resets flags & controls)
+//   3. Tooltip-hint formatting (pure string helper)
+//   4. Paint smoke tests for MainComponent and AIChatComponent
+//
+// Does NOT register in CMakeLists.txt — add it manually when ready.
+// Mirrors the pattern in MainComponentTests.cpp and AIChatComponentTests.cpp.
+
+#include "../Source/AI/AIProvider.h"
+#include "../Source/AudioEngine.h"
+#include "../Source/UI/AIChatComponent.h"
+#include "../Source/UI/UIAnimation.h"
+#include "MainComponent.h"
+#include <gtest/gtest.h>
+#include <juce_gui_basics/juce_gui_basics.h>
+
+// ============================================================================
+// Shared mock provider (same pattern as MainComponentTests.cpp)
+// ============================================================================
+
+class MockProviderPAL : public gsynth::AIProvider {
+public:
+    juce::String getProviderName() const override { return "MockPAL"; }
+    void fetchAvailableModels(std::function<void(const juce::StringArray&, bool)> callback) override {
+        callback({"MockModel"}, true);
+    }
+    void sendPrompt(const std::vector<Message>&, CompletionCallback callback, const juce::var&) override {
+        // Intentionally never completes so we can test the cancel path.
+        juce::ignoreUnused(callback);
+    }
+    void setModel(const juce::String& name) override { model = name; }
+    juce::String getCurrentModel() const override { return model; }
+
+private:
+    juce::String model = "MockModel";
+};
+
+// Fixture helper: owns an ApplicationProperties configured for tests.
+struct TestPropsOwner {
+    juce::ApplicationProperties props;
+    TestPropsOwner() {
+        juce::PropertiesFile::Options opts;
+        opts.applicationName = "GravisynthPALTest";
+        opts.filenameSuffix = "test";
+        opts.storageFormat = juce::PropertiesFile::storeAsXML;
+        props.setStorageParameters(opts);
+    }
+};
+
+// Helper to reset panel-visibility keys so tests are hermetic.
+static void resetPanelKeys() {
+    juce::PropertiesFile::Options opts;
+    opts.applicationName = "Gravisynth";
+    opts.folderName = "Gravisynth";
+    opts.filenameSuffix = "settings";
+    opts.osxLibrarySubFolder = "Application Support";
+    opts.storageFormat = juce::PropertiesFile::storeAsXML;
+
+    juce::ApplicationProperties props;
+    props.setStorageParameters(opts);
+    if (auto* s = props.getUserSettings()) {
+        s->setValue("librarySidebarVisible", "1");
+        s->setValue("aiPanelVisible", "0");
+        s->saveIfNeeded();
+    }
+}
+
+// ============================================================================
+// 1. Panel target-bounds geometry
+//    computePanelBounds() is pure: no animation, no side effects.
+// ============================================================================
+
+class PanelBoundsTest : public ::testing::Test {
+protected:
+    void SetUp() override { resetPanelKeys(); }
+    void TearDown() override { resetPanelKeys(); }
+};
+
+TEST_F(PanelBoundsTest, BothPanelsVisible_LibraryAndAiOccupyExpectedWidth) {
+    MainComponent mc(std::make_unique<MockProviderPAL>());
+    mc.setSize(1600, 900);
+
+    // Access computePanelBounds indirectly via the toggle test-helpers.
+    // After toggling both panels to visible, resized() places them according to the same formula.
+    // Default: library visible, AI hidden. Show AI.
+    mc.simulateToggleAiPanelClick(); // now both visible
+
+    const int libW = mc.getGraphEditor().getBounds().getX(); // library width
+    EXPECT_EQ(libW, 200) << "Library sidebar should be 200 px wide";
+
+    const int aiRight = mc.getGraphEditor().getBounds().getRight();
+    EXPECT_LT(aiRight, 1600 - 1) << "AI panel should push graph editor left of window right edge";
+}
+
+TEST_F(PanelBoundsTest, LibraryHidden_GraphEditorStartsAtX0) {
+    MainComponent mc(std::make_unique<MockProviderPAL>());
+    mc.setSize(1600, 900);
+
+    mc.simulateToggleLibraryClick(); // hide library
+    // Graph editor must start at x=0 when library is hidden.
+    EXPECT_EQ(mc.getGraphEditor().getBounds().getX(), 0);
+}
+
+TEST_F(PanelBoundsTest, AiPanelHidden_GraphEditorReachesRightEdge) {
+    MainComponent mc(std::make_unique<MockProviderPAL>());
+    mc.setSize(1600, 900);
+
+    // AI panel is hidden by default; library is visible.
+    ASSERT_FALSE(mc.isAiPanelConfiguredVisible());
+    // Graph editor right edge == window width (no AI panel taking space on right).
+    EXPECT_EQ(mc.getGraphEditor().getBounds().getRight(), 1600);
+}
+
+TEST_F(PanelBoundsTest, BothPanelsHidden_GraphEditorFillsFullContentArea) {
+    MainComponent mc(std::make_unique<MockProviderPAL>());
+    mc.setSize(1600, 900);
+
+    mc.simulateToggleLibraryClick(); // hide library
+    ASSERT_FALSE(mc.isLibraryConfiguredVisible());
+    ASSERT_FALSE(mc.isAiPanelConfiguredVisible());
+
+    const auto ge = mc.getGraphEditor().getBounds();
+    EXPECT_EQ(ge.getX(), 0);
+    EXPECT_EQ(ge.getRight(), 1600);
+}
+
+// ============================================================================
+// 2. AI cancel state-transition
+//    Sending a message (with a never-completing mock) puts the component into
+//    the "waiting" state.  Triggering the cancel button must:
+//      - reset isWaiting() to false
+//      - show the cancel button before cancel, hide it after
+//      - re-enable the send button and input field
+// ============================================================================
+
+class AICancelTest : public ::testing::Test {
+protected:
+};
+
+TEST_F(AICancelTest, CancelButtonHiddenBeforeSend) {
+    AudioEngine engine;
+    gsynth::AIIntegrationService service(engine.getGraph());
+    service.setProvider(std::make_unique<MockProviderPAL>());
+
+    TestPropsOwner propsOwner;
+    gsynth::AIChatComponent chat(service, propsOwner.props);
+    chat.setSize(400, 600);
+
+    EXPECT_FALSE(chat.isCancelVisible());
+    EXPECT_FALSE(chat.isWaiting());
+}
+
+TEST_F(AICancelTest, CancelButtonVisibleAfterSend) {
+    AudioEngine engine;
+    gsynth::AIIntegrationService service(engine.getGraph());
+    service.setProvider(std::make_unique<MockProviderPAL>());
+
+    TestPropsOwner propsOwner;
+    gsynth::AIChatComponent chat(service, propsOwner.props);
+    chat.setSize(400, 600);
+
+    // Set text and send — MockProviderPAL never calls back, so we stay in waiting state.
+    for (auto* child : chat.getChildren()) {
+        if (auto* editor = dynamic_cast<juce::TextEditor*>(child))
+            editor->setText("hello");
+    }
+    chat.triggerSend();
+
+    EXPECT_TRUE(chat.isWaiting());
+    EXPECT_TRUE(chat.isCancelVisible());
+}
+
+TEST_F(AICancelTest, CancelResetsWaitingStateAndHidesCancelButton) {
+    AudioEngine engine;
+    gsynth::AIIntegrationService service(engine.getGraph());
+    service.setProvider(std::make_unique<MockProviderPAL>());
+
+    TestPropsOwner propsOwner;
+    gsynth::AIChatComponent chat(service, propsOwner.props);
+    chat.setSize(400, 600);
+
+    // Enter waiting state.
+    for (auto* child : chat.getChildren()) {
+        if (auto* editor = dynamic_cast<juce::TextEditor*>(child))
+            editor->setText("hello");
+    }
+    chat.triggerSend();
+    ASSERT_TRUE(chat.isWaiting());
+
+    // Trigger cancel synchronously via the test hook (triggerClick posts async via MessageManager).
+    chat.simulateCancelClick();
+
+    EXPECT_FALSE(chat.isWaiting());
+    EXPECT_FALSE(chat.isCancelVisible());
+}
+
+TEST_F(AICancelTest, SendButtonReenabledAfterCancel) {
+    AudioEngine engine;
+    gsynth::AIIntegrationService service(engine.getGraph());
+    service.setProvider(std::make_unique<MockProviderPAL>());
+
+    TestPropsOwner propsOwner;
+    gsynth::AIChatComponent chat(service, propsOwner.props);
+    chat.setSize(400, 600);
+
+    for (auto* child : chat.getChildren()) {
+        if (auto* editor = dynamic_cast<juce::TextEditor*>(child))
+            editor->setText("hello");
+    }
+    chat.triggerSend();
+
+    // Trigger cancel synchronously via the test hook (triggerClick posts async via MessageManager).
+    chat.simulateCancelClick();
+
+    // Send button must be re-enabled.
+    juce::Button* sendBtn = nullptr;
+    for (auto* child : chat.getChildren()) {
+        if (auto* btn = dynamic_cast<juce::Button*>(child))
+            if (btn->getButtonText() == "Send")
+                sendBtn = btn;
+    }
+    ASSERT_NE(sendBtn, nullptr);
+    EXPECT_TRUE(sendBtn->isEnabled());
+}
+
+// ============================================================================
+// 3. Tooltip-hint formatting (pure helper — no GUI needed)
+// ============================================================================
+
+TEST(TooltipHint, EmptyShortcutReturnsBaseUnchanged) {
+    EXPECT_EQ(gravisynth::ui::formatShortcutHint("Save", ""), juce::String("Save"));
+}
+
+TEST(TooltipHint, ShortcutAppended) {
+    EXPECT_EQ(gravisynth::ui::formatShortcutHint("Save", "Cmd+S"), juce::String("Save  (Cmd+S)"));
+}
+
+TEST(TooltipHint, BothEmptyReturnsEmpty) { EXPECT_EQ(gravisynth::ui::formatShortcutHint("", ""), juce::String("")); }
+
+// ============================================================================
+// 4. Paint smoke tests
+//    Constructs MainComponent and AIChatComponent and calls paint() in various
+//    states to verify no crash.  Mirrors the headless-construction patterns in
+//    existing tests.
+// ============================================================================
+
+class PaintSmokeTest : public ::testing::Test {
+protected:
+    void SetUp() override { resetPanelKeys(); }
+    void TearDown() override { resetPanelKeys(); }
+};
+
+TEST_F(PaintSmokeTest, MainComponentPaintIdleState) {
+    MainComponent mc(std::make_unique<MockProviderPAL>());
+    mc.setSize(1600, 900);
+
+    juce::Image img(juce::Image::ARGB, 1600, 900, true);
+    juce::Graphics g(img);
+    EXPECT_NO_THROW(mc.paint(g));
+}
+
+TEST_F(PaintSmokeTest, MainComponentPaintWithAiPanelVisible) {
+    MainComponent mc(std::make_unique<MockProviderPAL>());
+    mc.setSize(1600, 900);
+    mc.simulateToggleAiPanelClick();
+
+    juce::Image img(juce::Image::ARGB, 1600, 900, true);
+    juce::Graphics g(img);
+    EXPECT_NO_THROW(mc.paint(g));
+}
+
+TEST_F(PaintSmokeTest, AIChatComponentPaintIdleState) {
+    AudioEngine engine;
+    gsynth::AIIntegrationService service(engine.getGraph());
+    service.setProvider(std::make_unique<MockProviderPAL>());
+
+    TestPropsOwner propsOwner;
+    gsynth::AIChatComponent chat(service, propsOwner.props);
+    chat.setSize(400, 600);
+
+    juce::Image img(juce::Image::ARGB, 400, 600, true);
+    juce::Graphics g(img);
+    EXPECT_NO_THROW(chat.paint(g));
+}
+
+TEST_F(PaintSmokeTest, AIChatComponentPaintWaitingState) {
+    AudioEngine engine;
+    gsynth::AIIntegrationService service(engine.getGraph());
+    service.setProvider(std::make_unique<MockProviderPAL>());
+
+    TestPropsOwner propsOwner;
+    gsynth::AIChatComponent chat(service, propsOwner.props);
+    chat.setSize(400, 600);
+
+    for (auto* child : chat.getChildren()) {
+        if (auto* editor = dynamic_cast<juce::TextEditor*>(child))
+            editor->setText("hello");
+    }
+    chat.triggerSend();
+    ASSERT_TRUE(chat.isWaiting());
+
+    juce::Image img(juce::Image::ARGB, 400, 600, true);
+    juce::Graphics g(img);
+    EXPECT_NO_THROW(chat.paint(g));
+}

--- a/Tests/SettingsWindowTests.cpp
+++ b/Tests/SettingsWindowTests.cpp
@@ -75,7 +75,7 @@ TEST_F(SettingsWindowTest, TabNamesAreCorrect) {
                                   themeManager);
     EXPECT_EQ(settingsWindow.getTabName(0), "Audio");
     EXPECT_EQ(settingsWindow.getTabName(1), "AI");
-    EXPECT_EQ(settingsWindow.getTabName(2), "General");
+    EXPECT_EQ(settingsWindow.getTabName(2), "Keyboard Shortcuts");
     EXPECT_EQ(settingsWindow.getTabName(3), "Appearance");
 }
 

--- a/Tests/ShortcutsSettingsTabTests.cpp
+++ b/Tests/ShortcutsSettingsTabTests.cpp
@@ -1,0 +1,130 @@
+// ShortcutsSettingsTabTests.cpp
+// Unit tests for ShortcutsSettingsTab: row count, description text, binding display
+// strings, paint smoke, and programmatic rebind via startListeningForTest.
+//
+// NOTE: ShortcutsSettingsTab.cpp must be added to BOTH the app target (Gravisynth)
+// and the test target (GravisynthTests) in the root CMakeLists.txt and
+// Tests/CMakeLists.txt respectively before these tests will link.
+
+#include "../Source/ShortcutManager.h"
+#include "../Source/UI/ShortcutsSettingsTab.h"
+#include <gtest/gtest.h>
+#include <juce_gui_basics/juce_gui_basics.h>
+
+class ShortcutsSettingsTabTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        // ShortcutManager::resetToDefaults() is called in its constructor.
+        tab = std::make_unique<ShortcutsSettingsTab>(manager);
+        tab->setSize(600, 500);
+    }
+
+    ShortcutManager manager;
+    std::unique_ptr<ShortcutsSettingsTab> tab;
+};
+
+// ---------------------------------------------------------------------------
+// Row count
+// ---------------------------------------------------------------------------
+
+TEST_F(ShortcutsSettingsTabTest, RowCountMatchesActionIds) {
+    // The tab must produce exactly one row per action registered in ShortcutManager.
+    int expectedCount = static_cast<int>(manager.getActionIds().size());
+    EXPECT_EQ(tab->getShortcutCount(), expectedCount);
+    EXPECT_GT(tab->getShortcutCount(), 0); // sanity: at least one action exists
+}
+
+// ---------------------------------------------------------------------------
+// Descriptions
+// ---------------------------------------------------------------------------
+
+TEST_F(ShortcutsSettingsTabTest, RowDescriptionsMatchActionDescriptions) {
+    const auto& ids = manager.getActionIds();
+    for (int i = 0; i < static_cast<int>(ids.size()); ++i) {
+        juce::String expected = ShortcutManager::getActionDescription(ids[i]);
+        EXPECT_EQ(tab->getRowDescription(i), expected)
+            << "Row " << i << " description mismatch for action: " << ids[i].toStdString();
+    }
+}
+
+TEST_F(ShortcutsSettingsTabTest, OutOfRangeDescriptionReturnsEmpty) {
+    EXPECT_EQ(tab->getRowDescription(-1), juce::String{});
+    EXPECT_EQ(tab->getRowDescription(tab->getShortcutCount()), juce::String{});
+}
+
+// ---------------------------------------------------------------------------
+// Binding display strings
+// ---------------------------------------------------------------------------
+
+TEST_F(ShortcutsSettingsTabTest, RowBindingTextsMatchCurrentBindings) {
+    const auto& ids = manager.getActionIds();
+    for (int i = 0; i < static_cast<int>(ids.size()); ++i) {
+        juce::String expected = ShortcutManager::keyPressToDisplayString(manager.getBinding(ids[i]));
+        EXPECT_EQ(tab->getRowBindingText(i), expected)
+            << "Row " << i << " binding text mismatch for action: " << ids[i].toStdString();
+    }
+}
+
+TEST_F(ShortcutsSettingsTabTest, OutOfRangeBindingTextReturnsEmpty) {
+    EXPECT_EQ(tab->getRowBindingText(-1), juce::String{});
+    EXPECT_EQ(tab->getRowBindingText(tab->getShortcutCount()), juce::String{});
+}
+
+// ---------------------------------------------------------------------------
+// Paint smoke test
+// ---------------------------------------------------------------------------
+
+TEST_F(ShortcutsSettingsTabTest, PaintDoesNotCrash) {
+    juce::Image img(juce::Image::ARGB, 600, 500, true);
+    juce::Graphics g(img);
+    EXPECT_NO_THROW(tab->paint(g));
+}
+
+// ---------------------------------------------------------------------------
+// Programmatic rebind
+// ---------------------------------------------------------------------------
+
+TEST_F(ShortcutsSettingsTabTest, StartListeningEntersListeningMode) {
+    // After startListeningForTest, the button text should change to "Press a key..."
+    ASSERT_GT(tab->getShortcutCount(), 0);
+    tab->startListeningForTest(0);
+    EXPECT_EQ(tab->getRowBindingText(0), "Press a key...");
+}
+
+TEST_F(ShortcutsSettingsTabTest, KeyPressWhileListeningUpdatesBinding) {
+    // Enter listening mode on row 0, then simulate a key press.
+    // The binding should be updated and the button text should reflect the new key.
+    ASSERT_GT(tab->getShortcutCount(), 0);
+    tab->startListeningForTest(0);
+
+    // Press Cmd+K (unlikely to conflict with row 0's default ',')
+    juce::KeyPress newKey('k', juce::ModifierKeys::commandModifier, 0);
+    tab->keyPressed(newKey);
+
+    juce::String expected = ShortcutManager::keyPressToDisplayString(newKey);
+    EXPECT_EQ(tab->getRowBindingText(0), expected);
+
+    // The ShortcutManager should also reflect the change
+    const auto& ids = manager.getActionIds();
+    EXPECT_EQ(manager.getBinding(ids[0]).getKeyCode(), 'k');
+}
+
+TEST_F(ShortcutsSettingsTabTest, EscapeCancelsListening) {
+    ASSERT_GT(tab->getShortcutCount(), 0);
+    // Record the original binding text
+    juce::String original = tab->getRowBindingText(0);
+
+    tab->startListeningForTest(0);
+    EXPECT_EQ(tab->getRowBindingText(0), "Press a key..."); // in listening mode
+
+    // Press Escape — should restore the original text
+    tab->keyPressed(juce::KeyPress(juce::KeyPress::escapeKey));
+    EXPECT_EQ(tab->getRowBindingText(0), original);
+}
+
+TEST_F(ShortcutsSettingsTabTest, ResizingDoesNotCrash) {
+    EXPECT_NO_THROW(tab->setSize(400, 300));
+    EXPECT_NO_THROW(tab->resized());
+    EXPECT_NO_THROW(tab->setSize(800, 600));
+    EXPECT_NO_THROW(tab->resized());
+}

--- a/Tests/UIAnimationTests.cpp
+++ b/Tests/UIAnimationTests.cpp
@@ -1,0 +1,178 @@
+// UIAnimationTests.cpp
+// Headless gtest coverage for gravisynth::ui easing math and formatShortcutHint.
+// Does NOT test the JUCE-dependent AnimationDriver (that requires a running
+// MessageManager / VBlankAttachment and is validated by the paint smoke test below).
+//
+// All tests in this file run without a GUI / MessageManager. They only exercise
+// the pure-math and pure-string sections of UIAnimation.h, which have no JUCE
+// GUI dependencies.
+
+#include "../Source/UI/UIAnimation.h"
+#include <cmath>
+#include <gtest/gtest.h>
+
+// ============================================================================
+// easeOutCubic
+// ============================================================================
+
+TEST(EaseOutCubic, Endpoints) {
+    EXPECT_FLOAT_EQ(gravisynth::ui::easeOutCubic(0.0f), 0.0f);
+    EXPECT_FLOAT_EQ(gravisynth::ui::easeOutCubic(1.0f), 1.0f);
+}
+
+TEST(EaseOutCubic, MidpointIsReasonable) {
+    // At t=0.5, easeOutCubic should be > 0.5 (output front-loaded)
+    const float mid = gravisynth::ui::easeOutCubic(0.5f);
+    EXPECT_GT(mid, 0.5f);
+    EXPECT_LT(mid, 1.0f);
+}
+
+TEST(EaseOutCubic, Monotonic) {
+    // Output must be strictly non-decreasing for t in [0,1].
+    float prev = gravisynth::ui::easeOutCubic(0.0f);
+    for (int i = 1; i <= 100; ++i) {
+        const float t = static_cast<float>(i) / 100.0f;
+        const float val = gravisynth::ui::easeOutCubic(t);
+        EXPECT_GE(val, prev) << "Not monotonic at t=" << t;
+        prev = val;
+    }
+}
+
+// ============================================================================
+// easeInOutCubic
+// ============================================================================
+
+TEST(EaseInOutCubic, Endpoints) {
+    EXPECT_FLOAT_EQ(gravisynth::ui::easeInOutCubic(0.0f), 0.0f);
+    EXPECT_FLOAT_EQ(gravisynth::ui::easeInOutCubic(1.0f), 1.0f);
+}
+
+TEST(EaseInOutCubic, Symmetry) {
+    // easeInOutCubic(t) + easeInOutCubic(1-t) == 1  (anti-symmetric around 0.5)
+    for (int i = 0; i <= 10; ++i) {
+        const float t = static_cast<float>(i) / 10.0f;
+        const float sum = gravisynth::ui::easeInOutCubic(t) + gravisynth::ui::easeInOutCubic(1.0f - t);
+        EXPECT_NEAR(sum, 1.0f, 1e-5f) << "Symmetry broken at t=" << t;
+    }
+}
+
+TEST(EaseInOutCubic, MidpointIsHalf) { EXPECT_NEAR(gravisynth::ui::easeInOutCubic(0.5f), 0.5f, 1e-5f); }
+
+TEST(EaseInOutCubic, Monotonic) {
+    float prev = gravisynth::ui::easeInOutCubic(0.0f);
+    for (int i = 1; i <= 100; ++i) {
+        const float t = static_cast<float>(i) / 100.0f;
+        const float val = gravisynth::ui::easeInOutCubic(t);
+        EXPECT_GE(val, prev) << "Not monotonic at t=" << t;
+        prev = val;
+    }
+}
+
+// ============================================================================
+// easeOutBack
+// ============================================================================
+
+TEST(EaseOutBack, Endpoints) {
+    EXPECT_FLOAT_EQ(gravisynth::ui::easeOutBack(0.0f), 0.0f);
+    EXPECT_NEAR(gravisynth::ui::easeOutBack(1.0f), 1.0f, 1e-5f);
+}
+
+TEST(EaseOutBack, OvershootsAboveOne) {
+    // easeOutBack should exceed 1.0 somewhere in (0.5, 1.0) — that's the "back" effect.
+    bool foundOvershoot = false;
+    for (int i = 50; i < 100; ++i) {
+        const float t = static_cast<float>(i) / 100.0f;
+        if (gravisynth::ui::easeOutBack(t) > 1.0f) {
+            foundOvershoot = true;
+            break;
+        }
+    }
+    EXPECT_TRUE(foundOvershoot) << "easeOutBack should overshoot 1.0 near t=1";
+}
+
+// ============================================================================
+// AnimationDriver::lerpBounds
+// ============================================================================
+
+TEST(AnimationDriverLerpBounds, ZeroTReturnsFrom) {
+    juce::Rectangle<int> from{0, 0, 100, 50};
+    juce::Rectangle<int> to{200, 100, 300, 150};
+    auto result = gravisynth::ui::AnimationDriver::lerpBounds(from, to, 0.0f);
+    EXPECT_EQ(result, from);
+}
+
+TEST(AnimationDriverLerpBounds, OneTReturnsTo) {
+    juce::Rectangle<int> from{0, 0, 100, 50};
+    juce::Rectangle<int> to{200, 100, 300, 150};
+    auto result = gravisynth::ui::AnimationDriver::lerpBounds(from, to, 1.0f);
+    EXPECT_EQ(result, to);
+}
+
+TEST(AnimationDriverLerpBounds, HalfTIsMidpoint) {
+    juce::Rectangle<int> from{0, 0, 100, 100};
+    juce::Rectangle<int> to{200, 200, 300, 300};
+    auto result = gravisynth::ui::AnimationDriver::lerpBounds(from, to, 0.5f);
+    EXPECT_EQ(result.getX(), 100);
+    EXPECT_EQ(result.getY(), 100);
+    EXPECT_EQ(result.getWidth(), 200);
+    EXPECT_EQ(result.getHeight(), 200);
+}
+
+// ============================================================================
+// formatShortcutHint
+// ============================================================================
+
+TEST(FormatShortcutHint, EmptyShortcutReturnsBase) {
+    auto result = gravisynth::ui::formatShortcutHint("Save", "");
+    EXPECT_EQ(result, juce::String("Save"));
+}
+
+TEST(FormatShortcutHint, NonEmptyShortcutAppendsHint) {
+    auto result = gravisynth::ui::formatShortcutHint("Save", "Cmd+S");
+    EXPECT_EQ(result, juce::String("Save  (Cmd+S)"));
+}
+
+TEST(FormatShortcutHint, BothEmptyReturnsEmpty) {
+    auto result = gravisynth::ui::formatShortcutHint("", "");
+    EXPECT_EQ(result, juce::String(""));
+}
+
+TEST(FormatShortcutHint, BaseEmptyWithShortcutReturnsFormatted) {
+    auto result = gravisynth::ui::formatShortcutHint("", "Ctrl+Z");
+    EXPECT_EQ(result, juce::String("  (Ctrl+Z)"));
+}
+
+// ============================================================================
+// Paint smoke test for AnimationDriver (GUI required — runs under the shared
+// ScopedJuceInitialiser_GUI in TestMain.cpp).
+// Constructs a dummy Component, creates an AnimationDriver + VBlankAnimatorUpdater,
+// starts a zero-or-near-zero duration animation, and pumps the message queue.
+// The test simply asserts no crash.
+// ============================================================================
+
+TEST(AnimationDriverSmoke, StartAndCompleteNocrash) {
+    // A plain Component suffices — VBlankAttachment works on any Component.
+    juce::Component dummyComponent;
+    dummyComponent.setSize(1, 1);
+
+    juce::VBlankAnimatorUpdater updater{&dummyComponent};
+    gravisynth::ui::AnimationDriver driver;
+
+    bool completeCalled = false;
+    float lastT = -1.0f;
+
+    driver.start(
+        updater,
+        /*durationMs=*/1.0, gravisynth::ui::easeOutCubic, [&](float t) { lastT = t; },
+        [&]() { completeCalled = true; });
+
+    EXPECT_TRUE(driver.isRunning());
+
+    // Pump the message loop briefly; the 1 ms animation should complete quickly.
+    if (auto* mm = juce::MessageManager::getInstanceWithoutCreating())
+        mm->runDispatchLoopUntil(50);
+
+    // Either completeCalled is true (fast machine) or we at least got frames.
+    // The key assertion is: no crash.
+    SUCCEED();
+}

--- a/assets/icons/action-new.svg
+++ b/assets/icons/action-new.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
+  <path d="M5,4 L5,20 L19,20 L19,10 L14,10 L14,4 Z" stroke="#FFFFFF" stroke-width="1.5" fill="none" stroke-linejoin="round"/>
+  <path d="M14,4 L14,10 L19,10" stroke="#FFFFFF" stroke-width="1.5" fill="none" stroke-linejoin="round"/>
+  <path d="M10,14 L14,14 M12,12 L12,16" stroke="#FFFFFF" stroke-width="2" fill="none" stroke-linecap="round"/>
+</svg>

--- a/docs/layout.md
+++ b/docs/layout.md
@@ -554,3 +554,80 @@ Guidelines to preserve smooth frame rates:
 - **Single re-skin pass on theme switch**: `GravisynthLookAndFeel::applyTheme()` → `sendLookAndFeelChangeMessage()` → one `repaint()`. No timer is started and no continuous repaint is added during or after a theme switch.
 - **`applyToolbarIcons()` is gated**: cloning `Drawable` objects is expensive. The call is restricted to narrow-mode transitions in `MainComponent::resized()` — not executed on every resize frame. See §5 for the gate logic.
 - **Status bar polls at 5 Hz** and repaints only itself (`repaint()` on `StatusBarComponent` only). There are zero `writeToLog` calls in the status-polling path.
+- **All UI animations are time-bounded** (see §11). They run for a finite transition duration and stop when settled. Never add continuous / per-frame animations outside the loading-spinner exception defined in §11.
+
+---
+
+## 11. Animation System (Phase 5)
+
+Phase 5 introduces a shared animation infrastructure in `Source/UI/UIAnimation.h` (namespace `gravisynth::ui`). All motion in the app uses this helper. The `juce_animation` module is linked into both `GravisynthCore` and the `Gravisynth` app target.
+
+### Easing functions
+
+Pure, stateless helpers — no component state required:
+
+| Function | Signature | Curve |
+|---|---|---|
+| `easeOutCubic` | `float easeOutCubic(float t)` | Fast-out deceleration |
+| `easeInOutCubic` | `float easeInOutCubic(float t)` | Smooth in + out |
+| `easeOutBack` | `float easeOutBack(float t)` | Overshoots slightly then settles |
+
+All take `t` in `[0, 1]` and return a mapped `[0, 1]` value (may exceed 1 briefly for `easeOutBack`).
+
+### `AnimationDriver`
+
+VBlank-driven, **time-bounded** tween: animates a progress value from `0` to `1` over a caller-specified duration, then auto-stops. It never ticks beyond `t = 1.0`.
+
+**Usage contract:**
+
+```cpp
+// Members in the owning component:
+juce::VBlankAnimatorUpdater vblankUpdater_{ this };
+gravisynth::ui::AnimationDriver driver_;
+
+// Start a 200 ms transition:
+driver_.start(0.20);   // seconds
+
+// In timerCallback / VBlank callback:
+float t = driver_.getValue();
+auto bounds = AnimationDriver::lerpBounds(startRect, endRect, t);
+setBounds(bounds);
+if (!driver_.isRunning())
+    ; // settled — no more repaints fired
+```
+
+**Key properties:**
+- Callers must hold both a `juce::VBlankAnimatorUpdater` and an `AnimationDriver` as members (VBlank updater keeps the driver alive and ticking).
+- `isRunning()` returns `false` once `t` reaches `1.0` — the driver stops itself and fires no further repaints.
+- `AnimationDriver::lerpBounds(from, to, t)` is a static helper that interpolates a `juce::Rectangle<int>` linearly between two positions.
+
+### `formatShortcutHint`
+
+```cpp
+juce::String formatShortcutHint(const juce::String& base,
+                                const juce::String& shortcutDisplay);
+```
+
+Composes tooltip text with an optional keyboard shortcut hint appended in `[brackets]`. Pass an empty `shortcutDisplay` to omit the hint. Used by feature controls to produce consistent `setTooltip()` strings.
+
+### Phase 5 micro-interactions
+
+| Feature | Animation | Note |
+|---|---|---|
+| **Module drop landing** | Eased tween from drop position → snapped + anti-overlapped final position (`easeOutBack`); `computeDropFinalPosition` is a pure helper | `GraphEditor` |
+| **Mod-matrix show/hide** | Bounds tween, `easeInOutCubic` | `GraphEditor` |
+| **Library sidebar show/hide** | Bounds tween, `easeInOutCubic` | `MainComponent` |
+| **AI panel show/hide** | Bounds tween, `easeInOutCubic` | `MainComponent` |
+| **Empty-canvas first-run hint** | Static drawn text; no animation — drawn only when `isCanvasEmpty(nodeCount)` returns `true` | `GraphEditor` |
+| **ModuleLibraryComponent rows** | Row hover-highlight; grab/dragging-hand cursor on draggable rows; per-module descriptions via `descriptionFor(name)` surfaced as `setTooltip()` | `ModuleLibraryComponent` |
+| **Preset-load feedback** | Status bar text updated during load; no spinner | `MainComponent` → `StatusBarComponent` |
+| **AI request Cancel + spinner** | Cancel button visible while a request is in flight; pulsing "thinking" spinner (time-bounded — stops on completion or cancel, confined to its region) | `AIChatComponent` |
+
+### Time-bounded animation rule
+
+**All animations MUST be time-bounded.** An `AnimationDriver` runs for a finite duration and stops at `t = 1.0`. The single permitted exception is the AI thinking spinner — it pulses only while a network request is in flight and stops immediately on completion or cancel. Its repaint is confined to its own component region.
+
+Never add:
+- Continuous `timerCallback` repaints on `ModuleComponent` or its children outside the existing gated 15 Hz gate.
+- A free-running `AnimationDriver` (no duration, or duration far longer than the visible transition).
+- Per-frame `repaint()` calls in any path that is always active (not gated to an active transition).

--- a/docs/shortcuts.md
+++ b/docs/shortcuts.md
@@ -1,6 +1,6 @@
 # Keyboard Shortcuts
 
-Shortcuts are configurable in Settings → General tab (click a binding to rebind, with conflict detection and swap). Export/import shortcuts as JSON. A native macOS menu bar (File + Edit) provides Undo/Redo via `ApplicationCommandManager`, while `keyPressed()` handles all shortcuts with case-insensitive key matching.
+Shortcuts are configurable in **Settings → Keyboard Shortcuts** tab (renamed from "General" in Phase 5; extracted into `ShortcutsSettingsTab.h/.cpp`). Click any binding to rebind it; conflict detection swaps the displaced binding automatically. Export/import shortcuts as JSON or reset to defaults. A native macOS menu bar (File + Edit) provides Undo/Redo via `ApplicationCommandManager`, while `keyPressed()` handles all shortcuts with case-insensitive key matching.
 
 | Shortcut | Action |
 |----------|--------|

--- a/docs/shortcuts.md
+++ b/docs/shortcuts.md
@@ -5,6 +5,7 @@ Shortcuts are configurable in **Settings → Keyboard Shortcuts** tab (renamed f
 | Shortcut | Action |
 |----------|--------|
 | Cmd+, | Open Settings |
+| Cmd+N | New Patch (clear canvas) |
 | Cmd+S | Save Preset |
 | Cmd+O | Open Preset (file picker) |
 | Cmd+Z | Undo |

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -450,6 +450,10 @@ The following stock-widget overrides are now fully implemented in `GravisynthLoo
 
 > **MidiKeyboardComponent limitation:** `juce_audio_utils` is not linked into `GravisynthCore` (it would bloat the headless test binary). As a result, `MidiKeyboardComponent` inherits JUCE default colours and cannot be themed from `GravisynthLookAndFeel`. This is a known and accepted limitation.
 
+### Phase 5 completions
+
+- **TooltipWindow** — a single `juce::TooltipWindow` is now owned by `MainComponent` (member `tooltipWindow{ this }`). The tooltip `ColourIds` and `drawTooltip` override were already present in `GravisynthLookAndFeel`; this instance causes them to take effect. Feature code calls `setTooltip()` on individual controls; no second `TooltipWindow` should be created elsewhere.
+
 ### Phase 4 completions
 
 - **Waveform glyphs** (`WaveformSine`, `WaveformSaw`, `WaveformSquare`, `WaveformTriangle`) — SVG assets added in `assets/icons/waveform-{sine,saw,square,triangle}.svg`; `Icon` enum values 22–25 registered in `IconLibrary`; tinted to `textPrimary` by `retintIcons()`; consumed by `ModuleComponent` waveform combos (Oscillator). `GravisynthLookAndFeel::drawPopupMenuItem` now paints the 14×14 waveform glyph left of the item text; `drawComboBox` renders the selected waveform glyph in the closed combo; `positionComboBoxText` shifts the label right when the selected item carries a glyph.


### PR DESCRIPTION
## Summary

UI Phase 5 (#101): onboarding & micro-interactions. Adds `juce_animation`-backed, **time-bounded** micro-interactions, first-run guidance, tooltips everywhere, a dedicated Keyboard Shortcuts settings tab, a **New Patch** action, and loading/cancel feedback for slow actions. Follows Phase 4 (#100/#109); rebased onto main after #113.

## Changes

- **Animation infra:** linked `juce_animation`; new header-only `Source/UI/UIAnimation.h` (`gravisynth::ui`) with a time-bounded `AnimationDriver` (VBlank tween that auto-stops when settled), easing math (`easeOutCubic` / `easeInOutCubic` / `easeOutBack`), and `formatShortcutHint`.
- **Tooltips:** one `juce::TooltipWindow` owned by `MainComponent`; each owner sets tooltips on its own controls, with shortcut hints pulled from `ShortcutManager`.
- **GraphEditor:** empty-canvas first-run hint ("Drag modules here to build your patch") — drawn in `paintOverChildren()` centered in the visible viewport (not the transformed canvas); eased drop-landing to the snapped + anti-overlapped position; eased mod-matrix show/hide.
- **ModuleLibrary:** row hover-highlight, grab/dragging-hand cursor, and per-module descriptions surfaced as tooltips.
- **Settings:** extracted the keyboard-shortcut editor into a dedicated, still-editable **"Keyboard Shortcuts"** tab (`ShortcutsSettingsTab.h/.cpp`).
- **New Patch action:** `Cmd+N` + toolbar button (with a new `ActionNew` icon) that clears the canvas back to the empty state and is **undoable** (`Cmd+Z` restores) — makes the empty-canvas hint reachable on demand. Auto-listed in the Keyboard Shortcuts tab.
- **MainComponent / AIChat:** eased library + AI panel show/hide (layout stays synchronous; animation is cosmetic), preset-load status feedback (`StatusBarComponent::showMessage`), and an AI request **cancel** button + time-bounded pulsing "thinking" spinner.
- **Invariants preserved:** all animations time-bounded; `ModuleComponent` `setBufferedToImage` perf gating untouched; **no** high-frequency logging on the global `juce::Logger`; themes don't swap fonts.

## Test Plan

- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] Tested locally (build + run)
- [x] Documentation updated (CLAUDE.md, docs/) to reflect any new files, architecture changes, or conventions

New test suites: `UIAnimationTests`, `GraphEditorOnboardingTests`, `ModuleLibraryComponentTests`, `ShortcutsSettingsTabTests`, `PanelAnimationAndLoadingTests` (plus New Patch + icon/hint coverage). **Full suite: 592 passing.** The `Gravisynth` app target also builds clean. Formatted with the repo-pinned clang-format 22.1.2 (matches CI, per #113).

## Screenshots

N/A — run locally to view the empty-canvas hint, tooltips, eased panel transitions, the New Patch button, and the AI cancel button / spinner.

Closes #101
