### PR TITLE
fix: stop AI chat history from growing unboundedly

### DIFF
--- a/Source/AI/AIIntegrationService.cpp
+++ b/Source/AI/AIIntegrationService.cpp
@@ -1,5 +1,6 @@
 #include "AIIntegrationService.h"
 #include "../Branding.h"
+#include <algorithm>
 
 namespace synth {
 
@@ -14,28 +15,21 @@ void AIIntegrationService::setProvider(std::unique_ptr<AIProvider> newProvider) 
 
 void AIIntegrationService::sendMessage(const juce::String& text, AIProvider::CompletionCallback callback,
                                        bool useStructuredOutput) {
-    // Inject current graph state only for patch-related requests
-    juce::String messageContent = text;
-    if (useStructuredOutput) {
-        juce::var graphJson = AIStateMapper::graphToJSON(audioGraph);
-        if (auto* obj = graphJson.getDynamicObject()) {
-            if (auto* nodeArr = obj->getProperty("nodes").getArray()) {
-                if (!nodeArr->isEmpty()) {
-                    messageContent = "Current patch state:\n```json\n" + juce::JSON::toString(graphJson) +
-                                     "\n```\n\nUser request: " + text;
-                }
-            }
-        }
-    }
-
-    chatHistory.push_back({"user", messageContent});
+    // The stored history always keeps the user's original text. Patch context is ephemeral:
+    // it is spliced into the outgoing request only, never retained in chatHistory.
+    chatHistory.push_back({"user", text});
+    trimHistory();
 
     if (provider) {
+        std::vector<AIProvider::Message> request = chatHistory;
+        if (useStructuredOutput && !request.empty())
+            request.back().content = buildPatchAugmentedContent(text);
+
         auto weakThis = juce::WeakReference<AIIntegrationService>(this);
         auto schema = useStructuredOutput ? AIStateMapper::getPatchSchema() : juce::var();
 
         provider->sendPrompt(
-            chatHistory,
+            request,
             [weakThis, callback](const juce::String& response, bool success) {
                 if (weakThis.get() == nullptr)
                     return; // Service was destroyed
@@ -43,6 +37,7 @@ void AIIntegrationService::sendMessage(const juce::String& text, AIProvider::Com
                 auto* self = weakThis.get();
                 if (success) {
                     self->chatHistory.push_back({"assistant", response});
+                    self->trimHistory();
                 }
                 if (callback) {
                     callback(response, success);
@@ -54,6 +49,38 @@ void AIIntegrationService::sendMessage(const juce::String& text, AIProvider::Com
             callback("Error: No AI provider selected.", false);
         }
     }
+}
+
+juce::String AIIntegrationService::buildPatchAugmentedContent(const juce::String& text) {
+    juce::var graphJson = AIStateMapper::graphToJSON(audioGraph);
+    if (auto* obj = graphJson.getDynamicObject()) {
+        if (auto* nodeArr = obj->getProperty("nodes").getArray()) {
+            if (!nodeArr->isEmpty()) {
+                return "Current patch state:\n```json\n" + juce::JSON::toString(graphJson) +
+                       "\n```\n\nUser request: " + text;
+            }
+        }
+    }
+    return text;
+}
+
+void AIIntegrationService::trimHistory() {
+    if (chatHistory.empty())
+        return;
+
+    size_t start = (chatHistory.front().role == "system") ? 1 : 0;
+    size_t conversationSize = chatHistory.size() - start;
+    size_t maxConversation = static_cast<size_t>(kMaxHistoryTurns) * 2;
+
+    if (conversationSize <= maxConversation)
+        return;
+
+    size_t excess = conversationSize - maxConversation;
+    size_t pairsToRemove = (excess + 1) / 2; // round up to whole pairs
+    size_t messagesToRemove = std::min(pairsToRemove * 2, conversationSize);
+
+    chatHistory.erase(chatHistory.begin() + static_cast<long>(start),
+                      chatHistory.begin() + static_cast<long>(start + messagesToRemove));
 }
 
 bool AIIntegrationService::applyPatch(const juce::String& jsonString, bool mergeMode) {

--- a/Source/AI/AIIntegrationService.h
+++ b/Source/AI/AIIntegrationService.h
@@ -39,6 +39,12 @@ public:
     void setProvider(std::unique_ptr<AIProvider> newProvider);
 
     /**
+     * @brief Maximum number of retained user/assistant turn pairs, beyond the system prompt.
+     *        Oldest pairs are trimmed first once this cap is exceeded.
+     */
+    static constexpr int kMaxHistoryTurns = 8;
+
+    /**
      * @brief Sends a user message and gets a response.
      */
     void sendMessage(const juce::String& text, AIProvider::CompletionCallback callback,
@@ -83,6 +89,17 @@ private:
      * @brief Helper to extract JSON from a response that might contain conversational text.
      */
     juce::String extractJsonFromResponse(const juce::String& response);
+
+    /**
+     * @brief Builds the patch-augmented request content for a user message, without mutating chatHistory.
+     */
+    juce::String buildPatchAugmentedContent(const juce::String& text);
+
+    /**
+     * @brief Trims chatHistory to the system prompt plus the most recent kMaxHistoryTurns pairs,
+     *        removing oldest whole user+assistant pairs so history never starts on an assistant turn.
+     */
+    void trimHistory();
 
     JUCE_DECLARE_WEAK_REFERENCEABLE(AIIntegrationService)
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(AIIntegrationService)

--- a/Tests/AIIntegrationServiceTests.cpp
+++ b/Tests/AIIntegrationServiceTests.cpp
@@ -8,7 +8,8 @@ class MockAIProvider : public AIProvider {
 public:
     void sendPrompt(const std::vector<Message>& conversation, CompletionCallback callback,
                     const juce::var& responseSchema) override {
-        juce::ignoreUnused(conversation, responseSchema);
+        juce::ignoreUnused(responseSchema);
+        lastConversation = conversation;
         if (shouldFail) {
             callback("Error", false);
         } else {
@@ -30,6 +31,7 @@ public:
     juce::String mockResponse = "{\"nodes\": [], \"connections\": []}";
     bool shouldFail = false;
     juce::String currentModel;
+    std::vector<Message> lastConversation;
 };
 
 class AIIntegrationServiceTest : public ::testing::Test {
@@ -130,6 +132,61 @@ TEST_F(AIIntegrationServiceTest, ApplyPatch_DefaultReplace_ClearsGraph) {
     bool success = service->applyPatch(fullJson);
     ASSERT_TRUE(success);
     ASSERT_EQ(graph->getNumNodes(), 1); // Only the Filter from JSON, Oscillator cleared
+}
+
+TEST_F(AIIntegrationServiceTest, HistoryDoesNotRetainPatchContext) {
+    graph->addNode(std::make_unique<OscillatorModule>());
+
+    auto provider = std::make_unique<MockAIProvider>();
+    service->setProvider(std::move(provider));
+
+    bool called = false;
+    service->sendMessage("Add a filter", [&](const juce::String&, bool) { called = true; }, true);
+
+    EXPECT_TRUE(called);
+    auto history = service->getHistory();
+    ASSERT_GE(history.size(), 2u);
+    EXPECT_EQ(history[1].role, "user");
+    EXPECT_EQ(history[1].content, "Add a filter");
+    EXPECT_FALSE(history[1].content.contains("Current patch state"));
+}
+
+TEST_F(AIIntegrationServiceTest, OutgoingRequestStillIncludesPatchContext) {
+    graph->addNode(std::make_unique<OscillatorModule>());
+
+    auto provider = std::make_unique<MockAIProvider>();
+    auto* rawProvider = provider.get();
+    service->setProvider(std::move(provider));
+
+    service->sendMessage("Add a filter", nullptr, true);
+
+    ASSERT_FALSE(rawProvider->lastConversation.empty());
+    EXPECT_TRUE(rawProvider->lastConversation.back().content.contains("Current patch state"));
+    EXPECT_TRUE(rawProvider->lastConversation.back().content.contains("Add a filter"));
+}
+
+TEST_F(AIIntegrationServiceTest, HistoryIsTrimmedToCap) {
+    auto provider = std::make_unique<MockAIProvider>();
+    service->setProvider(std::move(provider));
+
+    const int turnsToSend = AIIntegrationService::kMaxHistoryTurns + 5;
+    for (int i = 0; i < turnsToSend; ++i)
+        service->sendMessage("msg " + juce::String(i), nullptr);
+
+    auto history = service->getHistory();
+    EXPECT_LE(history.size(), 1u + static_cast<size_t>(AIIntegrationService::kMaxHistoryTurns) * 2u);
+}
+
+TEST_F(AIIntegrationServiceTest, SystemPromptSurvivesTrimming) {
+    auto provider = std::make_unique<MockAIProvider>();
+    service->setProvider(std::move(provider));
+
+    const int turnsToSend = AIIntegrationService::kMaxHistoryTurns + 5;
+    for (int i = 0; i < turnsToSend; ++i)
+        service->sendMessage("msg " + juce::String(i), nullptr);
+
+    ASSERT_FALSE(service->getHistory().empty());
+    EXPECT_EQ(service->getHistory()[0].role, "system");
 }
 
 } // namespace synth


### PR DESCRIPTION
## Summary
- `AIIntegrationService::sendMessage()` was embedding the full patch JSON into `messageContent` and storing that patch-augmented string directly in `chatHistory`, so every subsequent request re-sent every prior patch snapshot verbatim. On a metered hosted backend this means cost grows unboundedly with conversation length.
- `chatHistory` now stores only the user's original text; patch context is spliced into a separate ephemeral request vector built at send time and is never persisted.
- Added a `kMaxHistoryTurns = 8` cap: `trimHistory()` keeps the system prompt (always index 0) plus the most recent 8 user/assistant pairs, trimming oldest whole pairs first so history never starts on an assistant turn.

## Test plan
- [x] `HistoryDoesNotRetainPatchContext` — stored history entry equals the raw user text, no "Current patch state" leakage
- [x] `OutgoingRequestStillIncludesPatchContext` — MockProvider still receives the patch-augmented content in the request
- [x] `HistoryIsTrimmedToCap` — sending N+5 turns keeps history bounded at system prompt + 2*N
- [x] `SystemPromptSurvivesTrimming` — `history[0].role == "system"` after trimming
- [x] `cmake -S . -B build -DENABLE_TESTS=ON && cmake --build build --target GravisynthTests && ./build/Tests/GravisynthTests` — all 606 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0146LKJJT3YSNaAvoawMnjbw