### PR TITLE
fix: restore AI model discovery after provider installation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,7 @@ Every implementation plan **must** include:
 - **No high-frequency logging** — AIChatComponent registers a global `juce::Logger` (Debug builds only) that pipes `writeToLog` into a UI-thread console. Never add per-sample / per-frame / per-parameter / per-connection logs (one caused a multi-second freeze; guarded by `AIStateMapperTest.PresetLoadDoesNotSpamLogger`). → [`docs/AI_Engine.md`](docs/AI_Engine.md)
 - **No unconditional per-tick repaint** — `ModuleComponent` is `setBufferedToImage(true)` with a gated 15 Hz timer; the 30 Hz GraphEditor animation composites cached images. A theme switch is exactly one re-skin pass. All UI animations use `AnimationDriver` (VBlank-driven, **time-bounded** — stops at `t=1`); never add free-running or continuous repaints. Exception: the AI thinking spinner pulses only while a request is in flight, confined to its region. → [`docs/layout.md §10–11`](docs/layout.md)
 - **Themes don't swap fonts** — all built-ins share Inter + JetBrains Mono; swapping the embedded typeface *family* at runtime corrupts text (JUCE 8 + CoreText). Themes differ by colour/treatment/glow only. → [`docs/theming.md`](docs/theming.md)
+- **AI model discovery ordering** — `AIChatComponent`'s ctor-time `refreshModels()` is a no-op if its `AIIntegrationService` has no provider yet; any owner (e.g. `MainComponent`) that installs a provider afterward MUST call `refreshModels()` again post-`setProvider()`, or `currentModel` stays empty and every `/api/chat` gets a 400. → [`docs/AI_Engine.md`](docs/AI_Engine.md)
 
 ## Docs map
 

--- a/Source/AI/OllamaProvider.cpp
+++ b/Source/AI/OllamaProvider.cpp
@@ -124,6 +124,30 @@ void OllamaProvider::run() {
 }
 
 void OllamaProvider::processRequest(const Request& req) {
+    // Delivers (responseText, success) through the same test-mode-aware channel used by
+    // every exit path below, so the fail-fast path and the network paths stay identical.
+    auto deliver = [this, &req](const juce::String& responseText, bool success) {
+        if (isTestMode) {
+            if (req.callback)
+                req.callback(responseText, success);
+        } else {
+            juce::MessageManager::callAsync([req, responseText, success]() {
+                if (req.callback)
+                    req.callback(responseText, success);
+            });
+        }
+    };
+
+    // Fail fast: never hit the network with an empty model. Ollama rejects such requests
+    // with HTTP 400 "model is required", which previously surfaced as a misleading
+    // "Could not connect to Ollama" error even when the server was reachable.
+    if (currentModel.isEmpty()) {
+        deliver("Error: No Ollama model selected. Check that Ollama is running and that a model is available "
+                "(ollama list).",
+                false);
+        return;
+    }
+
     juce::URL url(ollamaHost + "/api/chat");
 
     // Build JSON body
@@ -147,10 +171,12 @@ void OllamaProvider::processRequest(const Request& req) {
 
     juce::String responseText;
     bool success = false;
+    int httpStatus = 0;
 
-    if (auto stream = createStream(
-            url.withPOSTData(jsonString),
-            juce::URL::InputStreamOptions(juce::URL::ParameterHandling::inPostData).withConnectionTimeoutMs(120000))) {
+    if (auto stream = createStream(url.withPOSTData(jsonString),
+                                   juce::URL::InputStreamOptions(juce::URL::ParameterHandling::inPostData)
+                                       .withConnectionTimeoutMs(120000)
+                                       .withStatusCode(&httpStatus))) {
         responseText = stream->readEntireStreamAsString();
         // DBG("AI Chat Response (before JSON parse): [" + responseText + "]"); // Potentially expensive
 
@@ -166,19 +192,14 @@ void OllamaProvider::processRequest(const Request& req) {
                 }
             }
         }
+    } else if (httpStatus != 0) {
+        responseText =
+            "Error: Ollama at " + ollamaHost + " rejected the request (HTTP " + juce::String(httpStatus) + ").";
     } else {
         responseText = "Error: Could not connect to Ollama at " + ollamaHost;
     }
 
-    if (isTestMode) {
-        if (req.callback)
-            req.callback(responseText, success);
-    } else {
-        juce::MessageManager::callAsync([req, responseText, success]() {
-            if (req.callback)
-                req.callback(responseText, success);
-        });
-    }
+    deliver(responseText, success);
 }
 
 } // namespace gsynth

