### PR TITLE
Centralise product identity into Source/Branding.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,14 @@ FetchContent_MakeAvailable(juce)
 option(ENABLE_COVERAGE "Enable code coverage testing" OFF)
 option(ENABLE_TESTS "Enable building test suite" OFF)
 
+# Product identity — the single place to override branding at configure time
+# (e.g. `cmake -S . -B build -DSYNTH_PRODUCT_NAME=MySynth`). Mirrored in C++ at
+# Source/Branding.h, which JUCE's PRODUCT_NAME/COMPANY_NAME/BUNDLE_ID args can't read
+# directly since they're consumed at configure time, not compile time.
+set(SYNTH_PRODUCT_NAME "Gravisynth" CACHE STRING "Display name: window title, About box, installer")
+set(SYNTH_COMPANY_NAME "yourcompany" CACHE STRING "JUCE COMPANY_NAME / macOS bundle vendor")
+set(SYNTH_BUNDLE_ID "com.gravisynth.app" CACHE STRING "macOS/iOS CFBundleIdentifier")
+
 if(ENABLE_COVERAGE)
     if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
         add_compile_options(-fprofile-instr-generate -fcoverage-mapping)
@@ -40,8 +48,9 @@ endif()
 add_library(GravisynthCore STATIC
     Source/AudioEngine.cpp
     Source/AudioEngine.h
-    Source/GravisynthUndoManager.cpp
-    Source/GravisynthUndoManager.h
+    Source/AppUndoManager.cpp
+    Source/AppUndoManager.h
+    Source/Branding.h
     Source/PresetManager.cpp
     Source/PresetManager.h
     # Modules
@@ -89,8 +98,8 @@ add_library(GravisynthCore STATIC
     Source/UI/Theme/BuiltInThemes.cpp
     Source/UI/Theme/IconLibrary.h
     Source/UI/Theme/IconLibrary.cpp
-    Source/UI/Theme/GravisynthLookAndFeel.h
-    Source/UI/Theme/GravisynthLookAndFeel.cpp
+    Source/UI/Theme/AppLookAndFeel.h
+    Source/UI/Theme/AppLookAndFeel.cpp
 )
 
 # Link Core against JUCE
@@ -135,9 +144,10 @@ endif()
 
 # Create the application target
 juce_add_gui_app(Gravisynth
-    PRODUCT_NAME "Gravisynth"
+    PRODUCT_NAME "${SYNTH_PRODUCT_NAME}"
     VERSION "0.13.2"
-    BUNDLE_ID "com.gravisynth.app"
+    COMPANY_NAME "${SYNTH_COMPANY_NAME}"
+    BUNDLE_ID "${SYNTH_BUNDLE_ID}"
     BLUETOOTH_PERMISSION_ENABLED TRUE
     BLUETOOTH_PERMISSION_TEXT "We need Bluetooth access to connect to your external MIDI devices."
 )
@@ -145,7 +155,7 @@ juce_add_gui_app(Gravisynth
 juce_generate_juce_header(Gravisynth)
 
 # Embed font files as binary data (SIL OFL licensed — see assets/fonts/LICENSES.md).
-# GravisynthLookAndFeel (compiled into GravisynthCore) loads these typefaces from BinaryData,
+# AppLookAndFeel (compiled into GravisynthCore) loads these typefaces from BinaryData,
 # so the asset library + GRAVISYNTH_HAS_FONT_ASSETS define are attached to Core (PUBLIC) below;
 # the app and the test target both link Core and therefore resolve the BinaryData symbols.
 # Guard: icon filenames must use hyphens only (JUCE strips hyphens entirely, so 'a-b.svg' becomes

--- a/Source/AI/AIIntegrationService.cpp
+++ b/Source/AI/AIIntegrationService.cpp
@@ -1,4 +1,5 @@
 #include "AIIntegrationService.h"
+#include "../Branding.h"
 
 namespace synth {
 
@@ -110,9 +111,12 @@ void AIIntegrationService::initSystemPrompt() {
     juce::String schema = AIStateMapper::getModuleSchema();
 
     juce::String systemMsg =
-        "You are Gravisynth AI, an expert sound designer for the Gravisynth modular synthesizer. "
-        "Your goal is to help users create and modify patches. "
-        "Gravisynth uses a nodes-and-connections model. "
+        "You are " + juce::String(synth::branding::kProductName) + " AI, an expert sound designer for the " +
+        juce::String(synth::branding::kProductName) +
+        " modular synthesizer. "
+        "Your goal is to help users create and modify patches. " +
+        juce::String(synth::branding::kProductName) +
+        " uses a nodes-and-connections model. "
         "\n\n" +
         schema +
         "\n"

--- a/Source/AppUndoManager.cpp
+++ b/Source/AppUndoManager.cpp
@@ -1,4 +1,4 @@
-#include "GravisynthUndoManager.h"
+#include "AppUndoManager.h"
 #include "AI/AIStateMapper.h"
 #include "UI/GraphEditor.h"
 
@@ -181,9 +181,9 @@ private:
 
 // =============================================================================
 
-GravisynthUndoManager::GravisynthUndoManager() {}
+AppUndoManager::AppUndoManager() {}
 
-void GravisynthUndoManager::recordStructuralChange(juce::AudioProcessorGraph& graph, std::function<void()> mutation) {
+void AppUndoManager::recordStructuralChange(juce::AudioProcessorGraph& graph, std::function<void()> mutation) {
     auto beforeState = synth::AIStateMapper::graphToJSON(graph);
 
     undoManager.beginNewTransaction();
@@ -205,17 +205,15 @@ void GravisynthUndoManager::recordStructuralChange(juce::AudioProcessorGraph& gr
         }));
 }
 
-void GravisynthUndoManager::recordParameterChange(juce::AudioProcessorGraph& graph,
-                                                  juce::AudioProcessorGraph::NodeID nodeId, const juce::String& paramId,
-                                                  float oldValue, float newValue) {
+void AppUndoManager::recordParameterChange(juce::AudioProcessorGraph& graph, juce::AudioProcessorGraph::NodeID nodeId,
+                                           const juce::String& paramId, float oldValue, float newValue) {
     // The firstPerform flag will skip the first perform() since the parameter
     // was already changed by the user.
     undoManager.perform(new ParameterChangeAction(graph, nodeId, paramId, oldValue, newValue));
 }
 
-void GravisynthUndoManager::recordPositionChange(juce::AudioProcessorGraph& graph,
-                                                 juce::AudioProcessorGraph::NodeID nodeId, int oldX, int oldY, int newX,
-                                                 int newY, std::function<void()> postRestore) {
+void AppUndoManager::recordPositionChange(juce::AudioProcessorGraph& graph, juce::AudioProcessorGraph::NodeID nodeId,
+                                          int oldX, int oldY, int newX, int newY, std::function<void()> postRestore) {
     undoManager.beginNewTransaction();
 
     // The firstPerform flag will skip the first perform() since the position
@@ -223,11 +221,11 @@ void GravisynthUndoManager::recordPositionChange(juce::AudioProcessorGraph& grap
     undoManager.perform(new PositionChangeAction(graph, nodeId, oldX, oldY, newX, newY, postRestore));
 }
 
-void GravisynthUndoManager::captureBeforeState(juce::AudioProcessorGraph& graph) {
+void AppUndoManager::captureBeforeState(juce::AudioProcessorGraph& graph) {
     capturedBeforeState = synth::AIStateMapper::graphToJSON(graph);
 }
 
-void GravisynthUndoManager::pushSnapshotFromCapture(juce::AudioProcessorGraph& graph) {
+void AppUndoManager::pushSnapshotFromCapture(juce::AudioProcessorGraph& graph) {
     if (capturedBeforeState.isVoid())
         return;
 

--- a/Source/AppUndoManager.h
+++ b/Source/AppUndoManager.h
@@ -5,15 +5,15 @@
 #include <juce_data_structures/juce_data_structures.h>
 
 /**
- * @class GravisynthUndoManager
+ * @class AppUndoManager
  * @brief Thin wrapper around juce::UndoManager with convenience methods for
  *        structural changes, parameter edits, and module repositioning.
  */
 class GraphEditor; // Forward declaration
 
-class GravisynthUndoManager {
+class AppUndoManager {
 public:
-    GravisynthUndoManager();
+    AppUndoManager();
 
     void setGraphEditor(GraphEditor* ge) { graphEditor = ge; }
 
@@ -81,5 +81,5 @@ private:
     juce::UndoManager undoManager{30000000, 50}; // 30MB limit, 50 min transactions
     juce::var capturedBeforeState;
 
-    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(GravisynthUndoManager)
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(AppUndoManager)
 };

--- a/Source/Branding.h
+++ b/Source/Branding.h
@@ -1,0 +1,38 @@
+#pragma once
+
+// Single source of truth for product identity in application code. Renaming the product
+// later should mean editing the values in this file (plus the mirrored CMake cache
+// variables in CMakeLists.txt, which JUCE's PRODUCT_NAME/COMPANY_NAME/BUNDLE_ID need at
+// configure time and can't read a C++ header for).
+
+namespace synth::branding {
+
+// Window title (via ProjectInfo::projectName, generated from CMake PRODUCT_NAME), About
+// box, and installer/package display name.
+constexpr const char* kProductName = "Gravisynth";
+
+// JUCE COMPANY_NAME (juce_add_gui_app) and the macOS bundle vendor field.
+constexpr const char* kCompanyName = "yourcompany";
+
+// macOS/iOS CFBundleIdentifier (juce_add_gui_app BUNDLE_ID).
+constexpr const char* kBundleIdentifier = "com.gravisynth.app";
+
+// juce::PropertiesFile::Options::folderName — the on-disk ApplicationProperties folder,
+// also the parent of the user Themes folder (ThemeManager::getUserThemesFolder()).
+// WARNING: do NOT change this value. It is the folder name existing users' settings,
+// presets, and themes already live under; changing it orphans that data. A follow-up task
+// adds a migration shim — only after that lands is it safe to change.
+constexpr const char* kSettingsFolderName = "Gravisynth";
+
+// Folder name reserved for user-saved presets. Not yet referenced on disk (preset
+// save/load currently goes through ad hoc juce::FileChooser dialogs with no fixed
+// directory); seeded here so a future on-disk preset store has a name to use.
+constexpr const char* kPresetFolderName = "Gravisynth";
+
+// Product website, for the About box / support links. Not yet referenced anywhere.
+constexpr const char* kWebsiteUrl = "https://gravisynth.app";
+
+// Support contact address, for the About box / support links. Not yet referenced anywhere.
+constexpr const char* kSupportEmail = "support@gravisynth.app";
+
+} // namespace synth::branding

--- a/Source/Main.cpp
+++ b/Source/Main.cpp
@@ -1,12 +1,12 @@
 #include "MainComponent.h"
 #include "ShortcutManager.h"
-#include "UI/Theme/GravisynthLookAndFeel.h"
+#include "UI/Theme/AppLookAndFeel.h"
 #include "UI/Theme/ThemeManager.h"
 #include <JuceHeader.h>
 
-class GravisynthApplication : public juce::JUCEApplication {
+class AppApplication : public juce::JUCEApplication {
 public:
-    GravisynthApplication() {}
+    AppApplication() {}
 
     const juce::String getApplicationName() override { return ProjectInfo::projectName; }
     const juce::String getApplicationVersion() override { return ProjectInfo::versionString; }
@@ -40,7 +40,7 @@ public:
         : public juce::DocumentWindow
         , public juce::MenuBarModel {
     public:
-        MainWindow(juce::String name, synth::theme::ThemeManager& tm, synth::theme::GravisynthLookAndFeel& lf)
+        MainWindow(juce::String name, synth::theme::ThemeManager& tm, synth::theme::AppLookAndFeel& lf)
             : DocumentWindow(name,
                              juce::Desktop::getInstance().getDefaultLookAndFeel().findColour(
                                  juce::ResizableWindow::backgroundColourId),
@@ -83,13 +83,13 @@ public:
             if (auto* mc = dynamic_cast<MainComponent*>(getContentComponent())) {
                 auto& cm = mc->getCommandManager();
                 if (menuIndex == 0) {
-                    menu.addCommandItem(&cm, GravisynthCommands::savePreset);
-                    menu.addCommandItem(&cm, GravisynthCommands::openPreset);
+                    menu.addCommandItem(&cm, AppCommands::savePreset);
+                    menu.addCommandItem(&cm, AppCommands::openPreset);
                     menu.addSeparator();
-                    menu.addCommandItem(&cm, GravisynthCommands::openSettings);
+                    menu.addCommandItem(&cm, AppCommands::openSettings);
                 } else if (menuIndex == 1) {
-                    menu.addCommandItem(&cm, GravisynthCommands::undo);
-                    menu.addCommandItem(&cm, GravisynthCommands::redo);
+                    menu.addCommandItem(&cm, AppCommands::undo);
+                    menu.addCommandItem(&cm, AppCommands::redo);
                 }
             }
             return menu;
@@ -106,9 +106,9 @@ private:
     // so they are constructed first and destroyed LAST (after mainWindow). This guarantees
     // the LnF object outlives every Component — the classic JUCE shutdown-crash guard.
     synth::theme::ThemeManager themeManager;
-    synth::theme::GravisynthLookAndFeel lookAndFeel;
+    synth::theme::AppLookAndFeel lookAndFeel;
     std::unique_ptr<MainWindow> mainWindow;
 };
 
 //==============================================================================
-START_JUCE_APPLICATION(GravisynthApplication)
+START_JUCE_APPLICATION(AppApplication)

--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -1,9 +1,10 @@
 #include "MainComponent.h"
 #include "AI/OllamaProvider.h"
+#include "Branding.h"
 #include "UI/SettingsWindow.h"
 
 // ---- Primary constructor (injected ThemeManager + LookAndFeel from Main.cpp) ----
-MainComponent::MainComponent(synth::theme::ThemeManager& tm, synth::theme::GravisynthLookAndFeel& lf,
+MainComponent::MainComponent(synth::theme::ThemeManager& tm, synth::theme::AppLookAndFeel& lf,
                              std::unique_ptr<synth::AIProvider> provider)
     : graphEditor(audioEngine, &undoManager)
     , aiService(audioEngine.getGraph())
@@ -11,8 +12,8 @@ MainComponent::MainComponent(synth::theme::ThemeManager& tm, synth::theme::Gravi
     , themeManager(&tm)
     , lookAndFeel(&lf) {
     // Setup ApplicationProperties
-    propertiesOptions.applicationName = "Gravisynth";
-    propertiesOptions.folderName = "Gravisynth";
+    propertiesOptions.applicationName = synth::branding::kProductName;
+    propertiesOptions.folderName = synth::branding::kSettingsFolderName;
     propertiesOptions.filenameSuffix = "settings";
     propertiesOptions.osxLibrarySubFolder = "Application Support";
     propertiesOptions.storageFormat = juce::PropertiesFile::storeAsXML;
@@ -37,13 +38,13 @@ MainComponent::MainComponent(std::unique_ptr<synth::AIProvider> provider)
     // Own a default ThemeManager + LookAndFeel so the code behaves identically
     // to the primary-ctor path (no special-casing in the rest of the class).
     ownedThemeManager = std::make_unique<synth::theme::ThemeManager>();
-    ownedLookAndFeel = std::make_unique<synth::theme::GravisynthLookAndFeel>();
+    ownedLookAndFeel = std::make_unique<synth::theme::AppLookAndFeel>();
     themeManager = ownedThemeManager.get();
     lookAndFeel = ownedLookAndFeel.get();
 
     // Setup ApplicationProperties (same as primary ctor)
-    propertiesOptions.applicationName = "Gravisynth";
-    propertiesOptions.folderName = "Gravisynth";
+    propertiesOptions.applicationName = synth::branding::kProductName;
+    propertiesOptions.folderName = synth::branding::kSettingsFolderName;
     propertiesOptions.filenameSuffix = "settings";
     propertiesOptions.osxLibrarySubFolder = "Application Support";
     propertiesOptions.storageFormat = juce::PropertiesFile::storeAsXML;
@@ -112,7 +113,7 @@ void MainComponent::initialiseCommon(std::unique_ptr<synth::AIProvider> provider
     // Buttons
     addAndMakeVisible(newButton);
     newButton.setComponentID("newButton");
-    newButton.onClick = [this] { commandManager.invokeDirectly(GravisynthCommands::newPatch, true); };
+    newButton.onClick = [this] { commandManager.invokeDirectly(AppCommands::newPatch, true); };
 
     addAndMakeVisible(saveButton);
     saveButton.setComponentID("saveButton");
@@ -361,69 +362,68 @@ void MainComponent::paint(juce::Graphics& g) {
 }
 
 void MainComponent::getAllCommands(juce::Array<juce::CommandID>& commands) {
-    commands.addArray({GravisynthCommands::openSettings, GravisynthCommands::savePreset, GravisynthCommands::openPreset,
-                       GravisynthCommands::newPatch, GravisynthCommands::undo, GravisynthCommands::redo,
-                       GravisynthCommands::toggleModMatrix, GravisynthCommands::toggleAiPanel,
-                       GravisynthCommands::autoArrange, GravisynthCommands::toggleLibrary});
+    commands.addArray({AppCommands::openSettings, AppCommands::savePreset, AppCommands::openPreset,
+                       AppCommands::newPatch, AppCommands::undo, AppCommands::redo, AppCommands::toggleModMatrix,
+                       AppCommands::toggleAiPanel, AppCommands::autoArrange, AppCommands::toggleLibrary});
 }
 
 void MainComponent::getCommandInfo(juce::CommandID commandID, juce::ApplicationCommandInfo& result) {
     switch (commandID) {
-    case GravisynthCommands::openSettings: {
+    case AppCommands::openSettings: {
         result.setInfo("Open Settings", "Open the settings window", "General", 0);
         auto kp = shortcutManager.getBinding("openSettings");
         result.addDefaultKeypress(kp.getKeyCode(), kp.getModifiers());
         break;
     }
-    case GravisynthCommands::savePreset: {
+    case AppCommands::savePreset: {
         result.setInfo("Save Preset", "Save the current preset", "General", 0);
         auto kp = shortcutManager.getBinding("savePreset");
         result.addDefaultKeypress(kp.getKeyCode(), kp.getModifiers());
         break;
     }
-    case GravisynthCommands::openPreset: {
+    case AppCommands::openPreset: {
         result.setInfo("Open Preset", "Open a preset file", "General", 0);
         auto kp = shortcutManager.getBinding("openPreset");
         result.addDefaultKeypress(kp.getKeyCode(), kp.getModifiers());
         break;
     }
-    case GravisynthCommands::newPatch: {
+    case AppCommands::newPatch: {
         result.setInfo("New Patch", "Clear the canvas and start a new patch", "General", 0);
         auto kp = shortcutManager.getBinding("newPatch");
         result.addDefaultKeypress(kp.getKeyCode(), kp.getModifiers());
         break;
     }
-    case GravisynthCommands::undo: {
+    case AppCommands::undo: {
         result.setInfo("Undo", "Undo the last action", "Edit", 0);
         auto kp = shortcutManager.getBinding("undo");
         result.addDefaultKeypress(kp.getKeyCode(), kp.getModifiers());
         break;
     }
-    case GravisynthCommands::redo: {
+    case AppCommands::redo: {
         result.setInfo("Redo", "Redo the last undone action", "Edit", 0);
         auto kp = shortcutManager.getBinding("redo");
         result.addDefaultKeypress(kp.getKeyCode(), kp.getModifiers());
         break;
     }
-    case GravisynthCommands::toggleModMatrix: {
+    case AppCommands::toggleModMatrix: {
         result.setInfo("Toggle Mod Matrix", "Toggle the modulation matrix panel", "View", 0);
         auto kp = shortcutManager.getBinding("toggleModMatrix");
         result.addDefaultKeypress(kp.getKeyCode(), kp.getModifiers());
         break;
     }
-    case GravisynthCommands::toggleAiPanel: {
+    case AppCommands::toggleAiPanel: {
         result.setInfo("Toggle AI Panel", "Toggle the AI chat panel", "View", 0);
         auto kp = shortcutManager.getBinding("toggleAiPanel");
         result.addDefaultKeypress(kp.getKeyCode(), kp.getModifiers());
         break;
     }
-    case GravisynthCommands::autoArrange: {
+    case AppCommands::autoArrange: {
         result.setInfo("Auto Arrange", "Auto-arrange modules by signal flow", "View", 0);
         auto kp = shortcutManager.getBinding("autoArrange");
         result.addDefaultKeypress(kp.getKeyCode(), kp.getModifiers());
         break;
     }
-    case GravisynthCommands::toggleLibrary: {
+    case AppCommands::toggleLibrary: {
         result.setInfo("Toggle Module Library", "Toggle the module library sidebar", "View", 0);
         auto kp = shortcutManager.getBinding("toggleLibrary");
         result.addDefaultKeypress(kp.getKeyCode(), kp.getModifiers());
@@ -436,40 +436,40 @@ void MainComponent::getCommandInfo(juce::CommandID commandID, juce::ApplicationC
 
 bool MainComponent::perform(const InvocationInfo& info) {
     switch (info.commandID) {
-    case GravisynthCommands::openSettings:
+    case AppCommands::openSettings:
         if (settingsButton.onClick)
             settingsButton.onClick();
         return true;
-    case GravisynthCommands::savePreset:
+    case AppCommands::savePreset:
         if (saveButton.onClick)
             saveButton.onClick();
         return true;
-    case GravisynthCommands::openPreset:
+    case AppCommands::openPreset:
         openPresetFromFile();
         return true;
-    case GravisynthCommands::newPatch:
+    case AppCommands::newPatch:
         graphEditor.newPatch();
         setCurrentPatchName("Untitled");
         statusBar.showMessage("New patch");
         return true;
-    case GravisynthCommands::undo:
+    case AppCommands::undo:
         if (undoManager.canUndo())
             undoManager.undo();
         return true;
-    case GravisynthCommands::redo:
+    case AppCommands::redo:
         if (undoManager.canRedo())
             undoManager.redo();
         return true;
-    case GravisynthCommands::toggleModMatrix:
+    case AppCommands::toggleModMatrix:
         toggleModMatrixButton.triggerClick();
         return true;
-    case GravisynthCommands::toggleAiPanel:
+    case AppCommands::toggleAiPanel:
         toggleAiPanelButton.triggerClick();
         return true;
-    case GravisynthCommands::autoArrange:
+    case AppCommands::autoArrange:
         graphEditor.autoArrange();
         return true;
-    case GravisynthCommands::toggleLibrary:
+    case AppCommands::toggleLibrary:
         setLibraryVisible(!isLibraryVisible);
         return true;
     default:
@@ -483,7 +483,7 @@ bool MainComponent::keyPressed(const juce::KeyPress& key) {
     auto action = shortcutManager.getActionForKeyPress(key);
     if (action.isEmpty())
         return false;
-    auto cmdId = GravisynthCommands::getCommandForAction(action);
+    auto cmdId = AppCommands::getCommandForAction(action);
     if (cmdId == 0)
         return false;
     return commandManager.invokeDirectly(cmdId, true);
@@ -496,7 +496,7 @@ void MainComponent::resized() {
     int tbH = 36, sbH = 24;
     int libW = isLibraryVisible ? 200 : 0;
     int aiW = isAiPanelVisible ? 300 : 0;
-    if (auto* lf = dynamic_cast<synth::theme::GravisynthLookAndFeel*>(&getLookAndFeel())) {
+    if (auto* lf = dynamic_cast<synth::theme::AppLookAndFeel*>(&getLookAndFeel())) {
         const auto& m = lf->getTheme().metrics;
         tbH = m.toolbarHeight;
         sbH = m.statusBarHeight;
@@ -531,7 +531,7 @@ void MainComponent::resized() {
 void MainComponent::applyToolbarIcons() {
     using synth::theme::Icon;
 
-    auto* lf = dynamic_cast<synth::theme::GravisynthLookAndFeel*>(&getLookAndFeel());
+    auto* lf = dynamic_cast<synth::theme::AppLookAndFeel*>(&getLookAndFeel());
 
     // In narrow mode the buttons are 32 px wide — icon only, no text. In wide mode the
     // toggle buttons carry stateful text; the rest carry a static label.
@@ -603,7 +603,7 @@ MainComponent::PanelBoundsResult MainComponent::computePanelBounds(bool libVisib
     int tbH = 36, sbH = 24;
     int libW = libVisible ? 200 : 0;
     int aiW = aiVisible ? 300 : 0;
-    if (auto* lf = dynamic_cast<const synth::theme::GravisynthLookAndFeel*>(&getLookAndFeel())) {
+    if (auto* lf = dynamic_cast<const synth::theme::AppLookAndFeel*>(&getLookAndFeel())) {
         const auto& m = lf->getTheme().metrics;
         tbH = m.toolbarHeight;
         sbH = m.statusBarHeight;

--- a/Source/MainComponent.h
+++ b/Source/MainComponent.h
@@ -1,15 +1,15 @@
 #pragma once
 
 #include "AI/AIIntegrationService.h"
+#include "AppUndoManager.h"
 #include "AudioEngine.h"
-#include "GravisynthUndoManager.h"
 #include "PresetManager.h"
 #include "ShortcutManager.h"
 #include "UI/AIChatComponent.h"
 #include "UI/GraphEditor.h"
 #include "UI/ModuleLibraryComponent.h"
 #include "UI/StatusBarComponent.h"
-#include "UI/Theme/GravisynthLookAndFeel.h"
+#include "UI/Theme/AppLookAndFeel.h"
 #include "UI/Theme/ThemeManager.h"
 #include "UI/ToolbarComponent.h"
 #include "UI/UIAnimation.h"
@@ -27,11 +27,11 @@ class MainComponent
 public:
     // Primary ctor: receives injected ThemeManager and LookAndFeel from Main.cpp.
     // provider is optional (nullptr → reads saved provider pref from appProperties).
-    MainComponent(synth::theme::ThemeManager& tm, synth::theme::GravisynthLookAndFeel& lf,
+    MainComponent(synth::theme::ThemeManager& tm, synth::theme::AppLookAndFeel& lf,
                   std::unique_ptr<synth::AIProvider> provider = nullptr);
 
     // Delegating ctor for tests and legacy call sites that don't inject theme objects.
-    // Lazily owns private default ThemeManager + GravisynthLookAndFeel instances
+    // Lazily owns private default ThemeManager + AppLookAndFeel instances
     // (stored in ownedThemeManager / ownedLookAndFeel below).
     explicit MainComponent(std::unique_ptr<synth::AIProvider> provider = nullptr);
 
@@ -83,7 +83,7 @@ public:
         if (redoButton.onClick)
             redoButton.onClick();
     }
-    GravisynthUndoManager& getUndoManager() { return undoManager; }
+    AppUndoManager& getUndoManager() { return undoManager; }
     AudioEngine& getAudioEngine() { return audioEngine; }
     const juce::String& getCurrentPatchName() const { return currentPatchName_; }
     // Non-const access to ApplicationProperties for persistence tests (read-back within session).
@@ -130,15 +130,15 @@ private:
     // Owned fallback objects used when the delegating ctor is called (tests/legacy).
     // Null when the primary ctor is used (refs point at external objects instead).
     std::unique_ptr<synth::theme::ThemeManager> ownedThemeManager;
-    std::unique_ptr<synth::theme::GravisynthLookAndFeel> ownedLookAndFeel;
+    std::unique_ptr<synth::theme::AppLookAndFeel> ownedLookAndFeel;
 
     // Non-owning references to the active ThemeManager and LookAndFeel.
     // Always valid — set by both constructors (either to external objects or to the
     // owned fallbacks above).
     synth::theme::ThemeManager* themeManager{nullptr};
-    synth::theme::GravisynthLookAndFeel* lookAndFeel{nullptr};
+    synth::theme::AppLookAndFeel* lookAndFeel{nullptr};
 
-    GravisynthUndoManager undoManager;
+    AppUndoManager undoManager;
     AudioEngine audioEngine;
     GraphEditor graphEditor;
     ModuleLibraryComponent moduleLibrary;

--- a/Source/ShortcutManager.h
+++ b/Source/ShortcutManager.h
@@ -2,7 +2,7 @@
 
 #include <juce_gui_basics/juce_gui_basics.h>
 
-namespace GravisynthCommands {
+namespace AppCommands {
 enum CommandIDs {
     openSettings = 0x100,
     savePreset,
@@ -39,7 +39,7 @@ inline juce::CommandID getCommandForAction(const juce::String& actionId) {
         return toggleLibrary;
     return 0;
 }
-} // namespace GravisynthCommands
+} // namespace AppCommands
 
 class ShortcutManager {
 public:

--- a/Source/UI/AIChatComponent.cpp
+++ b/Source/UI/AIChatComponent.cpp
@@ -367,7 +367,7 @@ void AIChatComponent::resized() {
 }
 
 void AIChatComponent::paint(juce::Graphics& g) {
-    auto lf = dynamic_cast<synth::theme::GravisynthLookAndFeel*>(&getLookAndFeel());
+    auto lf = dynamic_cast<synth::theme::AppLookAndFeel*>(&getLookAndFeel());
     if (lf != nullptr) {
         g.fillAll(lf->getTheme().colors.bg0);
     } else {

--- a/Source/UI/AIChatComponent.h
+++ b/Source/UI/AIChatComponent.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "../AI/AIIntegrationService.h"
-#include "Theme/GravisynthLookAndFeel.h"
+#include "Theme/AppLookAndFeel.h"
 #include "UIAnimation.h"
 #include <atomic>
 #include <juce_animation/juce_animation.h>
@@ -72,8 +72,8 @@ private:
         SpinnerDot() = default;
 
         void paint(juce::Graphics& g) override {
-            using synth::theme::GravisynthLookAndFeel;
-            auto* lf = dynamic_cast<GravisynthLookAndFeel*>(&getLookAndFeel());
+            using synth::theme::AppLookAndFeel;
+            auto* lf = dynamic_cast<AppLookAndFeel*>(&getLookAndFeel());
             juce::Colour accentColor = (lf != nullptr) ? lf->getTheme().colors.accent : juce::Colours::lightblue;
             g.setColour(accentColor.withAlpha(currentAlpha));
             g.fillEllipse(getLocalBounds().toFloat().reduced(1.0f));

--- a/Source/UI/FrequencyResponseComponent.h
+++ b/Source/UI/FrequencyResponseComponent.h
@@ -2,7 +2,7 @@
 
 #include "../Modules/FilterModule.h"
 #include "../Modules/VisualBuffer.h"
-#include "Theme/GravisynthLookAndFeel.h"
+#include "Theme/AppLookAndFeel.h"
 #include "Theme/Theme.h"
 #include <cmath>
 #include <juce_dsp/juce_dsp.h>
@@ -142,8 +142,8 @@ public:
         float w = bounds.getWidth();
         float h = bounds.getHeight();
 
-        using synth::theme::GravisynthLookAndFeel;
-        auto* lf = dynamic_cast<GravisynthLookAndFeel*>(&getLookAndFeel());
+        using synth::theme::AppLookAndFeel;
+        auto* lf = dynamic_cast<AppLookAndFeel*>(&getLookAndFeel());
 
         juce::Colour bgColor = lf ? lf->getTheme().colors.bg1 : juce::Colour(0xff1a1a2e);
         juce::Colour gridColor = lf ? lf->getTheme().colors.border.withAlpha(0.4f) : juce::Colour(0xff2a2a3e);

--- a/Source/UI/GraphEditor.cpp
+++ b/Source/UI/GraphEditor.cpp
@@ -22,7 +22,7 @@
 #include "../PresetManager.h"
 #include "LayoutUtil.h"
 #include "ModuleComponent.h"
-#include "Theme/GravisynthLookAndFeel.h"
+#include "Theme/AppLookAndFeel.h"
 #include <set>
 #include <tuple>
 #include <unordered_map>
@@ -65,7 +65,7 @@ static juce::Point<int> estimateModuleSize(const juce::String& typeName) {
     return {280, 360};
 }
 
-GraphEditor::GraphEditor(AudioEngine& engine, GravisynthUndoManager* undoMgr)
+GraphEditor::GraphEditor(AudioEngine& engine, AppUndoManager* undoMgr)
     : audioEngine(engine)
     , content(*this)
     , modMatrix(engine, undoMgr)
@@ -94,7 +94,7 @@ GraphEditor::GraphContentComponent::GraphContentComponent(GraphEditor& ed)
 void GraphEditor::GraphContentComponent::paint(juce::Graphics& g) {
     // Resolve the themed LookAndFeel once. In headless tests the default JUCE LnF is
     // installed, so the cast returns null and we fall back to plain fills/lines.
-    auto* lf = dynamic_cast<synth::theme::GravisynthLookAndFeel*>(&getLookAndFeel());
+    auto* lf = dynamic_cast<synth::theme::AppLookAndFeel*>(&getLookAndFeel());
 
     if (lf != nullptr)
         lf->fillThemedBackground(g, getLocalBounds().toFloat(), /*isCanvas*/ true);
@@ -138,7 +138,7 @@ void GraphEditor::GraphContentComponent::paint(juce::Graphics& g) {
     const juce::Colour textPrimaryColour = lf != nullptr ? lf->getTheme().colors.textPrimary : juce::Colours::white;
     const juce::Colour textMutedColour = lf != nullptr ? lf->getTheme().colors.textMuted : juce::Colours::white;
 
-    // Build the cubic-bezier wire path (identical to GravisynthLookAndFeel::drawConnectionWire's
+    // Build the cubic-bezier wire path (identical to AppLookAndFeel::drawConnectionWire's
     // default curve) so the animated dots can ride the EXACT same curve as the drawn wire instead
     // of cutting straight across it.
     auto buildWirePath = [](juce::Point<float> p1, juce::Point<float> p2) {
@@ -445,7 +445,7 @@ void GraphEditor::GraphContentComponent::paintOverChildren(juce::Graphics& g) {
     // ---- Drag-preview landing ghost (on top of module cards) ----
     // Draw a translucent rounded rect at the exact snapped+anti-overlapped landing position.
     if (editor.dragPreviewActive && !editor.dragPreviewGhost.isEmpty()) {
-        auto* lf = dynamic_cast<synth::theme::GravisynthLookAndFeel*>(&getLookAndFeel());
+        auto* lf = dynamic_cast<synth::theme::AppLookAndFeel*>(&getLookAndFeel());
         const juce::Colour accentColour = lf != nullptr ? lf->getTheme().colors.accent : juce::Colour(0xff00D1FF);
         const auto& m = lf != nullptr ? lf->getTheme().metrics : synth::theme::Metrics{};
         const float cornerRadius = m.cornerRadius;
@@ -465,7 +465,7 @@ void GraphEditor::GraphContentComponent::paintOverChildren(juce::Graphics& g) {
     // ---- Alignment guides (UI Phase 7 - Item 4) ----
     // Draw aligned edges when hovering near other modules (Figma-style)
     if (editor.dragPreviewActive && !editor.alignmentGuides.empty() && editor.alignmentGuidesEnabled) {
-        auto* lf = dynamic_cast<synth::theme::GravisynthLookAndFeel*>(&getLookAndFeel());
+        auto* lf = dynamic_cast<synth::theme::AppLookAndFeel*>(&getLookAndFeel());
         const juce::Colour guideColour = lf != nullptr ? lf->getTheme().colors.textMuted : juce::Colours::white;
 
         // Solid lines, ~70% opacity for visibility without distraction
@@ -698,7 +698,7 @@ void GraphEditor::paintOverChildren(juce::Graphics& g) {
     if (!GraphEditor::isCanvasEmpty(static_cast<int>(content.getModules().size())))
         return;
 
-    auto* lf = dynamic_cast<synth::theme::GravisynthLookAndFeel*>(&getLookAndFeel());
+    auto* lf = dynamic_cast<synth::theme::AppLookAndFeel*>(&getLookAndFeel());
 
     // textMuted token at ~60% alpha — tasteful, non-distracting.
     const juce::Colour textMutedColour = lf != nullptr ? lf->getTheme().colors.textMuted : juce::Colours::white;
@@ -1226,7 +1226,7 @@ void GraphEditor::updateDragPreview(juce::Point<int> desiredTopLeftCanvas) {
     if (dragPreviewGhost.isEmpty())
         return;
 
-    auto* lf = dynamic_cast<synth::theme::GravisynthLookAndFeel*>(&getLookAndFeel());
+    auto* lf = dynamic_cast<synth::theme::AppLookAndFeel*>(&getLookAndFeel());
     const auto& m = lf != nullptr ? lf->getTheme().metrics : synth::theme::Metrics{};
     const float snapThreshold = static_cast<float>(m.gridSize); // kGridSize
 

--- a/Source/UI/GraphEditor.h
+++ b/Source/UI/GraphEditor.h
@@ -1,7 +1,7 @@
 #pragma once
 
+#include "../AppUndoManager.h"
 #include "../AudioEngine.h"
-#include "../GravisynthUndoManager.h"
 #include "LayoutUtil.h"
 #include "UIAnimation.h"
 #include <juce_gui_basics/juce_gui_basics.h>
@@ -15,7 +15,7 @@ class GraphEditor
     , public juce::DragAndDropTarget
     , public juce::SettableTooltipClient {
 public:
-    GraphEditor(AudioEngine& engine, GravisynthUndoManager* undoMgr = nullptr);
+    GraphEditor(AudioEngine& engine, AppUndoManager* undoMgr = nullptr);
     ~GraphEditor() override;
 
     AudioEngine& getAudioEngine() { return audioEngine; }
@@ -155,7 +155,7 @@ private:
     juce::AudioProcessorGraph::NodeID draggingAttenuverterNodeId;
     float attenDragStartValue = 0.0f;
 
-    GravisynthUndoManager* undoManager = nullptr;
+    AppUndoManager* undoManager = nullptr;
     std::vector<AudioEngine::ModulationDisplayInfo> cachedModDisplayInfo;
     std::vector<AudioEngine::ModulationRouting> cachedModRoutings;
 

--- a/Source/UI/ModMatrixComponent.cpp
+++ b/Source/UI/ModMatrixComponent.cpp
@@ -1,10 +1,10 @@
 #include "ModMatrixComponent.h"
 #include "../Modules/AttenuverterModule.h"
-#include "Theme/GravisynthLookAndFeel.h"
+#include "Theme/AppLookAndFeel.h"
 #include <algorithm>
 #include <map>
 
-ModMatrixComponent::ModMatrixComponent(AudioEngine& engine, GravisynthUndoManager* undoMgr)
+ModMatrixComponent::ModMatrixComponent(AudioEngine& engine, AppUndoManager* undoMgr)
     : audioEngine(engine)
     , undoManager(undoMgr) {
     addAndMakeVisible(viewport);
@@ -34,7 +34,7 @@ void ModMatrixComponent::setFlatSourceMenu(bool shouldBeFlat) {
 void ModMatrixComponent::paint(juce::Graphics& g) {
     // Resolve the themed LookAndFeel; in headless tests the default JUCE LnF is installed and the
     // cast returns null, so we fall back to the legacy literals.
-    auto* lf = dynamic_cast<synth::theme::GravisynthLookAndFeel*>(&getLookAndFeel());
+    auto* lf = dynamic_cast<synth::theme::AppLookAndFeel*>(&getLookAndFeel());
 
     const juce::Colour bgColour = lf != nullptr ? lf->getTheme().colors.bg1 : juce::Colour(0xff1a1c1e);
     const juce::Colour surfaceHiColour =
@@ -204,7 +204,7 @@ ModMatrixComponent::ModRow::ModRow(ModMatrixComponent& o, juce::AudioProcessorGr
 
     // Slider colours from theme tokens when the themed LnF is installed; otherwise leave the
     // ColourId defaults (the LnF maps them in applyTheme(), so explicit literals are not needed).
-    if (auto* lf = dynamic_cast<synth::theme::GravisynthLookAndFeel*>(&owner.getLookAndFeel())) {
+    if (auto* lf = dynamic_cast<synth::theme::AppLookAndFeel*>(&owner.getLookAndFeel())) {
         const auto& colors = lf->getTheme().colors;
         amountSlider.setColour(juce::Slider::thumbColourId, colors.knobPointer);
         amountSlider.setColour(juce::Slider::trackColourId, colors.accent);
@@ -226,7 +226,7 @@ ModMatrixComponent::ModRow::ModRow(ModMatrixComponent& o, juce::AudioProcessorGr
     bypassToggle.setTooltip("Bypass modulation");
     // Keep only the semantic on-colour from the theme (bypass-active = warning). The off-state,
     // text and base colours re-skin via the LnF ColourId mapping. When unthemed, leave defaults.
-    if (auto* lf = dynamic_cast<synth::theme::GravisynthLookAndFeel*>(&owner.getLookAndFeel())) {
+    if (auto* lf = dynamic_cast<synth::theme::AppLookAndFeel*>(&owner.getLookAndFeel())) {
         const auto& colors = lf->getTheme().colors;
         bypassToggle.setColour(juce::TextButton::buttonOnColourId, colors.warning);
         bypassToggle.setColour(juce::TextButton::textColourOnId, colors.bg0);
@@ -272,7 +272,7 @@ void ModMatrixComponent::ModRow::resized() {
 }
 
 void ModMatrixComponent::ModRow::paint(juce::Graphics& g) {
-    auto* lf = dynamic_cast<synth::theme::GravisynthLookAndFeel*>(&owner.getLookAndFeel());
+    auto* lf = dynamic_cast<synth::theme::AppLookAndFeel*>(&owner.getLookAndFeel());
 
     // --- Row background: zebra striping + hover highlight ---
     const bool isHovered = (owner.getHoveredRow() == rowIndex);

--- a/Source/UI/ModMatrixComponent.h
+++ b/Source/UI/ModMatrixComponent.h
@@ -1,7 +1,7 @@
 #pragma once
 
+#include "../AppUndoManager.h"
 #include "../AudioEngine.h"
-#include "../GravisynthUndoManager.h"
 #include <juce_gui_basics/juce_gui_basics.h>
 #include <map>
 
@@ -15,7 +15,7 @@ public:
     /** Returns true for odd rows (zebra striping). */
     static bool isZebraRow(int rowIndex) noexcept { return rowIndex % 2 == 1; }
 
-    ModMatrixComponent(AudioEngine& engine, GravisynthUndoManager* undoMgr = nullptr);
+    ModMatrixComponent(AudioEngine& engine, AppUndoManager* undoMgr = nullptr);
     ~ModMatrixComponent() override;
 
     void paint(juce::Graphics& g) override;
@@ -38,7 +38,7 @@ public:
 
 private:
     AudioEngine& audioEngine;
-    GravisynthUndoManager* undoManager = nullptr;
+    AppUndoManager* undoManager = nullptr;
     bool isSourceMenuFlat = false;
 
     juce::TextButton addButton{"Add Modulation"};

--- a/Source/UI/ModuleComponent.cpp
+++ b/Source/UI/ModuleComponent.cpp
@@ -5,7 +5,7 @@
 #include "../Modules/SequencerModule.h"
 #include "GraphEditor.h"
 #include "LayoutUtil.h"
-#include "Theme/GravisynthLookAndFeel.h"
+#include "Theme/AppLookAndFeel.h"
 
 static ModuleType getType(juce::AudioProcessor* module) {
     if (auto* mb = dynamic_cast<ModuleBase*>(module))
@@ -14,7 +14,7 @@ static ModuleType getType(juce::AudioProcessor* module) {
 }
 
 ModuleComponent::ModuleComponent(juce::AudioProcessor* m, juce::AudioProcessorGraph::NodeID nId, GraphEditor& owner,
-                                 GravisynthUndoManager* undoMgr)
+                                 AppUndoManager* undoMgr)
     : module(m)
     , nodeId(nId)
     , owner(owner)
@@ -128,7 +128,7 @@ void ModuleComponent::detachFromProcessor() {
 void ModuleComponent::applyHeaderButtonIcons() {
     // Headless-safe: when our themed LnF is not installed (unit tests), buttons remain blank
     // (no image set). The DrawableButton still exists and functions correctly without an image.
-    auto* lf = dynamic_cast<synth::theme::GravisynthLookAndFeel*>(&getLookAndFeel());
+    auto* lf = dynamic_cast<synth::theme::AppLookAndFeel*>(&getLookAndFeel());
     if (lf == nullptr)
         return;
 
@@ -147,10 +147,10 @@ void ModuleComponent::applyHeaderButtonIcons() {
 }
 
 void ModuleComponent::refreshWaveformComboIcons() {
-    using synth::theme::GravisynthLookAndFeel;
+    using synth::theme::AppLookAndFeel;
     using synth::theme::Icon;
 
-    auto* lf = dynamic_cast<GravisynthLookAndFeel*>(&getLookAndFeel());
+    auto* lf = dynamic_cast<AppLookAndFeel*>(&getLookAndFeel());
     // Headless / no themed LnF: nothing to refresh.
     if (lf == nullptr)
         return;
@@ -297,8 +297,8 @@ void ModuleComponent::createControls() {
             midiKeyboard->getKeyboardState(), juce::MidiKeyboardComponent::horizontalKeyboard);
 
         // Theme the keyboard component
-        using synth::theme::GravisynthLookAndFeel;
-        auto* lf = dynamic_cast<GravisynthLookAndFeel*>(&getLookAndFeel());
+        using synth::theme::AppLookAndFeel;
+        auto* lf = dynamic_cast<AppLookAndFeel*>(&getLookAndFeel());
         if (lf != nullptr) {
             keyboardComponent->setColour(juce::MidiKeyboardComponent::whiteNoteColourId, lf->getTheme().colors.bg1);
             keyboardComponent->setColour(juce::MidiKeyboardComponent::blackNoteColourId,
@@ -381,7 +381,7 @@ void ModuleComponent::createControls() {
                     using synth::theme::Icon;
                     const Icon kIcons[4] = {Icon::WaveformSine, Icon::WaveformSquare, Icon::WaveformSaw,
                                             Icon::WaveformTriangle};
-                    auto* lf = dynamic_cast<synth::theme::GravisynthLookAndFeel*>(&getLookAndFeel());
+                    auto* lf = dynamic_cast<synth::theme::AppLookAndFeel*>(&getLookAndFeel());
                     for (int i = 0; i < 4; ++i) {
                         std::unique_ptr<juce::Drawable> icon;
                         if (lf != nullptr)
@@ -584,7 +584,7 @@ void ModuleComponent::paint(juce::Graphics& g) {
 
     // Guarded LnF cast: headless tests construct this component WITHOUT installing our LnF.
     // When the cast is null we fall back to a plain themed-ish fill so those tests don't crash.
-    auto* lf = dynamic_cast<synth::theme::GravisynthLookAndFeel*>(&getLookAndFeel());
+    auto* lf = dynamic_cast<synth::theme::AppLookAndFeel*>(&getLookAndFeel());
 
     if (lf != nullptr) {
         // Single owner of card treatment: background, drop shadow, body fill, border, and the

--- a/Source/UI/ModuleComponent.h
+++ b/Source/UI/ModuleComponent.h
@@ -1,7 +1,7 @@
 #pragma once
 
+#include "../AppUndoManager.h"
 #include "../AudioEngine.h"
-#include "../GravisynthUndoManager.h"
 #include "../Modules/FilterModule.h"
 #include "../Modules/MidiKeyboardModule.h"
 #include "FrequencyResponseComponent.h"
@@ -19,7 +19,7 @@ class ModuleComponent
     , public juce::AudioProcessorParameter::Listener {
 public:
     ModuleComponent(juce::AudioProcessor* module, juce::AudioProcessorGraph::NodeID nodeId, GraphEditor& owner,
-                    GravisynthUndoManager* undoMgr = nullptr);
+                    AppUndoManager* undoMgr = nullptr);
 
     void parameterValueChanged(int parameterIndex, float newValue) override;
     void parameterGestureChanged(int parameterIndex, bool gestureIsStarting) override;
@@ -83,7 +83,7 @@ private:
     std::unique_ptr<juce::ButtonParameterAttachment> muteAttachment;
     std::unique_ptr<juce::DrawableButton> deleteButton;
 
-    GravisynthUndoManager* undoManager = nullptr;
+    AppUndoManager* undoManager = nullptr;
     std::map<int, float> gestureStartValues;
     juce::Point<int> dragStartPosition;
 

--- a/Source/UI/ModuleLibraryComponent.h
+++ b/Source/UI/ModuleLibraryComponent.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "Theme/GravisynthLookAndFeel.h"
+#include "Theme/AppLookAndFeel.h"
 #include <juce_gui_basics/juce_gui_basics.h>
 
 class ModuleLibraryComponent
@@ -87,7 +87,7 @@ public:
         juce::Colour itemColour = juce::Colours::white;
         juce::Colour accentColour = juce::Colours::lightblue;
 
-        auto* lf = dynamic_cast<synth::theme::GravisynthLookAndFeel*>(&getLookAndFeel());
+        auto* lf = dynamic_cast<synth::theme::AppLookAndFeel*>(&getLookAndFeel());
         if (lf != nullptr) {
             const auto& c = lf->getTheme().colors;
             bgColour = c.bg0;

--- a/Source/UI/ScopeComponent.h
+++ b/Source/UI/ScopeComponent.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "../Modules/VisualBuffer.h"
-#include "Theme/GravisynthLookAndFeel.h"
+#include "Theme/AppLookAndFeel.h"
 #include <juce_gui_basics/juce_gui_basics.h>
 
 class ScopeComponent
@@ -41,7 +41,7 @@ public:
 
     void paint(juce::Graphics& g) override {
         juce::Colour bgColor = juce::Colours::black;
-        if (auto* lf = dynamic_cast<synth::theme::GravisynthLookAndFeel*>(&getLookAndFeel())) {
+        if (auto* lf = dynamic_cast<synth::theme::AppLookAndFeel*>(&getLookAndFeel())) {
             bgColor = lf->getTheme().colors.bg1;
         }
         g.fillAll(bgColor);
@@ -61,7 +61,7 @@ public:
         juce::Colour mutedColour = juce::Colour(0xff5C6470); // textDisabled token default
         juce::Colour waveColour = juce::Colours::limegreen;
 
-        if (auto* lf = dynamic_cast<synth::theme::GravisynthLookAndFeel*>(&getLookAndFeel())) {
+        if (auto* lf = dynamic_cast<synth::theme::AppLookAndFeel*>(&getLookAndFeel())) {
             const auto& colors = lf->getTheme().colors;
             gridColour = colors.border.withAlpha(0.6f);
             mutedColour = colors.textDisabled;

--- a/Source/UI/StatusBarComponent.cpp
+++ b/Source/UI/StatusBarComponent.cpp
@@ -1,5 +1,5 @@
 #include "StatusBarComponent.h"
-#include "Theme/GravisynthLookAndFeel.h"
+#include "Theme/AppLookAndFeel.h"
 
 // ---------------------------------------------------------------------------
 StatusBarComponent::StatusBarComponent() { addAndMakeVisible(masterMuteButton_); }
@@ -39,7 +39,7 @@ void StatusBarComponent::timerCallback() {
 void StatusBarComponent::paint(juce::Graphics& g) {
     using namespace synth::theme;
 
-    auto* lnf = dynamic_cast<GravisynthLookAndFeel*>(&getLookAndFeel());
+    auto* lnf = dynamic_cast<AppLookAndFeel*>(&getLookAndFeel());
 
     // --- Resolve colours: themed if LnF present, otherwise JUCE fallback ---
     juce::Colour bg0, border, textPrimary, textMuted, warningColour;

--- a/Source/UI/StatusBarComponent.h
+++ b/Source/UI/StatusBarComponent.h
@@ -5,7 +5,7 @@
 // StatusBarComponent  §4.1
 // Bottom chrome strip: patch name, CPU %, voice count, master-mute button.
 //
-// Headless-safe: all paint paths dynamic_cast<GravisynthLookAndFeel*> and fall back to plain
+// Headless-safe: all paint paths dynamic_cast<AppLookAndFeel*> and fall back to plain
 // JUCE colours when the cast returns null (test runner has no themed LnF installed).
 //
 // update() is gated — it only calls repaint() when the displayed values actually change

--- a/Source/UI/Theme/AppLookAndFeel.cpp
+++ b/Source/UI/Theme/AppLookAndFeel.cpp
@@ -1,4 +1,4 @@
-#include "GravisynthLookAndFeel.h"
+#include "AppLookAndFeel.h"
 
 #ifdef GRAVISYNTH_HAS_FONT_ASSETS
 #include "BinaryData.h"
@@ -80,7 +80,7 @@ juce::Image makeGridTile(juce::Colour dot) {
 } // namespace
 
 //==============================================================================
-GravisynthLookAndFeel::GravisynthLookAndFeel() {
+AppLookAndFeel::AppLookAndFeel() {
     // Pre-create EVERY built-in family's typefaces now, at construction (the process is fresh
     // and no text has been rendered yet). Creating an embedded typeface for the first time at
     // RUNTIME — after the app has already rendered with another font — globally corrupts text
@@ -102,10 +102,10 @@ GravisynthLookAndFeel::GravisynthLookAndFeel() {
     applyTheme(theme);
 }
 
-GravisynthLookAndFeel::~GravisynthLookAndFeel() = default;
+AppLookAndFeel::~AppLookAndFeel() = default;
 
 //==============================================================================
-void GravisynthLookAndFeel::applyTheme(const Theme& newTheme) {
+void AppLookAndFeel::applyTheme(const Theme& newTheme) {
     const bool familyChanged =
         (theme.type.uiFamily != newTheme.type.uiFamily) || (theme.type.monoFamily != newTheme.type.monoFamily);
 
@@ -189,7 +189,7 @@ void GravisynthLookAndFeel::applyTheme(const Theme& newTheme) {
     retintIcons();
 }
 
-void GravisynthLookAndFeel::retintIcons() {
+void AppLookAndFeel::retintIcons() {
     const auto& c = theme.colors;
 
     // Module header glyphs carry semantic intent.
@@ -231,12 +231,12 @@ void GravisynthLookAndFeel::retintIcons() {
     iconLibrary_.setTintColour(Icon::WaveformTriangle, c.textPrimary);
 }
 
-void GravisynthLookAndFeel::refreshTypefaces() {
+void AppLookAndFeel::refreshTypefaces() {
     uiTypeface = loadEmbeddedTypeface(theme.type.uiFamily, false, false);
     monoTypeface = loadEmbeddedTypeface(theme.type.monoFamily, false, false);
 }
 
-juce::Typeface::Ptr GravisynthLookAndFeel::getTypefaceForFont(const juce::Font& font) {
+juce::Typeface::Ptr AppLookAndFeel::getTypefaceForFont(const juce::Font& font) {
     const bool bold = font.isBold();
     const bool medium = false; // JUCE Font has no "medium" flag; bold/regular only.
 
@@ -269,9 +269,9 @@ juce::Typeface::Ptr GravisynthLookAndFeel::getTypefaceForFont(const juce::Font& 
 //==============================================================================
 // Stock widget overrides
 //==============================================================================
-void GravisynthLookAndFeel::drawRotarySlider(juce::Graphics& g, int x, int y, int width, int height,
-                                             float sliderPosProportional, float /*rotaryStartAngle*/,
-                                             float /*rotaryEndAngle*/, juce::Slider& slider) {
+void AppLookAndFeel::drawRotarySlider(juce::Graphics& g, int x, int y, int width, int height,
+                                      float sliderPosProportional, float /*rotaryStartAngle*/, float /*rotaryEndAngle*/,
+                                      juce::Slider& slider) {
     const auto& c = theme.colors;
     const auto& m = theme.metrics;
     const auto& tr = theme.treatment;
@@ -345,9 +345,9 @@ void GravisynthLookAndFeel::drawRotarySlider(juce::Graphics& g, int x, int y, in
     juce::ignoreUnused(slider);
 }
 
-void GravisynthLookAndFeel::drawLinearSlider(juce::Graphics& g, int x, int y, int width, int height, float sliderPos,
-                                             float /*minSliderPos*/, float /*maxSliderPos*/,
-                                             juce::Slider::SliderStyle style, juce::Slider& slider) {
+void AppLookAndFeel::drawLinearSlider(juce::Graphics& g, int x, int y, int width, int height, float sliderPos,
+                                      float /*minSliderPos*/, float /*maxSliderPos*/, juce::Slider::SliderStyle style,
+                                      juce::Slider& slider) {
     const auto& c = theme.colors;
     const bool vertical = (style == juce::Slider::LinearVertical || style == juce::Slider::LinearBarVertical);
 
@@ -382,9 +382,8 @@ void GravisynthLookAndFeel::drawLinearSlider(juce::Graphics& g, int x, int y, in
     juce::ignoreUnused(slider);
 }
 
-void GravisynthLookAndFeel::drawButtonBackground(juce::Graphics& g, juce::Button& button,
-                                                 const juce::Colour& backgroundColour,
-                                                 bool shouldDrawButtonAsHighlighted, bool shouldDrawButtonAsDown) {
+void AppLookAndFeel::drawButtonBackground(juce::Graphics& g, juce::Button& button, const juce::Colour& backgroundColour,
+                                          bool shouldDrawButtonAsHighlighted, bool shouldDrawButtonAsDown) {
     const auto& c = theme.colors;
     const auto& m = theme.metrics;
 
@@ -403,12 +402,12 @@ void GravisynthLookAndFeel::drawButtonBackground(juce::Graphics& g, juce::Button
     g.drawRoundedRectangle(bounds, m.pillRadius, m.borderWidth);
 }
 
-juce::Font GravisynthLookAndFeel::getTextButtonFont(juce::TextButton&, int buttonHeight) {
+juce::Font AppLookAndFeel::getTextButtonFont(juce::TextButton&, int buttonHeight) {
     return juce::Font(juce::FontOptions((float)juce::jmin(15, buttonHeight - 6)));
 }
 
-void GravisynthLookAndFeel::drawButtonText(juce::Graphics& g, juce::TextButton& button,
-                                           bool /*shouldDrawButtonAsHighlighted*/, bool /*shouldDrawButtonAsDown*/) {
+void AppLookAndFeel::drawButtonText(juce::Graphics& g, juce::TextButton& button, bool /*shouldDrawButtonAsHighlighted*/,
+                                    bool /*shouldDrawButtonAsDown*/) {
     g.setFont(getTextButtonFont(button, button.getHeight()));
     const auto colourId =
         button.getToggleState() ? juce::TextButton::textColourOnId : juce::TextButton::textColourOffId;
@@ -417,8 +416,8 @@ void GravisynthLookAndFeel::drawButtonText(juce::Graphics& g, juce::TextButton& 
     g.drawFittedText(button.getButtonText(), button.getLocalBounds().reduced(4, 0), juce::Justification::centred, 1);
 }
 
-void GravisynthLookAndFeel::drawComboBox(juce::Graphics& g, int width, int height, bool isButtonDown, int /*buttonX*/,
-                                         int /*buttonY*/, int /*buttonW*/, int /*buttonH*/, juce::ComboBox& box) {
+void AppLookAndFeel::drawComboBox(juce::Graphics& g, int width, int height, bool isButtonDown, int /*buttonX*/,
+                                  int /*buttonY*/, int /*buttonW*/, int /*buttonH*/, juce::ComboBox& box) {
     const auto& c = theme.colors;
     const auto& m = theme.metrics;
     const bool enabled = box.isEnabled();
@@ -479,14 +478,13 @@ void GravisynthLookAndFeel::drawComboBox(juce::Graphics& g, int width, int heigh
     }
 }
 
-void GravisynthLookAndFeel::drawComboBoxTextWhenNothingSelected(juce::Graphics& g, juce::ComboBox& box,
-                                                                juce::Label& label) {
+void AppLookAndFeel::drawComboBoxTextWhenNothingSelected(juce::Graphics& g, juce::ComboBox& box, juce::Label& label) {
     g.setColour(box.findColour(juce::ComboBox::textColourId).withMultipliedAlpha(0.4f));
     g.setFont(label.getFont());
     g.drawFittedText(box.getTextWhenNothingSelected(), label.getBounds(), label.getJustificationType(), 1);
 }
 
-void GravisynthLookAndFeel::positionComboBoxText(juce::ComboBox& box, juce::Label& label) {
+void AppLookAndFeel::positionComboBoxText(juce::ComboBox& box, juce::Label& label) {
     // If the selected item carries a Drawable icon, shift the text label right to leave room
     // for the ~14 px icon (painted in drawComboBox) plus a 4 px gap.
     int leftOffset = 8;
@@ -509,7 +507,7 @@ void GravisynthLookAndFeel::positionComboBoxText(juce::ComboBox& box, juce::Labe
     label.setFont(juce::Font(juce::FontOptions(theme.type.label + 2.0f)));
 }
 
-void GravisynthLookAndFeel::drawPopupMenuBackground(juce::Graphics& g, int width, int height) {
+void AppLookAndFeel::drawPopupMenuBackground(juce::Graphics& g, int width, int height) {
     const auto& c = theme.colors;
     const auto& m = theme.metrics;
     auto bounds = juce::Rectangle<float>(0, 0, (float)width, (float)height);
@@ -519,10 +517,10 @@ void GravisynthLookAndFeel::drawPopupMenuBackground(juce::Graphics& g, int width
     g.drawRoundedRectangle(bounds.reduced(0.5f), m.cornerRadius * 0.6f, m.borderWidth);
 }
 
-void GravisynthLookAndFeel::drawPopupMenuItem(juce::Graphics& g, const juce::Rectangle<int>& area, bool isSeparator,
-                                              bool isActive, bool isHighlighted, bool isTicked, bool hasSubMenu,
-                                              const juce::String& text, const juce::String& shortcutKeyText,
-                                              const juce::Drawable* icon, const juce::Colour* textColour) {
+void AppLookAndFeel::drawPopupMenuItem(juce::Graphics& g, const juce::Rectangle<int>& area, bool isSeparator,
+                                       bool isActive, bool isHighlighted, bool isTicked, bool hasSubMenu,
+                                       const juce::String& text, const juce::String& shortcutKeyText,
+                                       const juce::Drawable* icon, const juce::Colour* textColour) {
     const auto& c = theme.colors;
     const auto& m = theme.metrics;
 
@@ -595,9 +593,9 @@ void GravisynthLookAndFeel::drawPopupMenuItem(juce::Graphics& g, const juce::Rec
     }
 }
 
-void GravisynthLookAndFeel::drawScrollbar(juce::Graphics& g, juce::ScrollBar& /*scrollbar*/, int x, int y, int width,
-                                          int height, bool isScrollbarVertical, int thumbStartPosition, int thumbSize,
-                                          bool isMouseOver, bool isMouseDown) {
+void AppLookAndFeel::drawScrollbar(juce::Graphics& g, juce::ScrollBar& /*scrollbar*/, int x, int y, int width,
+                                   int height, bool isScrollbarVertical, int thumbStartPosition, int thumbSize,
+                                   bool isMouseOver, bool isMouseDown) {
     const auto& c = theme.colors;
 
     // Slim track underlay.
@@ -625,11 +623,11 @@ void GravisynthLookAndFeel::drawScrollbar(juce::Graphics& g, juce::ScrollBar& /*
                            (float)juce::jmin(thumb.getWidth(), thumb.getHeight()) * 0.5f);
 }
 
-int GravisynthLookAndFeel::getDefaultScrollbarWidth() { return kScrollbarWidth; }
+int AppLookAndFeel::getDefaultScrollbarWidth() { return kScrollbarWidth; }
 
-void GravisynthLookAndFeel::drawScrollbarButton(juce::Graphics& g, juce::ScrollBar& /*scrollbar*/, int width,
-                                                int height, int buttonDirection, bool /*isScrollbarVertical*/,
-                                                bool isMouseOverButton, bool isButtonDown) {
+void AppLookAndFeel::drawScrollbarButton(juce::Graphics& g, juce::ScrollBar& /*scrollbar*/, int width, int height,
+                                         int buttonDirection, bool /*isScrollbarVertical*/, bool isMouseOverButton,
+                                         bool isButtonDown) {
     // Minimal filled triangle pointing in buttonDirection (0=up,1=right,2=down,3=left).
     // Rarely shown on macOS overlay scrollbars; needed for Win/Linux parity.
     const auto& c = theme.colors;
@@ -658,13 +656,12 @@ void GravisynthLookAndFeel::drawScrollbarButton(juce::Graphics& g, juce::ScrollB
     g.fillPath(tri);
 }
 
-void GravisynthLookAndFeel::fillTextEditorBackground(juce::Graphics& g, int width, int height,
-                                                     juce::TextEditor& editor) {
+void AppLookAndFeel::fillTextEditorBackground(juce::Graphics& g, int width, int height, juce::TextEditor& editor) {
     g.setColour(editor.findColour(juce::TextEditor::backgroundColourId));
     g.fillRoundedRectangle(0.0f, 0.0f, (float)width, (float)height, theme.metrics.pillRadius);
 }
 
-void GravisynthLookAndFeel::drawTextEditorOutline(juce::Graphics& g, int width, int height, juce::TextEditor& editor) {
+void AppLookAndFeel::drawTextEditorOutline(juce::Graphics& g, int width, int height, juce::TextEditor& editor) {
     if (editor.isEnabled()) {
         const bool focused = editor.hasKeyboardFocus(true);
         g.setColour(focused ? theme.colors.accent : editor.findColour(juce::TextEditor::outlineColourId));
@@ -673,7 +670,7 @@ void GravisynthLookAndFeel::drawTextEditorOutline(juce::Graphics& g, int width, 
     }
 }
 
-void GravisynthLookAndFeel::drawLabel(juce::Graphics& g, juce::Label& label) {
+void AppLookAndFeel::drawLabel(juce::Graphics& g, juce::Label& label) {
     g.fillAll(label.findColour(juce::Label::backgroundColourId));
 
     if (!label.isBeingEdited()) {
@@ -688,8 +685,8 @@ void GravisynthLookAndFeel::drawLabel(juce::Graphics& g, juce::Label& label) {
     }
 }
 
-void GravisynthLookAndFeel::drawToggleButton(juce::Graphics& g, juce::ToggleButton& button,
-                                             bool shouldDrawButtonAsHighlighted, bool /*shouldDrawButtonAsDown*/) {
+void AppLookAndFeel::drawToggleButton(juce::Graphics& g, juce::ToggleButton& button, bool shouldDrawButtonAsHighlighted,
+                                      bool /*shouldDrawButtonAsDown*/) {
     const auto& c = theme.colors;
 
     const float boxSize = juce::jmin(18.0f, (float)button.getHeight() - 2.0f);
@@ -720,7 +717,7 @@ void GravisynthLookAndFeel::drawToggleButton(juce::Graphics& g, juce::ToggleButt
     }
 }
 
-void GravisynthLookAndFeel::drawTooltip(juce::Graphics& g, const juce::String& text, int width, int height) {
+void AppLookAndFeel::drawTooltip(juce::Graphics& g, const juce::String& text, int width, int height) {
     const auto& c = theme.colors;
     auto bounds = juce::Rectangle<float>(0, 0, (float)width, (float)height);
     g.setColour(c.surfaceHi);
@@ -733,8 +730,8 @@ void GravisynthLookAndFeel::drawTooltip(juce::Graphics& g, const juce::String& t
     g.drawFittedText(text, juce::Rectangle<int>(0, 0, width, height).reduced(6, 2), juce::Justification::centred, 3);
 }
 
-void GravisynthLookAndFeel::drawTabButton(juce::TabBarButton& button, juce::Graphics& g, bool isMouseOver,
-                                          bool /*isMouseDown*/) {
+void AppLookAndFeel::drawTabButton(juce::TabBarButton& button, juce::Graphics& g, bool isMouseOver,
+                                   bool /*isMouseDown*/) {
     const auto& c = theme.colors;
     const auto& m = theme.metrics;
     const bool active = button.getToggleState();
@@ -802,7 +799,7 @@ void GravisynthLookAndFeel::drawTabButton(juce::TabBarButton& button, juce::Grap
     g.drawFittedText(button.getButtonText(), button.getActiveArea().reduced(6, 0), juce::Justification::centred, 1);
 }
 
-void GravisynthLookAndFeel::drawTabbedButtonBarBackground(juce::TabbedButtonBar& bar, juce::Graphics& g) {
+void AppLookAndFeel::drawTabbedButtonBarBackground(juce::TabbedButtonBar& bar, juce::Graphics& g) {
     const auto& c = theme.colors;
     auto bounds = bar.getLocalBounds().toFloat();
 
@@ -831,8 +828,8 @@ void GravisynthLookAndFeel::drawTabbedButtonBarBackground(juce::TabbedButtonBar&
 //==============================================================================
 // Public treatment helpers
 //==============================================================================
-void GravisynthLookAndFeel::drawModulePanel(juce::Graphics& g, juce::Rectangle<float> bounds, int headerHeight,
-                                            const juce::String& title, bool selected, bool bypassed) {
+void AppLookAndFeel::drawModulePanel(juce::Graphics& g, juce::Rectangle<float> bounds, int headerHeight,
+                                     const juce::String& title, bool selected, bool bypassed) {
     const auto& c = theme.colors;
     const auto& m = theme.metrics;
     const auto& tr = theme.treatment;
@@ -954,9 +951,9 @@ void GravisynthLookAndFeel::drawModulePanel(juce::Graphics& g, juce::Rectangle<f
     }
 }
 
-void GravisynthLookAndFeel::drawConnectionWire(juce::Graphics& g, juce::Point<float> p1, juce::Point<float> p2,
-                                               const juce::Path& path, juce::Colour colour, bool isModulation,
-                                               float activity, bool hovered) {
+void AppLookAndFeel::drawConnectionWire(juce::Graphics& g, juce::Point<float> p1, juce::Point<float> p2,
+                                        const juce::Path& path, juce::Colour colour, bool isModulation, float activity,
+                                        bool hovered) {
     const auto& m = theme.metrics;
     const auto& tr = theme.treatment;
 
@@ -1001,8 +998,8 @@ void GravisynthLookAndFeel::drawConnectionWire(juce::Graphics& g, juce::Point<fl
     }
 }
 
-void GravisynthLookAndFeel::drawModulationRing(juce::Graphics& g, juce::Point<float> centre, float radius,
-                                               float baseNorm, float modNorm, bool positive) {
+void AppLookAndFeel::drawModulationRing(juce::Graphics& g, juce::Point<float> centre, float radius, float baseNorm,
+                                        float modNorm, bool positive) {
     if (radius <= 0.0f)
         return;
 
@@ -1021,7 +1018,7 @@ void GravisynthLookAndFeel::drawModulationRing(juce::Graphics& g, juce::Point<fl
                  juce::PathStrokeType(m.knobRingWidth, juce::PathStrokeType::curved, juce::PathStrokeType::rounded));
 }
 
-void GravisynthLookAndFeel::fillThemedBackground(juce::Graphics& g, juce::Rectangle<float> bounds, bool isCanvas) {
+void AppLookAndFeel::fillThemedBackground(juce::Graphics& g, juce::Rectangle<float> bounds, bool isCanvas) {
     const auto& c = theme.colors;
 
     if (!isCanvas) {

--- a/Source/UI/Theme/AppLookAndFeel.h
+++ b/Source/UI/Theme/AppLookAndFeel.h
@@ -15,10 +15,10 @@ namespace synth::theme {
 //       setting JUCE ColourIds from theme tokens in applyTheme() (section 3).
 //   (2) Provide PUBLIC helper draw methods that the bespoke painters (ModuleComponent,
 //       GraphEditor) call so cards / wires / rings honor the active treatment from ONE place.
-class GravisynthLookAndFeel : public juce::LookAndFeel_V4 {
+class AppLookAndFeel : public juce::LookAndFeel_V4 {
 public:
-    GravisynthLookAndFeel();
-    ~GravisynthLookAndFeel() override;
+    AppLookAndFeel();
+    ~AppLookAndFeel() override;
 
     // Store the theme, re-map every ColourId (section 3), refresh cached typefaces if the
     // family changed, and set the default sans/serif font. Does NOT repaint — the caller
@@ -140,7 +140,7 @@ private:
     std::optional<juce::ColourGradient> texturedGradient;
     std::optional<juce::ColourGradient> flatGradient;
 
-    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(GravisynthLookAndFeel)
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(AppLookAndFeel)
 };
 
 } // namespace synth::theme

--- a/Source/UI/Theme/IconLibrary.h
+++ b/Source/UI/Theme/IconLibrary.h
@@ -7,7 +7,7 @@
 
 namespace synth::theme {
 
-// The canonical Gravisynth icon set. Exactly 27 SVG glyphs, white-filled and tinted
+// The canonical icon set. Exactly 27 SVG glyphs, white-filled and tinted
 // programmatically at theme-apply time. Backed by GravisynthAssets BinaryData (see
 // CMakeLists.txt) when GRAVISYNTH_HAS_FONT_ASSETS is defined; otherwise every entry is a
 // null fallback so headless tests (no asset library) still link and run.

--- a/Source/UI/Theme/ThemeManager.cpp
+++ b/Source/UI/Theme/ThemeManager.cpp
@@ -1,4 +1,5 @@
 #include "ThemeManager.h"
+#include "../../Branding.h"
 #include "BuiltInThemes.h"
 #include "ThemeLoader.h"
 
@@ -83,7 +84,7 @@ void ThemeManager::addUserTheme(Theme theme) {
 // static
 juce::File ThemeManager::getUserThemesFolder() {
     juce::File folder = juce::File::getSpecialLocation(juce::File::userApplicationDataDirectory)
-                            .getChildFile("Gravisynth")
+                            .getChildFile(synth::branding::kSettingsFolderName)
                             .getChildFile("Themes");
 
     if (!folder.exists())

--- a/Source/UI/Theme/ThemeManager.h
+++ b/Source/UI/Theme/ThemeManager.h
@@ -43,7 +43,8 @@ public:
     // Sets isUserTheme=true. Does not change the active selection. Does not broadcast.
     void addUserTheme(Theme theme);
 
-    // Cross-platform: <userApplicationDataDirectory>/Gravisynth/Themes . Creates it if absent.
+    // Cross-platform: <userApplicationDataDirectory>/<synth::branding::kSettingsFolderName>/Themes .
+    // Creates it if absent.
     static juce::File getUserThemesFolder();
 
     // Scan the user themes folder for "*.gtheme.json", parse each, addUserTheme() the valid

--- a/Source/UI/ToolbarComponent.cpp
+++ b/Source/UI/ToolbarComponent.cpp
@@ -1,5 +1,5 @@
 #include "ToolbarComponent.h"
-#include "Theme/GravisynthLookAndFeel.h"
+#include "Theme/AppLookAndFeel.h"
 
 // ---------------------------------------------------------------------------
 void ToolbarComponent::setButtons(std::array<juce::DrawableButton*, NumSlots> btns) { buttons_ = btns; }
@@ -59,7 +59,7 @@ void ToolbarComponent::layoutButtons(juce::Rectangle<int> bounds) {
 void ToolbarComponent::paint(juce::Graphics& g) {
     using namespace synth::theme;
 
-    if (auto* lnf = dynamic_cast<GravisynthLookAndFeel*>(&getLookAndFeel()))
+    if (auto* lnf = dynamic_cast<AppLookAndFeel*>(&getLookAndFeel()))
         g.fillAll(lnf->getTheme().colors.bg0);
     else
         g.fillAll(juce::Colour(0xff0B0D10));

--- a/Source/UI/UIAnimation.h
+++ b/Source/UI/UIAnimation.h
@@ -1,7 +1,7 @@
 #pragma once
 
 // ============================================================================
-// UIAnimation.h — Shared animation utilities for Gravisynth UI Phase 5
+// UIAnimation.h — Shared animation utilities for the app UI Phase 5
 //
 // Namespace: synth::ui
 //

--- a/Tests/E2EWorkflowTests.cpp
+++ b/Tests/E2EWorkflowTests.cpp
@@ -1,5 +1,5 @@
 #include "../Source/AI/AIProvider.h"
-#include "../Source/GravisynthUndoManager.h"
+#include "../Source/AppUndoManager.h"
 #include "../Source/Modules/ADSRModule.h"
 #include "../Source/Modules/FX/ChorusModule.h"
 #include "../Source/Modules/FX/CompressorModule.h"
@@ -62,10 +62,10 @@ protected:
     GraphEditor& editor() { return mainComp->getGraphEditor(); }
     AudioEngine& engine() { return mainComp->getAudioEngine(); }
     juce::AudioProcessorGraph& graph() { return engine().getGraph(); }
-    GravisynthUndoManager& undoMgr() { return *undoMgrPtr(); }
+    AppUndoManager& undoMgr() { return *undoMgrPtr(); }
 
     // Access undo manager - note: MainComponent doesn't expose it yet, so we'll need a workaround
-    GravisynthUndoManager* undoMgrPtr() {
+    AppUndoManager* undoMgrPtr() {
         // For now, we'll use the GraphEditor's undoManager indirectly
         // This is a limitation of current testing hooks
         return nullptr; // Will be addressed with new hooks

--- a/Tests/GraphEditorOnboardingTests.cpp
+++ b/Tests/GraphEditorOnboardingTests.cpp
@@ -8,7 +8,7 @@
 // in TestMain.cpp and applies globally — no per-file setup needed).
 // This file is NOT registered in CMakeLists.txt (per OWNER instructions).
 
-#include "../Source/GravisynthUndoManager.h"
+#include "../Source/AppUndoManager.h"
 #include "../Source/Modules/OscillatorModule.h"
 #include "../Source/UI/GraphEditor.h"
 #include "../Source/UI/LayoutUtil.h"
@@ -288,7 +288,7 @@ TEST(GraphEditorOnboarding, NewPatchOnEmptyCanvasIsNoop) {
 TEST(GraphEditorOnboarding, NewPatchWithUndoManagerIsUndoable) {
     // With an undoManager present, newPatch must be undoable (Cmd+Z restores the graph).
     AudioEngine engine;
-    GravisynthUndoManager undoManager;
+    AppUndoManager undoManager;
     GraphEditor editor(engine, &undoManager);
     undoManager.setGraphEditor(&editor);
     editor.setSize(800, 600);

--- a/Tests/GraphEditorTests.cpp
+++ b/Tests/GraphEditorTests.cpp
@@ -1,4 +1,4 @@
-#include "../Source/GravisynthUndoManager.h"
+#include "../Source/AppUndoManager.h"
 #include "../Source/Modules/ADSRModule.h"
 #include "../Source/Modules/FilterModule.h"
 #include "../Source/Modules/LFOModule.h"
@@ -374,7 +374,7 @@ TEST_F(GraphEditorTest, PolyBusWireResolvesToVisibleJacks) {
 
 TEST_F(GraphEditorTest, ReplaceModuleIsUndoable) {
     AudioEngine engine;
-    GravisynthUndoManager undoMgr;
+    AppUndoManager undoMgr;
     GraphEditor editor(engine, &undoMgr);
     editor.setSize(800, 600);
 
@@ -631,7 +631,7 @@ TEST_F(GraphEditorTest, DropUsesRealModuleSizeForAntiOverlap) {
 
 TEST_F(GraphEditorTest, AlignmentGuideDrawingThemeAware) {
     // Verify paintOverChildren() uses theme colors correctly.
-    synth::theme::GravisynthLookAndFeel lf;
+    synth::theme::AppLookAndFeel lf;
     lf.applyTheme(synth::theme::makeObsidian());
 
     const auto& m = lf.getTheme().metrics;

--- a/Tests/ThemeTests.cpp
+++ b/Tests/ThemeTests.cpp
@@ -1,10 +1,10 @@
 // ThemeTests.cpp
 // Headless unit tests for the Gravisynth theme system.
-// Covers ThemeManager, ThemeLoader, BuiltInThemes, GravisynthLookAndFeel::applyTheme,
+// Covers ThemeManager, ThemeLoader, BuiltInThemes, AppLookAndFeel::applyTheme,
 // and the WCAG contrast requirement.  All 15 cases from spec section 9.
 
+#include "../Source/UI/Theme/AppLookAndFeel.h"
 #include "../Source/UI/Theme/BuiltInThemes.h"
-#include "../Source/UI/Theme/GravisynthLookAndFeel.h"
 #include "../Source/UI/Theme/Theme.h"
 #include "../Source/UI/Theme/ThemeLoader.h"
 #include "../Source/UI/Theme/ThemeManager.h"
@@ -90,7 +90,7 @@ TEST_F(ThemeTest, ManagerStartsOnDefault) {
 // 3. ApplyThemeSetsEveryColourId
 // ---------------------------------------------------------------------------
 TEST(ThemeLookAndFeelTest, ApplyThemeSetsEveryColourId) {
-    synth::theme::GravisynthLookAndFeel lf;
+    synth::theme::AppLookAndFeel lf;
     auto neon = synth::theme::makeNeon();
     lf.applyTheme(neon);
     const auto& c = neon.colors;
@@ -150,7 +150,7 @@ TEST(ThemeLookAndFeelTest, ApplyThemeSetsEveryColourId) {
     EXPECT_EQ(lf.findColour(juce::TabbedButtonBar::frontTextColourId), c.textPrimary);
     EXPECT_EQ(lf.findColour(juce::TabbedButtonBar::tabOutlineColourId), c.border);
     // MidiKeyboardComponent ColourIds (juce_audio_utils) are not linked into GravisynthCore;
-    // the on-screen keyboard keeps JUCE defaults for now (see GravisynthLookAndFeel::applyTheme).
+    // the on-screen keyboard keeps JUCE defaults for now (see AppLookAndFeel::applyTheme).
 }
 
 // ---------------------------------------------------------------------------
@@ -590,7 +590,7 @@ TEST(ThemeLoaderTest, Issue103MetricsNotInJSON) {
 TEST(GraphEditorRenderingTest, UsesMetricsCornerRadius) {
     // This test verifies that the code uses theme.metrics.cornerRadius
     // for drag ghost rendering instead of hardcoding it.
-    synth::theme::GravisynthLookAndFeel lf;
+    synth::theme::AppLookAndFeel lf;
     lf.applyTheme(synth::theme::makeObsidian());
 
     const auto& metrics = lf.getTheme().metrics;
@@ -599,7 +599,7 @@ TEST(GraphEditorRenderingTest, UsesMetricsCornerRadius) {
 }
 
 TEST(GraphEditorRenderingTest, UsesMetricsGuideParams) {
-    synth::theme::GravisynthLookAndFeel lf;
+    synth::theme::AppLookAndFeel lf;
     lf.applyTheme(synth::theme::makeNeon());
 
     const auto& m = lf.getTheme().metrics;
@@ -612,7 +612,7 @@ TEST(GraphEditorRenderingTest, UsesMetricsGuideParams) {
 // (Exercises the LnF draw paths in headless mode without asserting pixels.)
 // ---------------------------------------------------------------------------
 TEST(ThemeLookAndFeelTest, DrawHelpersSmoke) {
-    synth::theme::GravisynthLookAndFeel lf;
+    synth::theme::AppLookAndFeel lf;
     lf.applyTheme(synth::theme::makeObsidian());
 
     // Create a tiny in-memory image to draw into.
@@ -638,8 +638,8 @@ TEST(ThemeLookAndFeelTest, DrawHelpersSmoke) {
     juce::Slider slider(juce::Slider::RotaryVerticalDrag, juce::Slider::NoTextBox);
     slider.setRange(0.0, 1.0);
     slider.setValue(0.5);
-    EXPECT_NO_THROW(lf.drawRotarySlider(g, 0, 0, 100, 100, 0.5f, synth::theme::GravisynthLookAndFeel::kRotaryStart,
-                                        synth::theme::GravisynthLookAndFeel::kRotaryEnd, slider));
+    EXPECT_NO_THROW(lf.drawRotarySlider(g, 0, 0, 100, 100, 0.5f, synth::theme::AppLookAndFeel::kRotaryStart,
+                                        synth::theme::AppLookAndFeel::kRotaryEnd, slider));
 }
 
 // ---------------------------------------------------------------------------
@@ -687,7 +687,7 @@ TEST(ThemeLoaderTest, MetricsCodeOnlyFieldsNotInJSON) {
 // each built-in theme, getIcon() returns a usable (non-null when assets present) drawable and
 // nothing throws across repeated switches.
 TEST(ThemeLookAndFeelTest, RetintIconsCalledByApplyTheme) {
-    synth::theme::GravisynthLookAndFeel lf;
+    synth::theme::AppLookAndFeel lf;
 
     const std::array<synth::theme::Theme, 3> themes = {synth::theme::makeObsidian(), synth::theme::makeNeon(),
                                                        synth::theme::makeWarm()};
@@ -709,7 +709,7 @@ TEST(StyledWidgetSmokeTest, ComboBoxDrawNoThrow) {
     const std::array<synth::theme::Theme, 3> themes = {synth::theme::makeObsidian(), synth::theme::makeNeon(),
                                                        synth::theme::makeWarm()};
     for (const auto& t : themes) {
-        synth::theme::GravisynthLookAndFeel lf;
+        synth::theme::AppLookAndFeel lf;
         lf.applyTheme(t);
 
         juce::Image img(juce::Image::ARGB, 120, 28, true);
@@ -732,7 +732,7 @@ TEST(StyledWidgetSmokeTest, ComboBoxDrawNoThrow) {
 }
 
 TEST(StyledWidgetSmokeTest, ComboBoxTextWhenNothingSelected) {
-    synth::theme::GravisynthLookAndFeel lf;
+    synth::theme::AppLookAndFeel lf;
     lf.applyTheme(synth::theme::makeObsidian());
 
     juce::Image img(juce::Image::ARGB, 120, 28, true);
@@ -754,7 +754,7 @@ TEST(StyledWidgetSmokeTest, PopupMenuDrawNoThrow) {
     const std::array<synth::theme::Theme, 3> themes = {synth::theme::makeObsidian(), synth::theme::makeNeon(),
                                                        synth::theme::makeWarm()};
     for (const auto& t : themes) {
-        synth::theme::GravisynthLookAndFeel lf;
+        synth::theme::AppLookAndFeel lf;
         lf.applyTheme(t);
 
         juce::Image img(juce::Image::ARGB, 200, 30, true);
@@ -777,7 +777,7 @@ TEST(StyledWidgetSmokeTest, PopupMenuDrawNoThrow) {
 }
 
 TEST(StyledWidgetSmokeTest, ScrollbarWidthAndDrawNoThrow) {
-    synth::theme::GravisynthLookAndFeel lf;
+    synth::theme::AppLookAndFeel lf;
     lf.applyTheme(synth::theme::makeObsidian());
 
     EXPECT_EQ(lf.getDefaultScrollbarWidth(), 6);
@@ -802,7 +802,7 @@ TEST(StyledWidgetSmokeTest, ScrollbarWidthAndDrawNoThrow) {
 }
 
 TEST(StyledWidgetSmokeTest, TabBarDrawNoThrow) {
-    synth::theme::GravisynthLookAndFeel lf;
+    synth::theme::AppLookAndFeel lf;
     lf.applyTheme(synth::theme::makeObsidian());
 
     juce::TabbedButtonBar bar(juce::TabbedButtonBar::TabsAtTop);

--- a/Tests/UndoRedoTests.cpp
+++ b/Tests/UndoRedoTests.cpp
@@ -1,5 +1,5 @@
 #include "../Source/AI/AIStateMapper.h"
-#include "../Source/GravisynthUndoManager.h"
+#include "../Source/AppUndoManager.h"
 #include "../Source/Modules/ADSRModule.h"
 #include "../Source/Modules/AttenuverterModule.h"
 #include "../Source/Modules/FilterModule.h"
@@ -16,7 +16,7 @@
 class UndoRedoTest : public ::testing::Test {
 protected:
     juce::AudioProcessorGraph graph;
-    GravisynthUndoManager undoManager;
+    AppUndoManager undoManager;
 
     void SetUp() override { graph.clear(); }
 };
@@ -481,7 +481,7 @@ TEST_F(UndoRedoTest, RedoWithParameterValueInUnitInterval) {
  *
  * Verifies that the "Poly Pad" preset (index 6) connections survive a full
  * undo/redo cycle modelled by the graphToJSON -> applyJSONToGraph round-trip
- * (the same operation that GravisynthUndoManager::SnapshotAction performs on
+ * (the same operation that AppUndoManager::SnapshotAction performs on
  * undo and redo).
  *
  * The following connections must survive:
@@ -498,7 +498,7 @@ TEST_F(UndoRedoTest, RedoWithParameterValueInUnitInterval) {
  * routings, and the serializer must preserve them as-is without substituting
  * attenuverter chains.
  *
- * Strategy (mirrors GravisynthUndoManager behaviour):
+ * Strategy (mirrors AppUndoManager behaviour):
  *   1. Load Poly Pad (preset 6) into graph g.
  *   2. Snapshot: J0 = graphToJSON(g).
  *   3. Simulate "undo-apply-different-state": load preset 0 into g (clobbers Poly Pad).


### PR DESCRIPTION
## Summary
- Add `Source/Branding.h` (`synth::branding`) with `kProductName`, `kCompanyName`, `kBundleIdentifier`, `kSettingsFolderName`, `kPresetFolderName`, `kWebsiteUrl`, `kSupportEmail` — seeded with current values, so this is a one-file change for a future rename.
- Replace hardcoded `"Gravisynth"` strings in `Source/` (ApplicationProperties setup, user-themes folder, AI system prompt) with the new constants.
- Rename brand-bearing identifiers under `Source/`: `GravisynthLookAndFeel` → `AppLookAndFeel` (+ file rename), `GravisynthUndoManager` → `AppUndoManager` (+ file rename), `GravisynthCommands` namespace → `AppCommands`, `GravisynthApplication` → `AppApplication`.
- Drive JUCE's `PRODUCT_NAME`/`COMPANY_NAME`/`BUNDLE_ID` from new CMake cache variables (`SYNTH_PRODUCT_NAME`/`SYNTH_COMPANY_NAME`/`SYNTH_BUNDLE_ID`), defaulted to current values and overridable at configure time.
- Kept the `GravisynthCore`/`Gravisynth`/`GravisynthTests`/`GravisynthAssets` CMake target names unchanged (simplest option — they're referenced by `scripts/` and `.github/workflows/`).
- `kSettingsFolderName`'s **value** is deliberately unchanged (`"Gravisynth"`) — changing it would orphan existing users' settings/presets/themes; a migration shim is a follow-up task.

## Test plan
- [x] `grep -rn 'Gravisynth' --exclude-dir=build --exclude-dir=.git --exclude-dir=worktrees Source/` returns matches only in `Branding.h` plus the kept `GravisynthCore`/`GravisynthAssets` target-name comments.
- [x] `cmake -S . -B build -DENABLE_TESTS=ON && cmake --build build --target GravisynthTests && ./build/Tests/GravisynthTests` — 602/602 tests pass.
- [x] Built the `Gravisynth` app target; verified `Info.plist` (`CFBundleName`/`CFBundleDisplayName`/`CFBundleIdentifier`) is unchanged (`Gravisynth` / `com.gravisynth.app`).
- [x] Verified `SYNTH_PRODUCT_NAME`/`SYNTH_BUNDLE_ID` cache-variable overrides take effect at configure time.