### PR TITLE
Add settings/preset migration shim for product renames

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,8 @@ add_library(GravisynthCore STATIC
     Source/Branding.h
     Source/PresetManager.cpp
     Source/PresetManager.h
+    Source/SettingsMigration.cpp
+    Source/SettingsMigration.h
     # Modules
     Source/Modules/ModuleBase.h
     Source/Modules/OscillatorModule.h

--- a/Source/Branding.h
+++ b/Source/Branding.h
@@ -19,15 +19,22 @@ constexpr const char* kBundleIdentifier = "com.gravisynth.app";
 
 // juce::PropertiesFile::Options::folderName — the on-disk ApplicationProperties folder,
 // also the parent of the user Themes folder (ThemeManager::getUserThemesFolder()).
-// WARNING: do NOT change this value. It is the folder name existing users' settings,
-// presets, and themes already live under; changing it orphans that data. A follow-up task
-// adds a migration shim — only after that lands is it safe to change.
+// Changing this value is now safe: SettingsMigration::migrateUserData() runs at startup
+// (before ApplicationProperties is initialised, see Main.cpp) and copies data forward from
+// the first matching entry in kLegacyFolderNames below. When renaming, prepend the OLD value
+// of kSettingsFolderName to kLegacyFolderNames before changing this one.
 constexpr const char* kSettingsFolderName = "Gravisynth";
 
 // Folder name reserved for user-saved presets. Not yet referenced on disk (preset
 // save/load currently goes through ad hoc juce::FileChooser dialogs with no fixed
 // directory); seeded here so a future on-disk preset store has a name to use.
 constexpr const char* kPresetFolderName = "Gravisynth";
+
+// Previous kSettingsFolderName values, ordered newest-first. SettingsMigration walks this
+// list at startup and copies forward the first entry that exists and has data, so a rename
+// doesn't orphan existing users' settings/presets/themes. Seeded with the current name;
+// a future rename should prepend the old value here (leaving older entries in place).
+constexpr const char* kLegacyFolderNames[] = {kSettingsFolderName};
 
 // Product website, for the About box / support links. Not yet referenced anywhere.
 constexpr const char* kWebsiteUrl = "https://gravisynth.app";

--- a/Source/Main.cpp
+++ b/Source/Main.cpp
@@ -1,4 +1,6 @@
+#include "Branding.h"
 #include "MainComponent.h"
+#include "SettingsMigration.h"
 #include "ShortcutManager.h"
 #include "UI/Theme/AppLookAndFeel.h"
 #include "UI/Theme/ThemeManager.h"
@@ -14,6 +16,9 @@ public:
 
     void initialise(const juce::String& commandLine) override {
         juce::ignoreUnused(commandLine);
+
+        migrateLegacyUserData();
+
         // Apply default theme so the LnF is valid before any Component is created.
         // ThemeManager::initialise() (with appProperties) is called inside MainComponent,
         // which will restore the persisted theme and call applyTheme again.
@@ -35,6 +40,33 @@ public:
     void systemRequestedQuit() override { quit(); }
 
     void anotherInstanceStarted(const juce::String& commandLine) override { juce::ignoreUnused(commandLine); }
+
+private:
+    // Must run before anything creates a juce::ApplicationProperties for kSettingsFolderName
+    // (MainComponent's constructor does this) — otherwise JUCE creates an empty current-name
+    // folder first, and migrateUserData's "already exists" guard skips the real migration.
+    static void migrateLegacyUserData() {
+        juce::PropertiesFile::Options options;
+        options.applicationName = synth::branding::kProductName;
+        options.folderName = synth::branding::kSettingsFolderName;
+        options.filenameSuffix = "settings";
+        options.osxLibrarySubFolder = "Application Support";
+        options.storageFormat = juce::PropertiesFile::storeAsXML;
+
+        // getDefaultFile() resolves the platform-specific settings file inside the
+        // folderName directory; its grandparent is the directory that contains every
+        // differently-named settings folder (past and present).
+        const auto parentDir = options.getDefaultFile().getParentDirectory().getParentDirectory();
+
+        juce::StringArray legacyNames;
+        for (const auto* name : synth::branding::kLegacyFolderNames)
+            legacyNames.add(name);
+
+        const auto result = synth::migrateUserData(parentDir, synth::branding::kSettingsFolderName, legacyNames);
+        if (result.migrated)
+            juce::Logger::writeToLog("Migrated user settings from legacy folder \"" + result.fromName + "\" (" +
+                                     juce::String(result.filesCopied) + " files)");
+    }
 
     class MainWindow
         : public juce::DocumentWindow

--- a/Source/SettingsMigration.cpp
+++ b/Source/SettingsMigration.cpp
@@ -1,0 +1,48 @@
+#include "SettingsMigration.h"
+
+namespace synth {
+
+namespace {
+
+bool folderHasData(const juce::File& folder) {
+    return folder.isDirectory() && folder.getNumberOfChildFiles(juce::File::findFilesAndDirectories) > 0;
+}
+
+int copyRecursively(const juce::File& source, const juce::File& destination) {
+    int filesCopied = 0;
+    for (const auto& entry : juce::RangedDirectoryIterator(source, true, "*", juce::File::findFilesAndDirectories)) {
+        const juce::File src = entry.getFile();
+        const juce::File dest = destination.getChildFile(src.getRelativePathFrom(source));
+        if (src.isDirectory()) {
+            dest.createDirectory();
+        } else {
+            dest.getParentDirectory().createDirectory();
+            if (src.copyFileTo(dest))
+                ++filesCopied;
+        }
+    }
+    return filesCopied;
+}
+
+} // namespace
+
+MigrationResult migrateUserData(const juce::File& parentDir, const juce::String& currentName,
+                                const juce::StringArray& legacyNames) {
+    const auto currentDir = parentDir.getChildFile(currentName);
+    if (folderHasData(currentDir))
+        return {false, {}, 0};
+
+    for (const auto& legacyName : legacyNames) {
+        const auto legacyDir = parentDir.getChildFile(legacyName);
+        if (!folderHasData(legacyDir))
+            continue;
+
+        currentDir.createDirectory();
+        const int filesCopied = copyRecursively(legacyDir, currentDir);
+        return {true, legacyName, filesCopied};
+    }
+
+    return {false, {}, 0};
+}
+
+} // namespace synth

--- a/Source/SettingsMigration.h
+++ b/Source/SettingsMigration.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <juce_core/juce_core.h>
+
+namespace synth {
+
+struct MigrationResult {
+    bool migrated;
+    juce::String fromName;
+    int filesCopied;
+};
+
+// Copies user data (settings/presets/themes) forward from the newest existing legacy folder
+// into the current one, so renaming the product doesn't orphan existing users' data. Pure and
+// side-effect-free beyond the filesystem copy: takes directories as parameters rather than
+// resolving them, so callers point it at the real ApplicationProperties parent at startup and
+// tests point it at temp dirs. Never overwrites or moves data — see call sites for ordering
+// requirements (must run before ApplicationProperties creates the current-name folder).
+MigrationResult migrateUserData(const juce::File& parentDir, const juce::String& currentName,
+                                const juce::StringArray& legacyNames);
+
+} // namespace synth

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -40,6 +40,7 @@ add_executable(GravisynthTests
     E2EWorkflowTests.cpp
     ExternalMidiModuleTests.cpp
     PresetManagerTests.cpp
+    SettingsMigrationTests.cpp
     ModuleBypassTests.cpp
     BypassTests.cpp
     VisualSignalFlowTests.cpp

--- a/Tests/SettingsMigrationTests.cpp
+++ b/Tests/SettingsMigrationTests.cpp
@@ -1,0 +1,117 @@
+#include "../Source/SettingsMigration.h"
+#include <gtest/gtest.h>
+#include <juce_core/juce_core.h>
+
+namespace {
+
+class SettingsMigrationTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        parentDir = juce::File::getSpecialLocation(juce::File::tempDirectory)
+                        .getChildFile("GravisynthSettingsMigrationTest")
+                        .getNonexistentChildFile("run", "", false);
+        parentDir.createDirectory();
+    }
+
+    void TearDown() override { parentDir.deleteRecursively(); }
+
+    static juce::File writeFile(const juce::File& folder, const juce::String& relativePath,
+                                const juce::String& contents) {
+        auto file = folder.getChildFile(relativePath);
+        file.getParentDirectory().createDirectory();
+        file.replaceWithText(contents);
+        return file;
+    }
+
+    juce::File parentDir;
+};
+
+} // namespace
+
+TEST_F(SettingsMigrationTest, MigratesFromLegacyFolderWhenCurrentAbsent) {
+    writeFile(parentDir.getChildFile("OldName"), "settings.xml", "hello");
+
+    auto result = synth::migrateUserData(parentDir, "NewName", {"OldName"});
+
+    EXPECT_TRUE(result.migrated);
+    EXPECT_EQ(result.fromName, "OldName");
+    EXPECT_EQ(result.filesCopied, 1);
+
+    auto copied = parentDir.getChildFile("NewName").getChildFile("settings.xml");
+    EXPECT_TRUE(copied.existsAsFile());
+    EXPECT_EQ(copied.loadFileAsString(), "hello");
+}
+
+TEST_F(SettingsMigrationTest, DoesNotOverwriteExistingCurrentFolder) {
+    writeFile(parentDir.getChildFile("OldName"), "settings.xml", "legacy");
+    writeFile(parentDir.getChildFile("NewName"), "settings.xml", "current");
+
+    auto result = synth::migrateUserData(parentDir, "NewName", {"OldName"});
+
+    EXPECT_FALSE(result.migrated);
+    EXPECT_EQ(result.filesCopied, 0);
+
+    auto current = parentDir.getChildFile("NewName").getChildFile("settings.xml");
+    EXPECT_EQ(current.loadFileAsString(), "current");
+}
+
+TEST_F(SettingsMigrationTest, IsIdempotent) {
+    writeFile(parentDir.getChildFile("OldName"), "settings.xml", "hello");
+
+    auto first = synth::migrateUserData(parentDir, "NewName", {"OldName"});
+    ASSERT_TRUE(first.migrated);
+
+    auto second = synth::migrateUserData(parentDir, "NewName", {"OldName"});
+    EXPECT_FALSE(second.migrated);
+    EXPECT_EQ(second.filesCopied, 0);
+
+    auto current = parentDir.getChildFile("NewName").getChildFile("settings.xml");
+    EXPECT_EQ(current.loadFileAsString(), "hello");
+}
+
+TEST_F(SettingsMigrationTest, NoLegacyFolderIsNoOp) {
+    auto result = synth::migrateUserData(parentDir, "NewName", {"OldName", "OlderName"});
+
+    EXPECT_FALSE(result.migrated);
+    EXPECT_EQ(result.filesCopied, 0);
+    EXPECT_FALSE(parentDir.getChildFile("NewName").exists());
+}
+
+TEST_F(SettingsMigrationTest, PicksNewestLegacyWhenSeveralExist) {
+    writeFile(parentDir.getChildFile("Newer"), "settings.xml", "newer-data");
+    writeFile(parentDir.getChildFile("Older"), "settings.xml", "older-data");
+
+    auto result = synth::migrateUserData(parentDir, "Current", {"Newer", "Older"});
+
+    EXPECT_TRUE(result.migrated);
+    EXPECT_EQ(result.fromName, "Newer");
+
+    auto copied = parentDir.getChildFile("Current").getChildFile("settings.xml");
+    EXPECT_EQ(copied.loadFileAsString(), "newer-data");
+}
+
+TEST_F(SettingsMigrationTest, CopiesNestedSubdirectories) {
+    writeFile(parentDir.getChildFile("OldName"), "settings.xml", "settings");
+    writeFile(parentDir.getChildFile("OldName"), "Presets/lead.gpreset", "preset-data");
+    writeFile(parentDir.getChildFile("OldName"), "Presets/Bass/deep.gpreset", "deep-preset-data");
+
+    auto result = synth::migrateUserData(parentDir, "NewName", {"OldName"});
+
+    EXPECT_TRUE(result.migrated);
+    EXPECT_EQ(result.filesCopied, 3);
+
+    auto newDir = parentDir.getChildFile("NewName");
+    EXPECT_EQ(newDir.getChildFile("Presets/lead.gpreset").loadFileAsString(), "preset-data");
+    EXPECT_EQ(newDir.getChildFile("Presets/Bass/deep.gpreset").loadFileAsString(), "deep-preset-data");
+}
+
+TEST_F(SettingsMigrationTest, LeavesLegacyFolderIntact) {
+    writeFile(parentDir.getChildFile("OldName"), "settings.xml", "hello");
+    writeFile(parentDir.getChildFile("OldName"), "Presets/lead.gpreset", "preset-data");
+
+    synth::migrateUserData(parentDir, "NewName", {"OldName"});
+
+    auto legacyDir = parentDir.getChildFile("OldName");
+    EXPECT_EQ(legacyDir.getChildFile("settings.xml").loadFileAsString(), "hello");
+    EXPECT_EQ(legacyDir.getChildFile("Presets/lead.gpreset").loadFileAsString(), "preset-data");
+}


### PR DESCRIPTION
## Summary
- Adds `kLegacyFolderNames` to `Source/Branding.h` — a newest-first list of previous `kSettingsFolderName` values (seeded with the current name, so a future rename just prepends the old value).
- Adds `Source/SettingsMigration.h/.cpp` (`namespace synth`): a pure, testable `migrateUserData(parentDir, currentName, legacyNames) -> MigrationResult` that copies (never moves) user data forward from the newest existing, non-empty legacy folder into the current one — no-op if the current folder already has data, no-op if no legacy folder exists, idempotent, recursive (nested preset subfolders survive).
- Calls it once in `Source/Main.cpp::AppApplication::initialise()`, before `MainComponent`/`ApplicationProperties` is constructed (otherwise JUCE would create an empty current-name folder first and the migration's "already exists" guard would skip it). Logs one line only on an actual migration.
- Registers the new sources in `CMakeLists.txt` and the new test file in `Tests/CMakeLists.txt`.

## Test plan
- [x] `cmake -S . -B build -DENABLE_TESTS=ON && cmake --build build --target GravisynthTests` — builds clean
- [x] `./build/Tests/GravisynthTests --gtest_filter="SettingsMigrationTest.*"` — all 7 new cases pass (MigratesFromLegacyFolderWhenCurrentAbsent, DoesNotOverwriteExistingCurrentFolder, IsIdempotent, NoLegacyFolderIsNoOp, PicksNewestLegacyWhenSeveralExist, CopiesNestedSubdirectories, LeavesLegacyFolderIntact)
- [x] `./build/Tests/GravisynthTests` — full suite green, 609/609 passing, no regressions
- [x] Manual check: rename `~/Library/Application Support/Gravisynth` to a legacy name, launch the app, confirm preferences/presets reappear and the renamed folder is left intact (not yet done in this environment — no display/audio device available; worth a manual pass before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F2piqPV9stZnatt6sjA6cW