--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -78,9 +78,13 @@ void MainComponent::initialiseCommon(std::unique_ptr<gsynth::AIProvider> provide
         aiService.setProvider(std::make_unique<gsynth::OllamaProvider>(savedOllamaHost));
     }
 
-    // NOTE: Do NOT call aiChatComponent.refreshModels() here. The AIChatComponent
-    // constructor already kicks off model discovery on construction. A second call
-    // would trigger a redundant /api/tags request on startup.
+    // ORDERING CONTRACT: aiChatComponent is a member, so its constructor (which calls
+    // refreshModels()) already ran BEFORE this body — at that point aiService had no
+    // provider, so discovery short-circuited and no model was ever selected. We must
+    // refresh again HERE, after setProvider(), or currentModel stays empty and every
+    // /api/chat request is rejected by Ollama with HTTP 400 "model is required".
+    // Regression: see #96 / f7cba4a.
+    aiChatComponent.refreshModels();
     aiService.addListener(this);
     undoManager.setGraphEditor(&graphEditor);
     setWantsKeyboardFocus(true);

--- a/Source/MainComponent.h
+++ b/Source/MainComponent.h
@@ -93,6 +93,7 @@ public:
     // tests can verify the patch-name side effect without driving the async PopupMenu.
     void simulateLoadFactoryPresetForTest(int index);
     void openPresetFromFile();
+    gsynth::AIIntegrationService& getAiServiceForTest() { return aiService; }
 
 private:
     // AIIntegrationService::Listener

--- a/Tests/AIChatComponentTests.cpp
+++ b/Tests/AIChatComponentTests.cpp
@@ -23,7 +23,10 @@ public:
     juce::String getCurrentModel() const override { return currentModel; }
 
 private:
-    juce::String currentModel = "MockModel1";
+    // Empty by default (not pre-seeded with a model name) so tests that check
+    // getCurrentModel() after refreshModels()/setModel() genuinely prove that a model was
+    // selected, rather than being masked by a non-empty default.
+    juce::String currentModel;
 };
 
 class AIChatComponentTest : public ::testing::Test {
@@ -98,4 +101,36 @@ TEST_F(AIChatComponentTest, SendMessageUpdatesUIAndHistory) {
 
     // The AI response should now also be in the history because MockChatProvider is synchronous
     EXPECT_GT(service.getHistory().size(), initialHistorySize + 1);
+}
+
+// REGRESSION LOCK: reproduces MainComponent's member-init ordering, where AIChatComponent is
+// constructed BEFORE the owning component installs a provider on the service. The ctor's own
+// refreshModels() call therefore finds no provider and short-circuits, leaving currentModel
+// empty. The owner (MainComponent::initialiseCommon) must call refreshModels() again AFTER
+// setProvider(), or currentModel stays empty and every /api/chat request is rejected by
+// Ollama with HTTP 400 "model is required".
+TEST_F(AIChatComponentTest, RefreshModelsSelectsModelWhenProviderInstalledAfterConstruction) {
+    AudioEngine engine;
+    gsynth::AIIntegrationService service(engine.getGraph());
+    // No provider installed yet — mirrors AIChatComponent being constructed before
+    // MainComponent::initialiseCommon() calls aiService.setProvider().
+
+    juce::ApplicationProperties props;
+    juce::PropertiesFile::Options options;
+    options.applicationName = "Test";
+    options.filenameSuffix = "test";
+    options.storageFormat = juce::PropertiesFile::storeAsXML;
+    props.setStorageParameters(options);
+
+    gsynth::AIChatComponent chatComponent(service, props);
+
+    // The ctor's own refreshModels() ran with no provider installed, so no model was ever
+    // selected.
+    EXPECT_TRUE(service.getCurrentModel().isEmpty());
+
+    // Now install the provider (as MainComponent does later in its ctor body) and refresh.
+    service.setProvider(std::make_unique<MockChatProvider>());
+    chatComponent.refreshModels();
+
+    EXPECT_FALSE(service.getCurrentModel().isEmpty());
 }

--- a/Tests/MainComponentTests.cpp
+++ b/Tests/MainComponentTests.cpp
@@ -20,6 +20,28 @@ private:
     juce::String model = "MockModel";
 };
 
