### PR TITLE
security: harden AI patch JSON validation for untrusted sources

### DIFF
--- a/Source/AI/AIStateMapper.cpp
+++ b/Source/AI/AIStateMapper.cpp
@@ -21,7 +21,9 @@
 #include "../Modules/SequencerModule.h"
 #include "../Modules/VCAModule.h"
 #include "../Modules/VoiceMixerModule.h"
+#include <cmath>
 #include <functional> // For std::function
+#include <limits>
 #include <map>
 #include <set>
 #include <unordered_map> // For the factory map
@@ -61,41 +63,287 @@ static const std::unordered_map<juce::String, ModuleFactoryFunc> moduleFactory =
     {"Voice Mixer", []() { return std::make_unique<VoiceMixerModule>(); }},
     {"External MIDI", []() { return std::make_unique<ExternalMidiModule>(); }}};
 
-bool AIStateMapper::validatePatchJSON(const juce::var& json) {
-    if (!json.isObject()) {
-        juce::Logger::writeToLog("validatePatchJSON: Root is not an object.");
-        return false;
+namespace {
+
+// Accepts only whole numbers representable as a uint32 (matches juce::AudioProcessorGraph::NodeID's
+// underlying type). Rejects negatives, fractional values, and non-numeric JSON values outright —
+// there is no legitimate node id that isn't one of these.
+bool extractUnsignedInt(const juce::var& v, juce::uint32& out) {
+    if (v.isInt() || v.isInt64()) {
+        auto i = static_cast<juce::int64>(v);
+        if (i < 0 || i > static_cast<juce::int64>(std::numeric_limits<juce::uint32>::max()))
+            return false;
+        out = static_cast<juce::uint32>(i);
+        return true;
     }
+    if (v.isDouble()) {
+        double d = static_cast<double>(v);
+        if (!std::isfinite(d) || d < 0.0 || d > static_cast<double>(std::numeric_limits<juce::uint32>::max()) ||
+            d != std::floor(d))
+            return false;
+        out = static_cast<juce::uint32>(d);
+        return true;
+    }
+    return false;
+}
+
+// -1 is the MIDI sentinel used by graphToJSON/applyJSONToGraph (mapped to
+// juce::AudioProcessorGraph::midiChannelIndex on apply); anything else must be a plausible raw
+// channel index.
+bool isValidPatchPort(int port) {
+    if (port == -1)
+        return true;
+    return port >= 0 && port <= AIStateMapper::kMaxPortIndex;
+}
+
+} // namespace
+
+PatchValidationResult AIStateMapper::validateNodeParams(juce::AudioProcessor* processor,
+                                                        const juce::DynamicObject* paramsObj) {
+    for (auto* param : processor->getParameters()) {
+        auto* p = dynamic_cast<juce::RangedAudioParameter*>(param);
+        if (!p || !paramsObj->hasProperty(p->paramID))
+            continue;
+
+        juce::var jsonValue = paramsObj->getProperty(p->paramID);
+        bool isNumeric = jsonValue.isDouble() || jsonValue.isInt() || jsonValue.isInt64();
+
+        if (auto* choice = dynamic_cast<juce::AudioParameterChoice*>(p)) {
+            if (jsonValue.isString()) {
+                if (findChoiceIndex(choice, jsonValue.toString()) < 0) {
+                    return {false, PatchValidationError::InvalidChoiceValue,
+                            "Unrecognized choice \"" + jsonValue.toString() + "\" for parameter \"" + p->paramID +
+                                "\"."};
+                }
+            } else if (isNumeric) {
+                if (!std::isfinite(static_cast<double>(jsonValue))) {
+                    return {false, PatchValidationError::InvalidParameterValue,
+                            "Non-finite value for parameter \"" + p->paramID + "\"."};
+                }
+            } else {
+                return {false, PatchValidationError::InvalidParameterValue,
+                        "Invalid value for choice parameter \"" + p->paramID + "\"."};
+            }
+        } else if (dynamic_cast<juce::AudioParameterBool*>(p) != nullptr) {
+            // Any JSON value is coercible to bool; nothing to reject.
+        } else {
+            if (!isNumeric && !jsonValue.isBool()) {
+                return {false, PatchValidationError::InvalidParameterValue,
+                        "Invalid value for parameter \"" + p->paramID + "\"."};
+            }
+            if (isNumeric && !std::isfinite(static_cast<double>(jsonValue))) {
+                return {false, PatchValidationError::InvalidParameterValue,
+                        "Non-finite value for parameter \"" + p->paramID + "\"."};
+            }
+        }
+    }
+    return {};
+}
+
+PatchValidationResult AIStateMapper::validatePatch(const juce::var& json, const juce::AudioProcessorGraph& graph,
+                                                   bool clearExisting, bool trusted) {
+    if (!json.isObject())
+        return {false, PatchValidationError::NotAnObject, "Root is not an object."};
     auto* rootObj = json.getDynamicObject();
-    if (!rootObj) {
-        juce::Logger::writeToLog("validatePatchJSON: Root dynamic object is null.");
-        return false;
-    }
+    if (!rootObj)
+        return {false, PatchValidationError::NotAnObject, "Root dynamic object is null."};
 
-    // Check for "nodes" array
+    const juce::Array<juce::var>* nodesList = nullptr;
     if (rootObj->hasProperty("nodes")) {
-        auto* nodesList = rootObj->getProperty("nodes").getArray();
-        if (nodesList == nullptr) {
-            juce::Logger::writeToLog("validatePatchJSON: 'nodes' property is not an array.");
-            return false;
-        }
-        // Further validation of each node could go here (e.g., checking for id and type)
+        nodesList = rootObj->getProperty("nodes").getArray();
+        if (nodesList == nullptr)
+            return {false, PatchValidationError::NodesNotArray, "'nodes' property is not an array."};
     } else if (!rootObj->hasProperty("remove")) {
-        juce::Logger::writeToLog("validatePatchJSON: 'nodes' and 'remove' properties are both missing.");
-        return false;
+        return {false, PatchValidationError::MissingNodesOrRemove, "'nodes' and 'remove' properties are both missing."};
     }
 
-    // Check for "connections" array (optional, a patch can exist without connections)
+    const juce::Array<juce::var>* connList = nullptr;
     if (rootObj->hasProperty("connections")) {
-        auto* connList = rootObj->getProperty("connections").getArray();
-        if (connList == nullptr) {
-            juce::Logger::writeToLog("validatePatchJSON: 'connections' property is not an array.");
-            return false;
-        }
-        // Further validation of each connection could go here
+        connList = rootObj->getProperty("connections").getArray();
+        if (connList == nullptr)
+            return {false, PatchValidationError::ConnectionsNotArray, "'connections' property is not an array."};
     }
 
-    return true;
+    const juce::Array<juce::var>* modList = nullptr;
+    if (rootObj->hasProperty("modulations")) {
+        modList = rootObj->getProperty("modulations").getArray();
+        if (modList == nullptr)
+            return {false, PatchValidationError::ModulationsNotArray, "'modulations' property is not an array."};
+    }
+
+    const juce::Array<juce::var>* removeList = nullptr;
+    if (rootObj->hasProperty("remove")) {
+        removeList = rootObj->getProperty("remove").getArray();
+        if (removeList == nullptr)
+            return {false, PatchValidationError::RemoveNotArray, "'remove' property is not an array."};
+    }
+
+    const juce::Array<juce::var>* removeModList = nullptr;
+    if (rootObj->hasProperty("removeModulations")) {
+        removeModList = rootObj->getProperty("removeModulations").getArray();
+        if (removeModList == nullptr)
+            return {false, PatchValidationError::RemoveModulationsNotArray,
+                    "'removeModulations' property is not an array."};
+    }
+
+    // Trusted callers (locally-authored JSON: the user's own saved presets, undo/redo replay)
+    // keep the legacy, purely-structural validation above and skip the strict checks below.
+    if (trusted)
+        return {};
+
+    if (nodesList && nodesList->size() > kMaxNodes)
+        return {false, PatchValidationError::TooManyNodes,
+                "Patch has " + juce::String(nodesList->size()) + " nodes, exceeding the limit of " +
+                    juce::String(kMaxNodes) + "."};
+    if (connList && connList->size() > kMaxConnections)
+        return {false, PatchValidationError::TooManyConnections,
+                "Patch has " + juce::String(connList->size()) + " connections, exceeding the limit of " +
+                    juce::String(kMaxConnections) + "."};
+    if (modList && modList->size() > kMaxModulations)
+        return {false, PatchValidationError::TooManyModulations,
+                "Patch has " + juce::String(modList->size()) + " modulations, exceeding the limit of " +
+                    juce::String(kMaxModulations) + "."};
+    if (removeList && removeList->size() > kMaxRemovals)
+        return {false, PatchValidationError::TooManyRemovals,
+                "Patch has " + juce::String(removeList->size()) + " removals, exceeding the limit of " +
+                    juce::String(kMaxRemovals) + "."};
+    if (removeModList && removeModList->size() > kMaxRemoveModulations)
+        return {false, PatchValidationError::TooManyRemoveModulations,
+                "Patch has " + juce::String(removeModList->size()) + " modulation removals, exceeding the limit of " +
+                    juce::String(kMaxRemoveModulations) + "."};
+
+    // Ids this patch may legally reference: nodes it creates, plus (in merge mode) nodes that
+    // already exist in the live graph. Populated fully before any connection/modulation is
+    // checked, and nothing here mutates the graph — that only happens after validation passes.
+    std::set<juce::uint32> knownIds;
+    if (!clearExisting) {
+        for (auto* node : graph.getNodes())
+            knownIds.insert(node->nodeID.uid);
+    }
+
+    std::set<juce::uint32> patchNodeIds;
+    if (nodesList) {
+        for (const auto& nVar : *nodesList) {
+            auto* nObj = nVar.getDynamicObject();
+            if (!nObj)
+                return {false, PatchValidationError::NodeEntryInvalid, "Node entry is not an object."};
+
+            if (!nObj->hasProperty("id"))
+                return {false, PatchValidationError::NodeIdInvalid, "Node is missing 'id'."};
+            juce::uint32 nodeId = 0;
+            if (!extractUnsignedInt(nObj->getProperty("id"), nodeId))
+                return {false, PatchValidationError::NodeIdInvalid,
+                        "Node 'id' must be an integer within uint32 range."};
+
+            if (!nObj->hasProperty("type"))
+                return {false, PatchValidationError::NodeTypeInvalid, "Node is missing 'type'."};
+            juce::var typeVar = nObj->getProperty("type");
+            if (!typeVar.isString())
+                return {false, PatchValidationError::NodeTypeInvalid, "Node 'type' must be a string."};
+            juce::String type = typeVar.toString();
+            if (type.isEmpty() || type.length() > kMaxTypeNameLength)
+                return {false, PatchValidationError::NodeTypeInvalid,
+                        "Node 'type' must be 1-" + juce::String(kMaxTypeNameLength) + " characters."};
+
+            if (patchNodeIds.count(nodeId) > 0)
+                return {false, PatchValidationError::DuplicateNodeId,
+                        "Duplicate node id " + juce::String(nodeId) + " within patch."};
+            patchNodeIds.insert(nodeId);
+
+            // Resolve the type via the real factory up front, rather than discovering an
+            // unknown type mid-apply after other nodes may already have been created.
+            auto probe = createModule(type);
+            if (!probe)
+                return {false, PatchValidationError::UnknownNodeType, "Unknown module type: \"" + type + "\"."};
+
+            if (nObj->hasProperty("params")) {
+                if (auto* pObj = nObj->getProperty("params").getDynamicObject()) {
+                    auto paramResult = validateNodeParams(probe.get(), pObj);
+                    if (!paramResult.ok)
+                        return paramResult;
+                }
+            }
+        }
+    }
+    knownIds.insert(patchNodeIds.begin(), patchNodeIds.end());
+
+    if (connList) {
+        for (const auto& cVar : *connList) {
+            auto* cObj = cVar.getDynamicObject();
+            if (!cObj)
+                return {false, PatchValidationError::ConnectionEntryInvalid, "Connection entry is not an object."};
+
+            juce::uint32 src = 0, dst = 0;
+            if (!extractUnsignedInt(cObj->getProperty("src"), src) || knownIds.count(src) == 0)
+                return {false, PatchValidationError::ConnectionUnknownNode,
+                        "Connection references unknown source node id."};
+            if (!extractUnsignedInt(cObj->getProperty("dst"), dst) || knownIds.count(dst) == 0)
+                return {false, PatchValidationError::ConnectionUnknownNode,
+                        "Connection references unknown destination node id."};
+            if (src == dst)
+                return {false, PatchValidationError::ConnectionSelfCycle,
+                        "Connection would create a self-cycle (src == dst == " + juce::String(src) + ")."};
+
+            int srcPort = static_cast<int>(cObj->getProperty("srcPort"));
+            int dstPort = static_cast<int>(cObj->getProperty("dstPort"));
+            if (!isValidPatchPort(srcPort) || !isValidPatchPort(dstPort))
+                return {false, PatchValidationError::ConnectionInvalidPort, "Connection port index out of range."};
+        }
+    }
+
+    if (modList) {
+        for (const auto& mVar : *modList) {
+            auto* mObj = mVar.getDynamicObject();
+            if (!mObj)
+                return {false, PatchValidationError::ModulationEntryInvalid, "Modulation entry is not an object."};
+
+            juce::uint32 source = 0, dest = 0;
+            if (!extractUnsignedInt(mObj->getProperty("source"), source) || knownIds.count(source) == 0)
+                return {false, PatchValidationError::ModulationUnknownNode,
+                        "Modulation references unknown source node id."};
+            if (!extractUnsignedInt(mObj->getProperty("dest"), dest) || knownIds.count(dest) == 0)
+                return {false, PatchValidationError::ModulationUnknownNode,
+                        "Modulation references unknown destination node id."};
+            if (source == dest)
+                return {false, PatchValidationError::ModulationSelfCycle,
+                        "Modulation would create a self-cycle (source == dest == " + juce::String(source) + ")."};
+
+            // Modulation ports are always real audio/CV channels, never MIDI — reject the -1
+            // sentinel here even though it's legal for plain connections.
+            int destPort = static_cast<int>(mObj->getProperty("destPort"));
+            if (destPort < 0 || !isValidPatchPort(destPort))
+                return {false, PatchValidationError::ModulationInvalidPort, "Modulation destPort out of range."};
+
+            if (mObj->hasProperty("sourcePort")) {
+                int sourcePort = static_cast<int>(mObj->getProperty("sourcePort"));
+                if (sourcePort < 0 || !isValidPatchPort(sourcePort))
+                    return {false, PatchValidationError::ModulationInvalidPort, "Modulation sourcePort out of range."};
+            }
+        }
+    }
+
+    if (removeList) {
+        for (const auto& idVar : *removeList) {
+            juce::uint32 tmp = 0;
+            if (!extractUnsignedInt(idVar, tmp))
+                return {false, PatchValidationError::RemoveEntryInvalid,
+                        "Entries in 'remove' must be integers within uint32 range."};
+        }
+    }
+
+    if (removeModList) {
+        for (const auto& rVar : *removeModList) {
+            auto* rObj = rVar.getDynamicObject();
+            juce::uint32 tmp = 0;
+            if (!rObj || !rObj->hasProperty("source") || !extractUnsignedInt(rObj->getProperty("source"), tmp) ||
+                !rObj->hasProperty("dest") || !extractUnsignedInt(rObj->getProperty("dest"), tmp) ||
+                !rObj->hasProperty("destPort"))
+                return {false, PatchValidationError::RemoveModulationEntryInvalid,
+                        "Invalid 'removeModulations' entry."};
+        }
+    }
+
+    return {};
 }
 
 std::unique_ptr<juce::AudioProcessor> AIStateMapper::createModule(const juce::String& type) {
@@ -376,8 +624,9 @@ void AIStateMapper::applyParamsToProcessor(juce::AudioProcessor* processor, cons
                             p->setValueNotifyingHost(p->getNormalisableRange().convertTo0to1((float)index));
                         }
                     } else {
-                        float val = (float)jsonValue;
-                        p->setValueNotifyingHost(p->getNormalisableRange().convertTo0to1(val));
+                        auto choiceRange = p->getNormalisableRange();
+                        float val = choiceRange.snapToLegalValue((float)jsonValue);
+                        p->setValueNotifyingHost(choiceRange.convertTo0to1(val));
                     }
                 } else if (auto* b = dynamic_cast<juce::AudioParameterBool*>(p)) {
                     b->setValueNotifyingHost((bool)jsonValue ? 1.0f : 0.0f);
@@ -417,9 +666,11 @@ bool AIStateMapper::applyJSONToGraph(const juce::var& json, juce::AudioProcessor
         return false;
     }
 
-    // Validate JSON structure before making any changes
-    if (!validatePatchJSON(json)) {
-        juce::Logger::writeToLog("applyJSONToGraph: JSON patch validation failed.");
+    // Validate the entire patch before making any changes — a rejected patch must never be
+    // partially applied.
+    auto validation = validatePatch(json, graph, clearExisting, trusted);
+    if (!validation.ok) {
+        juce::Logger::writeToLog("applyJSONToGraph: JSON patch validation failed: " + validation.message);
         return false;
     }
 

--- a/Source/AI/AIStateMapper.h
+++ b/Source/AI/AIStateMapper.h
@@ -7,11 +7,70 @@
 namespace synth {
 
 /**
+ * @brief Why a patch JSON failed validation, so callers (and the UI) can say what was wrong.
+ */
+enum class PatchValidationError {
+    None,
+    NotAnObject,
+    MissingNodesOrRemove,
+    NodesNotArray,
+    ConnectionsNotArray,
+    ModulationsNotArray,
+    RemoveNotArray,
+    RemoveModulationsNotArray,
+    TooManyNodes,
+    TooManyConnections,
+    TooManyModulations,
+    TooManyRemovals,
+    TooManyRemoveModulations,
+    NodeEntryInvalid,
+    NodeIdInvalid,
+    NodeTypeInvalid,
+    UnknownNodeType,
+    DuplicateNodeId,
+    InvalidParameterValue,
+    InvalidChoiceValue,
+    ConnectionEntryInvalid,
+    ConnectionUnknownNode,
+    ConnectionInvalidPort,
+    ConnectionSelfCycle,
+    ModulationEntryInvalid,
+    ModulationUnknownNode,
+    ModulationInvalidPort,
+    ModulationSelfCycle,
+    RemoveEntryInvalid,
+    RemoveModulationEntryInvalid,
+};
+
+/**
+ * @brief Result of validating a patch JSON: whether it passed, and if not, why.
+ */
+struct PatchValidationResult {
+    bool ok = true;
+    PatchValidationError error = PatchValidationError::None;
+    juce::String message;
+};
+
+/**
  * @class AIStateMapper
  * @brief Handles conversion between AI-friendly JSON and juce::AudioProcessorGraph.
  */
 class AIStateMapper {
 public:
+    // Limits enforced against untrusted (network/AI-authored) patches — see validatePatch().
+    // Chosen generously above anything this app would author itself, while still bounding the
+    // worst case an adversarial or misbehaving remote model could throw at applyJSONToGraph
+    // while it holds the audio callback lock.
+    static constexpr int kMaxNodes = 256;
+    static constexpr int kMaxConnections = 1024;
+    static constexpr int kMaxModulations = 512;
+    static constexpr int kMaxRemovals = 256;
+    static constexpr int kMaxRemoveModulations = 256;
+    static constexpr int kMaxTypeNameLength = 64;
+    // No module in this codebase exposes anywhere near this many raw channels (poly buses top
+    // out at 16 — see PolyMidiModule); this just bounds how large a port index we'll accept.
+    static constexpr int kMaxPortIndex = 64;
+
     /**
      * @brief Converts the current graph state to a JSON-compatible juce::var.
      */
@@ -19,10 +78,30 @@ public:
 
     /**
      * @brief Applies a JSON-compatible juce::var to the graph.
+     *
+     * When `trusted` is false (the default), the patch is fully validated via validatePatch()
+     * before anything is touched, and rejected outright — never partially applied — on any
+     * violation. Only set `trusted` for JSON that originates locally and was already produced
+     * or vetted by this app (e.g. loading the user's own saved preset from disk, or undo/redo
+     * replaying prior graph state). Anything that could originate off-device (an AI provider,
+     * local or remote) must go through the default strict path.
+     *
      * @return true if the patch was applied successfully.
      */
     static bool applyJSONToGraph(const juce::var& json, juce::AudioProcessorGraph& graph, bool clearExisting = true,
                                  bool trusted = false);
+
+    /**
+     * @brief Validates a patch JSON without applying it, returning a reason on failure.
+     *
+     * @param graph existing graph the patch would be applied to — used in merge mode
+     *              (clearExisting == false) so connections/modulations may reference nodes
+     *              that already exist rather than only nodes newly created by this patch.
+     * @param trusted when true, only minimal structural checks are performed (matches legacy
+     *              behaviour); when false, the full strict validation runs.
+     */
+    static PatchValidationResult validatePatch(const juce::var& json, const juce::AudioProcessorGraph& graph,
+                                               bool clearExisting, bool trusted);
 
     /**
      * @brief Gets a Markdown-formatted string of all available modules and their parameters.
@@ -37,8 +116,6 @@ public:
     static std::unique_ptr<juce::AudioProcessor> createModule(const juce::String& type);
 
 private:
-    static bool validatePatchJSON(const juce::var& json);
-
     /**
      * @brief Helper to find the index of a string choice in an AudioParameterChoice.
      * @return index if found, -1 otherwise.
@@ -47,6 +124,11 @@ private:
 
     static void applyParamsToProcessor(juce::AudioProcessor* processor, const juce::DynamicObject* paramsObj,
                                        bool trusted = false);
+
+    // Validates JSON-provided parameter values for one node against its actual processor
+    // instance. Only used on the strict/untrusted validation path.
+    static PatchValidationResult validateNodeParams(juce::AudioProcessor* processor,
+                                                    const juce::DynamicObject* paramsObj);
 };
 
 } // namespace synth

--- a/Source/PresetManager.cpp
+++ b/Source/PresetManager.cpp
@@ -27,7 +27,9 @@ bool PresetManager::loadPreset(int index, juce::AudioProcessorGraph& graph) {
         return false;
 
     auto json = juce::JSON::parse(jsonStr);
-    return AIStateMapper::applyJSONToGraph(json, graph, true);
+    // Bundled/built-in presets are authored by us, not by an AI provider — trust them like any
+    // other local, first-party content.
+    return AIStateMapper::applyJSONToGraph(json, graph, true, /*trusted=*/true);
 }
 
 bool PresetManager::loadDefaultPreset(juce::AudioProcessorGraph& graph) { return loadPreset(0, graph); }

--- a/Source/UI/GraphEditor.cpp
+++ b/Source/UI/GraphEditor.cpp
@@ -1638,7 +1638,8 @@ void GraphEditor::loadPreset(juce::File file) {
     }
     // Detach before applyJSONToGraph clears the graph (see loadFactoryPreset — avoids scope-timer UAF).
     detachAllModuleComponents();
-    if (synth::AIStateMapper::applyJSONToGraph(json, audioEngine.getGraph(), true)) {
+    // The user picked this file from their own filesystem — trusted, unlike an AI-authored patch.
+    if (synth::AIStateMapper::applyJSONToGraph(json, audioEngine.getGraph(), true, /*trusted=*/true)) {
         updateComponents();
     } else {
         updateComponents(); // reconcile view to whatever state the graph is in after a failed apply

--- a/Tests/AIStateMapperTests.cpp
+++ b/Tests/AIStateMapperTests.cpp
@@ -7,6 +7,7 @@
 #include "../Source/PresetManager.h"
 #include <gtest/gtest.h>
 #include <juce_audio_processors/juce_audio_processors.h>
+#include <limits>
 
 // Helper function to create a basic graph for testing
 static void createBasicGraph(juce::AudioProcessorGraph& graph) {
@@ -130,7 +131,10 @@ TEST(AIStateMapperTest, UnknownModuleTypeLogsErrorAndSkips) {
     };
     LogCatcher logger;
 
-    bool success_unknown_module = synth::AIStateMapper::applyJSONToGraph(json, graph, true);
+    // Trusted mode (e.g. loading the user's own saved preset) keeps the legacy permissive
+    // behavior of skipping an unresolvable node rather than rejecting the whole patch. See
+    // RejectsUnknownModuleType below for the strict/untrusted behavior.
+    bool success_unknown_module = synth::AIStateMapper::applyJSONToGraph(json, graph, true, /*trusted=*/true);
     ASSERT_TRUE(success_unknown_module); // Should still return true if valid JSON, just skips the node
     ASSERT_EQ(graph.getNumNodes(), 0);   // Unknown module should not be added
     ASSERT_TRUE(logger.lastMessage.contains("Unknown module type"));
@@ -619,4 +623,190 @@ TEST(AIStateMapperTest, PresetLoadDoesNotSpamLogger) {
     // (which would be 100+ for a typical multi-module preset).
     EXPECT_LT(logCount, 20) << "applyJSONToGraph is spamming the logger (" << logCount
                             << " lines for 3 presets). This causes UI freezes in AIChatComponent.";
+}
+
+// ---------------------------------------------------------------------------------------------
+// Strict/untrusted patch validation (default mode) — hardening against a patch source that
+// isn't just a trusted local Ollama: a remote server, or a local model emitting garbage under
+// load. Every test below relies on applyJSONToGraph's default trusted=false.
+// ---------------------------------------------------------------------------------------------
+
+TEST(AIStateMapperTest, RejectsPatchExceedingNodeCap) {
+    juce::AudioProcessorGraph graph;
+
+    juce::Array<juce::var> nodes;
+    for (int i = 0; i < synth::AIStateMapper::kMaxNodes + 1; ++i) {
+        juce::DynamicObject::Ptr n = new juce::DynamicObject();
+        n->setProperty("id", i + 1);
+        n->setProperty("type", "Oscillator");
+        nodes.add(juce::var(n.get()));
+    }
+    juce::DynamicObject::Ptr root = new juce::DynamicObject();
+    root->setProperty("nodes", nodes);
+    root->setProperty("connections", juce::Array<juce::var>());
+
+    bool success = synth::AIStateMapper::applyJSONToGraph(juce::var(root.get()), graph, true);
+    EXPECT_FALSE(success);
+    EXPECT_EQ(graph.getNumNodes(), 0);
+}
+
+TEST(AIStateMapperTest, RejectsUnknownModuleType) {
+    juce::AudioProcessorGraph graph;
+    juce::var json = juce::JSON::parse(R"({"nodes":[{"id":1,"type":"TotallyBogusModule"}],"connections":[]})");
+
+    bool success = synth::AIStateMapper::applyJSONToGraph(json, graph, true);
+    EXPECT_FALSE(success);
+    EXPECT_EQ(graph.getNumNodes(), 0);
+}
+
+TEST(AIStateMapperTest, RejectsDuplicateNodeIds) {
+    juce::AudioProcessorGraph graph;
+    juce::var json =
+        juce::JSON::parse(R"({"nodes":[{"id":5,"type":"Oscillator"},{"id":5,"type":"Filter"}],"connections":[]})");
+
+    bool success = synth::AIStateMapper::applyJSONToGraph(json, graph, true);
+    EXPECT_FALSE(success);
+    EXPECT_EQ(graph.getNumNodes(), 0);
+}
+
+TEST(AIStateMapperTest, RejectsNaNAndInfinityParameterValues) {
+    // NaN/Infinity can't be spelled in strict JSON text, so build the var tree directly.
+    juce::DynamicObject::Ptr params = new juce::DynamicObject();
+    params->setProperty("fine", std::numeric_limits<double>::quiet_NaN());
+
+    juce::DynamicObject::Ptr node = new juce::DynamicObject();
+    node->setProperty("id", 1);
+    node->setProperty("type", "Oscillator");
+    node->setProperty("params", juce::var(params.get()));
+
+    juce::Array<juce::var> nodesArr;
+    nodesArr.add(juce::var(node.get()));
+
+    juce::DynamicObject::Ptr root = new juce::DynamicObject();
+    root->setProperty("nodes", nodesArr);
+    root->setProperty("connections", juce::Array<juce::var>());
+
+    {
+        juce::AudioProcessorGraph graph;
+        bool success = synth::AIStateMapper::applyJSONToGraph(juce::var(root.get()), graph, true);
+        EXPECT_FALSE(success);
+        EXPECT_EQ(graph.getNumNodes(), 0);
+    }
+
+    params->setProperty("fine", std::numeric_limits<double>::infinity());
+    {
+        juce::AudioProcessorGraph graph;
+        bool success = synth::AIStateMapper::applyJSONToGraph(juce::var(root.get()), graph, true);
+        EXPECT_FALSE(success);
+        EXPECT_EQ(graph.getNumNodes(), 0);
+    }
+}
+
+TEST(AIStateMapperTest, RejectsNegativeAndOutOfRangePortIndices) {
+    {
+        juce::AudioProcessorGraph graph;
+        juce::var json = juce::JSON::parse(R"({
+            "nodes":[{"id":1,"type":"Oscillator"},{"id":2,"type":"Filter"}],
+            "connections":[{"src":1,"srcPort":0,"dst":2,"dstPort":-5}]
+        })");
+        bool success = synth::AIStateMapper::applyJSONToGraph(json, graph, true);
+        EXPECT_FALSE(success);
+        EXPECT_EQ(graph.getNumNodes(), 0);
+    }
+    {
+        juce::AudioProcessorGraph graph;
+        juce::var json = juce::JSON::parse(R"({
+            "nodes":[{"id":1,"type":"Oscillator"},{"id":2,"type":"Filter"}],
+            "connections":[{"src":1,"srcPort":0,"dst":2,"dstPort":99999}]
+        })");
+        bool success = synth::AIStateMapper::applyJSONToGraph(json, graph, true);
+        EXPECT_FALSE(success);
+        EXPECT_EQ(graph.getNumNodes(), 0);
+    }
+}
+
+TEST(AIStateMapperTest, RejectsConnectionToUnknownNodeId) {
+    juce::AudioProcessorGraph graph;
+    juce::var json = juce::JSON::parse(R"({
+        "nodes":[{"id":1,"type":"Oscillator"}],
+        "connections":[{"src":1,"srcPort":0,"dst":9999,"dstPort":0}]
+    })");
+
+    bool success = synth::AIStateMapper::applyJSONToGraph(json, graph, true);
+    EXPECT_FALSE(success);
+    EXPECT_EQ(graph.getNumNodes(), 0);
+}
+
+TEST(AIStateMapperTest, RejectsSelfConnectionCycle) {
+    juce::AudioProcessorGraph graph;
+    juce::var json = juce::JSON::parse(R"({
+        "nodes":[{"id":1,"type":"Filter"}],
+        "connections":[{"src":1,"srcPort":0,"dst":1,"dstPort":0}]
+    })");
+
+    bool success = synth::AIStateMapper::applyJSONToGraph(json, graph, true);
+    EXPECT_FALSE(success);
+    EXPECT_EQ(graph.getNumNodes(), 0);
+}
+
+TEST(AIStateMapperTest, ClampsOutOfRangeParameterValues) {
+    juce::AudioProcessorGraph graph;
+    juce::var json =
+        juce::JSON::parse(R"({"nodes":[{"id":1,"type":"Oscillator","params":{"fine":-500.0}}],"connections":[]})");
+
+    bool success = synth::AIStateMapper::applyJSONToGraph(json, graph, true);
+    ASSERT_TRUE(success);
+    ASSERT_EQ(graph.getNumNodes(), 1);
+
+    auto* osc = dynamic_cast<OscillatorModule*>(graph.getNodes().getUnchecked(0)->getProcessor());
+    ASSERT_NE(osc, nullptr);
+    bool foundFine = false;
+    for (auto* param : osc->getParameters()) {
+        if (auto* p = dynamic_cast<juce::AudioProcessorParameterWithID*>(param)) {
+            if (p->paramID == "fine") {
+                foundFine = true;
+                // fine's range is -100..100; -500 should clamp to the minimum (normalized 0.0),
+                // not be rejected outright.
+                EXPECT_NEAR(p->getValue(), 0.0f, 0.001f);
+            }
+        }
+    }
+    EXPECT_TRUE(foundFine);
+}
+
+TEST(AIStateMapperTest, TrustedModeStillAcceptsExistingValidPresets) {
+    auto presetNames = synth::PresetManager::getPresetNames();
+    for (int i = 0; i < presetNames.size(); ++i) {
+        juce::AudioProcessorGraph graph;
+        EXPECT_TRUE(synth::PresetManager::loadPreset(i, graph))
+            << "Preset \"" << presetNames[i] << "\" (index " << i << ") failed to load";
+        EXPECT_GT(graph.getNumNodes(), 0) << "Preset \"" << presetNames[i] << "\" loaded with zero nodes";
+    }
+}
+
+TEST(AIStateMapperTest, GraphIsUnchangedAfterRejectedPatch) {
+    juce::AudioProcessorGraph graph;
+    createBasicGraph(graph);
+
+    juce::String beforeJson = juce::JSON::toString(synth::AIStateMapper::graphToJSON(graph));
+    int beforeNodes = graph.getNumNodes();
+    int beforeConnections = (int)graph.getConnections().size();
+
+    // Node 9001 is individually valid and appears first; node 9002 has an unknown type. If
+    // validation ran interleaved with apply (rather than fully up front), 9001 would end up
+    // added to the graph even though the overall patch is rejected.
+    juce::var badJson = juce::JSON::parse(R"({
+        "nodes":[
+            {"id":9001,"type":"Oscillator"},
+            {"id":9002,"type":"NotARealModuleType"}
+        ],
+        "connections":[{"src":9001,"srcPort":0,"dst":9002,"dstPort":0}]
+    })");
+
+    bool success = synth::AIStateMapper::applyJSONToGraph(badJson, graph, false);
+    EXPECT_FALSE(success);
+
+    EXPECT_EQ(graph.getNumNodes(), beforeNodes);
+    EXPECT_EQ((int)graph.getConnections().size(), beforeConnections);
+    EXPECT_EQ(juce::JSON::toString(synth::AIStateMapper::graphToJSON(graph)), beforeJson);
 }


### PR DESCRIPTION
## Summary
- `AIStateMapper::validatePatchJSON` only checked that the root was an object and that `nodes`/`connections`, if present, were arrays — no caps, no id/type checks, no port bounds, no parameter finiteness checks. `applyJSONToGraph` then constructed whatever it was given while holding the audio callback lock. Fine against a trusted local Ollama; a DoS surface against a remote server or a misbehaving model.
- Replaced it with `AIStateMapper::validatePatch`, which validates a patch **entirely before any graph mutation** and returns a `PatchValidationResult` (`ok` + `PatchValidationError` + `message`) instead of a bare bool:
  - Caps: max 256 nodes, 1024 connections, 512 modulations, 256 removals/removeModulations (`AIStateMapper::kMax*`).
  - Per node: `id` must be a uint32-range integer, `type` a non-empty string <64 chars resolvable by `createModule`; duplicate ids within one patch are rejected.
  - Per connection/modulation: `src`/`dst` must reference a known id (in this patch, or already in the graph in merge mode); ports must be non-negative and within a sane bound (`-1` is the MIDI sentinel, valid only for plain connections); self-connections are rejected.
  - Per parameter: NaN/Infinity are rejected outright; out-of-range finite numbers are still **clamped** to the parameter's `NormalisableRange` rather than rejected; unresolvable `AudioParameterChoice` strings are rejected in strict mode.
- The existing `trusted` flag (already defaulting to `false`) now gates strict vs. legacy-permissive validation. `PresetManager::loadPreset` and `GraphEditor::loadPreset` (disk-loaded presets) now pass `trusted=true` explicitly; the AI/network patch path (`AIIntegrationService::applyPatch`) is untouched and stays on the strict default.

## Test plan
- [x] `cmake -S . -B build -DENABLE_TESTS=ON && cmake --build build --target GravisynthTests`
- [x] `./build/Tests/GravisynthTests` — 612/612 tests pass
- [x] New tests in `Tests/AIStateMapperTests.cpp`: `RejectsPatchExceedingNodeCap`, `RejectsUnknownModuleType`, `RejectsDuplicateNodeIds`, `RejectsNaNAndInfinityParameterValues`, `RejectsNegativeAndOutOfRangePortIndices`, `RejectsConnectionToUnknownNodeId`, `RejectsSelfConnectionCycle`, `ClampsOutOfRangeParameterValues`, `TrustedModeStillAcceptsExistingValidPresets`, `GraphIsUnchangedAfterRejectedPatch` (the critical one — byte-identical graph state after a rejected patch)
- [x] Existing `AIStateMapperTest`/`IntegrationTest`/`StateRoundTripTests` suites all still pass
- [x] `clang-format --dry-run --Werror` clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DSVRKvE1xtMtcFjUNWfjVp