### PR TITLE
chore: add project-level read-only Bash allowlist

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(./build/Tests/GravisynthTests*)",
+      "Bash(curl -s -m 5 http://localhost:11434/*)",
+      "Bash(clang-format --dry-run *)"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `.claude/settings.json` with a curated `permissions.allow` list for read-only commands observed frequently in session transcripts that aren't already covered by Claude Code's built-in read-only auto-allow rules.
- `.claude/settings.local.json` (gitignored, personal, auto-accumulated) was left untouched — it contains broader/mutating entries that are fine as personal convenience approvals but shouldn't become shared repo policy.

## Entries added
| Pattern | Why |
|---|---|
| `Bash(./build/Tests/GravisynthTests*)` | Runs the built test suite/filters — reads code, no repo mutation |
| `Bash(curl -s -m 5 http://localhost:11434/*)` | Localhost-only GET health-check against Ollama |
| `Bash(clang-format --dry-run *)` | Lint check mirroring CI/pre-commit hook — never writes |

## Test plan
- [ ] N/A — config-only change, no code paths affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X7z2VVjTWJDR57FuM6nBbp