+// Mock provider that records fetchAvailableModels() calls and honours setModel()/
+// getCurrentModel() so tests can verify the post-setProvider() model-selection contract.
+class ModelTrackingMockProvider : public gsynth::AIProvider {
+public:
+    juce::String getProviderName() const override { return "ModelTrackingMock"; }
+    void fetchAvailableModels(std::function<void(const juce::StringArray&, bool)> callback) override {
+        ++fetchCallCount;
+        callback({"mock-model-a", "mock-model-b"}, true);
+    }
+    void sendPrompt(const std::vector<Message>&, CompletionCallback callback, const juce::var&) override {
+        if (callback)
+            callback("Mock response.", true);
+    }
+    void setModel(const juce::String& name) override { model = name; }
+    juce::String getCurrentModel() const override { return model; }
+
+    int fetchCallCount = 0;
+
+private:
+    juce::String model;
+};
+
 class MainComponentTest : public ::testing::Test {
 protected:
     // MainComponent reads/writes the panel-visibility flags from the shared "Gravisynth"
@@ -286,6 +308,21 @@ TEST_F(MainComponentTest, PatchNameUpdatesOnFactoryPresetLoad) {
     // loadFactoryPreset(index) + setCurrentPatchName(presets[index].name).
     mc.simulateLoadFactoryPresetForTest(1);
     EXPECT_EQ(mc.getCurrentPatchName(), presets[1].name);
+}
+
+// REGRESSION LOCK (f7cba4a): MainComponent must refresh models AFTER setProvider(). The
+// AIChatComponent ctor's own refreshModels() runs before the provider exists, so without
+// the post-setProvider refresh currentModel stays empty and every /api/chat is a 400
+// "model is required".
+TEST_F(MainComponentTest, AiProviderGetsModelSelectedOnStartup) {
+    auto ownedProvider = std::make_unique<ModelTrackingMockProvider>();
+    ModelTrackingMockProvider* rawProvider = ownedProvider.get();
+
+    MainComponent mc(std::move(ownedProvider));
+
+    EXPECT_GE(rawProvider->fetchCallCount, 1);
+    EXPECT_FALSE(mc.getAiServiceForTest().getCurrentModel().isEmpty());
+    EXPECT_EQ(mc.getAiServiceForTest().getCurrentModel(), "mock-model-a");
 }
 
 // Regression: toolbar buttons must have non-zero bounds immediately after construction,

--- a/Tests/OllamaProviderTests.cpp
+++ b/Tests/OllamaProviderTests.cpp
@@ -274,6 +274,74 @@ TEST_F(OllamaProviderTest, FetchAvailableModelsDoesNotBlockCaller) {
     provider.stopThread(5000);
 }
 
+// REGRESSION LOCK: sendPrompt() must fail fast, without touching the network, when no
+// model has been selected. Previously an empty currentModel silently sent
+// {"model": ""} to Ollama's /api/chat, which the server rejects with HTTP 400
+// "model is required" — surfaced to the user as a misleading "Could not connect"
+// error even though the server was perfectly reachable.
+TEST_F(OllamaProviderTest, SendPromptWithNoModelFailsWithoutHittingNetwork) {
+    bool networkFactoryInvoked = false;
+    auto trackingFactory =
+        [&networkFactoryInvoked](const juce::URL& url,
+                                 const juce::URL::InputStreamOptions& options) -> std::unique_ptr<juce::InputStream> {
+        juce::ignoreUnused(url, options);
+        networkFactoryInvoked = true;
+        juce::String jsonResponse =
+            R"({"model":"mock-model","message":{"role":"assistant","content":"Should not be reached."}})";
+        return std::make_unique<MockInputStream>(jsonResponse, false);
+    };
+
+    gsynth::OllamaProvider provider{"http://mock-host:11434", trackingFactory};
+    provider.setTestMode(true);
+    // Deliberately do NOT call setModel() — currentModel stays empty.
+
+    std::vector<gsynth::AIProvider::Message> conversation = {{"user", "Hello AI"}};
+    MockCompletionCallback callback;
+    provider.sendPrompt(conversation,
+                        [&callback](const juce::String& response, bool success) { callback(response, success); });
+
+    auto result = callback.getResult();
+    provider.stopThread(5000);
+
+    ASSERT_FALSE(std::get<1>(result)); // success == false
+    EXPECT_TRUE(std::get<0>(result).containsIgnoreCase("model"));
+    EXPECT_FALSE(networkFactoryInvoked) << "sendPrompt() must not hit the network when no model is selected";
+}
+
+// REGRESSION LOCK: direct lock on "we never send an empty model to Ollama". Captures the
+// actual POST body sent to /api/chat and verifies the "model" field matches whatever was
+// set via setModel().
+TEST_F(OllamaProviderTest, SendPromptIncludesSelectedModelInRequestBody) {
+    juce::String capturedPostData;
+    auto capturingFactory =
+        [&capturedPostData](const juce::URL& url,
+                            const juce::URL::InputStreamOptions& options) -> std::unique_ptr<juce::InputStream> {
+        juce::ignoreUnused(options);
+        capturedPostData = url.getPostData();
+        juce::String jsonResponse =
+            R"({"model":"mock-model","message":{"role":"assistant","content":"Mocked AI response."}})";
+        return std::make_unique<MockInputStream>(jsonResponse, false);
+    };
+
+    gsynth::OllamaProvider provider{"http://mock-host:11434", capturingFactory};
+    provider.setTestMode(true);
+    provider.setModel("mock-model:latest");
+
+    std::vector<gsynth::AIProvider::Message> conversation = {{"user", "Hello AI"}};
+    MockCompletionCallback callback;
+    provider.sendPrompt(conversation,
+                        [&callback](const juce::String& response, bool success) { callback(response, success); });
+
+    auto result = callback.getResult();
+    provider.stopThread(5000);
+
+    ASSERT_TRUE(std::get<1>(result)); // success == true
+
+    juce::var parsedBody = juce::JSON::parse(capturedPostData);
+    ASSERT_TRUE(parsedBody.isObject());
+    EXPECT_EQ(parsedBody.getProperty("model", juce::var()).toString(), juce::String("mock-model:latest"));
+}
+
 TEST_F(OllamaProviderTest, SendPromptTimeoutFails) {
     // Create a provider that uses the slow stream factory
     gsynth::OllamaProvider mockProviderSlowStream{"http://mock-host:11434", createSlowStream};

--- a/docs/AI_Engine.md
+++ b/docs/AI_Engine.md
@@ -115,6 +115,52 @@ isAiPanelVisible = appProperties.getUserSettings()->getBoolValue("aiPanelVisible
 
 Changes are written back to the same key when the panel is toggled.
 
+### Model Discovery Ordering Contract
+
+`AIChatComponent`'s constructor calls `refreshModels()` at construction time, which calls
+`AIIntegrationService::fetchAvailableModels()`. **If the service has no provider installed
+yet at that point, discovery short-circuits** (`AIIntegrationService::fetchAvailableModels`
+immediately invokes the callback with `({}, false)` when `provider == nullptr`) and no model
+is ever selected — `AIProvider::currentModel` (e.g. `OllamaProvider::currentModel`) stays
+empty for the rest of the session.
+
+This matters because `MainComponent` declares `aiChatComponent` as a member that is
+constructed in the member-initialiser list — i.e. **before** the constructor body runs — while
+`aiService.setProvider(...)` only happens later, inside `MainComponent::initialiseCommon()`.
+So the chat component's own ctor-time `refreshModels()` call is guaranteed to run with no
+provider installed and is therefore a no-op (it issues no `/api/tags` request at all).
+
+**Any owner that constructs `AIChatComponent` before installing a provider on the
+`AIIntegrationService` it was given MUST call `chatComponent.refreshModels()` again AFTER
+`aiService.setProvider(...)`.** `MainComponent::initialiseCommon()` does this immediately
+after its `setProvider(...)` if/else block. Skipping this step means `currentModel` stays
+empty and every subsequent `/api/chat` request is sent with `"model": ""`, which Ollama
+rejects with HTTP 400 `"model is required"`.
+
+Regression: this call was mistakenly deleted in commit `f7cba4a` (issue #96) and replaced
+with a comment incorrectly claiming the ctor-time call already covered discovery. Locked by
+`MainComponentTest.AiProviderGetsModelSelectedOnStartup` and
+`AIChatComponentTest.RefreshModelsSelectsModelWhenProviderInstalledAfterConstruction`.
+
+### OllamaProvider: Fail-Fast on Empty Model + HTTP-Status-Aware Errors
+
+`OllamaProvider::processRequest` (used by `sendPrompt`) now guards against the empty-model
+case directly: if `currentModel.isEmpty()`, it returns
+`"Error: No Ollama model selected. Check that Ollama is running and that a model is available
+(ollama list)."` with `success = false` **without touching the network** — this closes the
+window where the bug above could still silently POST `{"model": ""}`.
+
+When the HTTP request itself fails, `OllamaProvider` now distinguishes a reachable-but-rejecting
+server from an unreachable one using `juce::URL::InputStreamOptions::withStatusCode(&httpStatus)`:
+- Non-zero `httpStatus` (server responded, but `createInputStream` returned `nullptr` because the
+  status wasn't 2xx): `"Error: Ollama at <host> rejected the request (HTTP <status>)."`
+- `httpStatus == 0` (no response at all — connection refused/timeout): the original
+  `"Error: Could not connect to Ollama at <host>"`.
+
+Locked by `OllamaProviderTest.SendPromptWithNoModelFailsWithoutHittingNetwork` and
+`OllamaProviderTest.SendPromptIncludesSelectedModelInRequestBody` in
+`Tests/OllamaProviderTests.cpp`.
+
 ## 6. Future Considerations
 
 -   **Direct Saving of AI Suggested Patches**: Implement functionality for users to directly save AI-generated patches as presets.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -44,7 +44,7 @@ Test module interactions within the audio graph and cross-system integrations.
 |-------|-------|----------------|
 | IntegrationTest | 7 | Signal chain routing (Osc->Filter->VCA), LFO->Filter modulation, preset loading with graph structure validation |
 | ModMatrixTest | 22 | Add/remove mod routings, amount scaling, channel mapping, modulation chains; Phase 4 adds: `RowHeightIs48` — `kRowHeight == 48`; `ZebraAlternates` — `isZebraRow` false for even, true for odd indices; `HoverStateUpdates` — `setHoveredRow`/`getHoveredRow` round-trip, default -1, redundant-set no-op, reset to -1; `ModMatrixComponentPaintSmokeTest` — paint with two routings, no crash; `HoverResetsAfterRowRemoval` — hover clears to -1 when a routing is removed (componentsChanged path) |
-| OllamaProviderTest | 5 | AI LLM HTTP requests, streaming responses, model management |
+| OllamaProviderTest | 8 | AI LLM HTTP requests, streaming responses, model management, non-blocking discovery; `SendPromptWithNoModelFailsWithoutHittingNetwork` — fail-fast with no network call when `currentModel` is empty; `SendPromptIncludesSelectedModelInRequestBody` — captures the POST body and asserts `"model"` matches `setModel()` (regression lock for f7cba4a / empty-model 400s) |
 | AIIntegrationServiceTest | 9 | Module suggestions, parameter recommendations, graph state mapping |
 
 ### Component Workflow Tests (~50 tests)
@@ -53,7 +53,8 @@ Test UI component interactions using in-process construction (no window, no disp
 
 | Suite | Tests | What it covers |
 |-------|-------|----------------|
-| MainComponentTest | 20 | AI panel visibility toggle, mod matrix toggle, default configuration, command manager registration, redo shortcut; toolbar narrow/wide mode at 480/1600 px, library sidebar toggle + persistence, AI panel persistence, status bar bounds, canvas non-zero at minimum size, timer gating (5 Hz), patch name default + update on preset load, DrawableButton header buttons |
+| MainComponentTest | 21 | AI panel visibility toggle, mod matrix toggle, default configuration, command manager registration, redo shortcut; toolbar narrow/wide mode at 480/1600 px, library sidebar toggle + persistence, AI panel persistence, status bar bounds, canvas non-zero at minimum size, timer gating (5 Hz), patch name default + update on preset load, DrawableButton header buttons; `AiProviderGetsModelSelectedOnStartup` — regression lock (f7cba4a) that a model is selected on startup via `aiChatComponent.refreshModels()` called AFTER `setProvider()` |
+| AIChatComponentTest | 3 | Initialization/resizing, send-message updates UI + history via mock provider; `RefreshModelsSelectsModelWhenProviderInstalledAfterConstruction` — reproduces MainComponent's member-init ordering (chat component constructed before a provider is installed), asserting `getCurrentModel()` stays empty until a post-construction `setProvider()` + `refreshModels()` |
 | GraphEditorTest | 11 | Module drag-and-drop, port connection via beginConnectionDrag/endConnectionDrag, deletion, mod matrix visibility, snap-on-drop (position is grid-multiple of 8), overlap resolution (second drop at same coord produces non-overlapping bounding boxes) |
 | ModuleComponentTest | 5 | Initialization, resizing, parameter attachment to UI sliders; bypass/mute/delete are DrawableButtons with correct header bounds; delete button triggers requestDeleteModule |
 | MidiKeyboardModuleTest | 4 | Note on/off, key press handling, velocity |


### PR DESCRIPTION
## Problem

The Ollama integration stopped working. The model picker showed **"Error fetching models"**, and every chat request failed with a misleading **"Could not connect to Ollama"** — even though the server was running and reachable.

## Root cause

`MainComponent.h` declares `aiService` before `aiChatComponent`, so both are constructed in the **member-initialiser list** — before the constructor body reaches `initialiseCommon()` → `aiService.setProvider(...)`.

`AIChatComponent`'s constructor calls `refreshModels()`. At that instant `provider` is still null, so `AIIntegrationService::fetchAvailableModels` short-circuits to `callback({}, false)` and **`setModel()` is never called**. `OllamaProvider::currentModel` then stays empty for the whole session.

Every `/api/chat` POST therefore carried `"model": ""`. Reproduced against a live server:

```
HTTP=400  {"error":"model is required"}
```

`juce::URL::createInputStream` returns `nullptr` on non-2xx, so the code fell into its "could not connect" branch — which is why this presented as a connectivity fault rather than a missing model.

**Regression introduced in `f7cba4a`** (#96), which deleted the post-`setProvider` `refreshModels()` call on the premise that the constructor-time call already covered it. That premise is wrong: the constructor-time call issues no `/api/tags` request at all, because the provider doesn't exist yet. Restoring the call yields exactly one discovery request, not two.

## Changes

- **`Source/MainComponent.cpp`** — call `refreshModels()` after `setProvider()`, with the ordering contract documented inline.
- **`Source/AI/OllamaProvider.cpp`** — `processRequest()` now fails fast when no model is selected (never sends an empty model), and reports the real HTTP status via `withStatusCode()` instead of always blaming the connection. Both behaviours are why this fault misdiagnosed as a server problem.
- **`Source/MainComponent.h`** — `getAiServiceForTest()` accessor.
- Docs: `docs/AI_Engine.md`, `docs/testing.md`, plus one `CLAUDE.md` invariant bullet.

## Tests

Four new tests at three levels, so this can't slip back through the same gap:

| Test | Locks |
|---|---|
| `MainComponentTest.AiProviderGetsModelSelectedOnStartup` | a real `MainComponent` ends construction with a model selected |
| `AIChatComponentTest.RefreshModelsSelectsModelWhenProviderInstalledAfterConstruction` | the provider-installed-after-construction ordering |
| `OllamaProviderTest.SendPromptWithNoModelFailsWithoutHittingNetwork` | no network call, honest error message |
| `OllamaProviderTest.SendPromptIncludesSelectedModelInRequestBody` | the wire body never carries an empty `model` |

**Why the existing suite missed this:** every prior test called `setProvider()` *before* constructing the component — the reverse of production order — and `MockChatProvider` pre-seeded `currentModel = "MockModel1"`, masking a never-called `setModel`. That default is now empty.

## Verification

- **Full suite: 602/602 pass.**
- The primary regression lock was confirmed to genuinely fail against the unfixed code (`fetchCallCount` 0, `currentModel` empty); restoring the one-line fix returns it to green.
- Verified end to end against a live Ollama 0.32.5: discovery returned 11 models and a chat round-trip replied successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)