### PR TITLE
refactor: replace hardcoded Ollama selection with an AIProviderRegistry

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,8 @@ add_library(GravisynthCore STATIC
     Source/AI/AIIntegrationService.h
     Source/AI/AIStateMapper.cpp
     Source/AI/AIStateMapper.h
+    Source/AI/AIProviderRegistry.h
+    Source/AI/AIProviderRegistry.cpp
     # UI utilities
     Source/UI/LayoutUtil.h
     Source/UI/LayoutUtil.cpp

--- a/Source/AI/AIProviderRegistry.cpp
+++ b/Source/AI/AIProviderRegistry.cpp
@@ -1,0 +1,37 @@
+#include "AIProviderRegistry.h"
+#include "OllamaProvider.h"
+
+namespace synth {
+
+void AIProviderRegistry::registerProvider(ProviderDescriptor descriptor) {
+    descriptors.push_back(std::move(descriptor));
+}
+
+const ProviderDescriptor* AIProviderRegistry::find(const juce::String& id) const {
+    for (auto& d : descriptors)
+        if (d.id == id)
+            return &d;
+    return nullptr;
+}
+
+std::unique_ptr<AIProvider> AIProviderRegistry::create(const juce::String& id, const ProviderConfig& config) const {
+    if (descriptors.empty())
+        return nullptr;
+
+    const ProviderDescriptor* descriptor = find(id);
+    if (descriptor == nullptr)
+        descriptor = &descriptors.front();
+
+    return descriptor->create(config);
+}
+
+AIProviderRegistry AIProviderRegistry::createDefault() {
+    AIProviderRegistry registry;
+    registry.registerProvider(
+        {"ollama", "Ollama (local)", true, false, [](const ProviderConfig& config) -> std::unique_ptr<AIProvider> {
+             return std::make_unique<OllamaProvider>(config.host);
+         }});
+    return registry;
+}
+
+} // namespace synth

--- a/Source/AI/AIProviderRegistry.h
+++ b/Source/AI/AIProviderRegistry.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include "AIProvider.h"
+#include <functional>
+#include <juce_core/juce_core.h>
+#include <memory>
+#include <vector>
+
+namespace synth {
+
+/** Config passed to a ProviderDescriptor's factory when constructing a provider instance. */
+struct ProviderConfig {
+    juce::String host;
+    juce::String authToken;
+};
+
+/** Describes one registrable AI provider: how to build it and what the UI needs to show.
+    `id` is persisted to user settings and must never change once shipped — `displayName`
+    is free to change at any time without breaking a user's saved selection. */
+struct ProviderDescriptor {
+    juce::String id;
+    juce::String displayName;
+    bool needsHost = false;
+    bool needsAuth = false;
+    std::function<std::unique_ptr<AIProvider>(const ProviderConfig&)> create;
+};
+
+/** Registry of available AI providers, keyed by stable id.
+    Populated once via createDefault() and shared by MainComponent (construction) and
+    SettingsWindow (UI population) so that adding a new hosted provider later is a single
+    registration rather than edits scattered across both. */
+class AIProviderRegistry {
+public:
+    void registerProvider(ProviderDescriptor descriptor);
+
+    /** Returns nullptr if no provider with this id is registered. */
+    const ProviderDescriptor* find(const juce::String& id) const;
+
+    const std::vector<ProviderDescriptor>& listAll() const { return descriptors; }
+
+    /** Constructs a provider by id. Falls back to the first registered provider if `id`
+        is unknown or empty, and returns nullptr only if the registry itself is empty. */
+    std::unique_ptr<AIProvider> create(const juce::String& id, const ProviderConfig& config) const;
+
+    /** Registry pre-populated with all built-in providers (currently: Ollama). This is the
+        ONE place a new provider gets registered. */
+    static AIProviderRegistry createDefault();
+
+private:
+    std::vector<ProviderDescriptor> descriptors;
+};
+
+} // namespace synth

--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -1,5 +1,5 @@
 #include "MainComponent.h"
-#include "AI/OllamaProvider.h"
+#include "AI/AIProviderRegistry.h"
 #include "Branding.h"
 #include "UI/SettingsWindow.h"
 
@@ -27,11 +27,11 @@ MainComponent::MainComponent(synth::theme::ThemeManager& tm, synth::theme::AppLo
     // Subscribe to theme changes so we can re-skin on every switch.
     themeManager->addChangeListener(this);
 
-    initialiseCommon(std::move(provider));
+    initialiseCommon(std::move(provider), synth::AIProviderRegistry::createDefault());
 }
 
 // ---- Delegating constructor for tests / legacy call sites ----
-MainComponent::MainComponent(std::unique_ptr<synth::AIProvider> provider)
+MainComponent::MainComponent(std::unique_ptr<synth::AIProvider> provider, synth::AIProviderRegistry registry)
     : graphEditor(audioEngine, &undoManager)
     , aiService(audioEngine.getGraph())
     , aiChatComponent(aiService, appProperties) {
@@ -56,11 +56,11 @@ MainComponent::MainComponent(std::unique_ptr<synth::AIProvider> provider)
     lookAndFeel->applyTheme(themeManager->getActiveTheme());
     themeManager->addChangeListener(this);
 
-    initialiseCommon(std::move(provider));
+    initialiseCommon(std::move(provider), std::move(registry));
 }
 
 // ---- Shared post-construction body ----
-void MainComponent::initialiseCommon(std::unique_ptr<synth::AIProvider> provider) {
+void MainComponent::initialiseCommon(std::unique_ptr<synth::AIProvider> provider, synth::AIProviderRegistry registry) {
     // ORDERING CONTRACT: read the persisted panel-visibility flags FIRST, before any
     // setVisible()/addAndMakeVisible() call that depends on them. These override the member
     // initialisers (isLibraryVisible{true}, isAiPanelVisible=false).
@@ -69,14 +69,16 @@ void MainComponent::initialiseCommon(std::unique_ptr<synth::AIProvider> provider
     graphEditor.setAlignmentGuidesEnabled(
         appProperties.getUserSettings()->getBoolValue("alignmentGuidesEnabled", true));
 
-    // Load AI provider preference
-    juce::String savedProviderName = appProperties.getUserSettings()->getValue("aiProvider", "Ollama");
+    // Load AI provider preference. "ollama" is the persisted id (see AIProviderRegistry),
+    // not a display name — registry.create() falls back to the first registered provider
+    // if the saved id is unknown (e.g. stale pre-registry value, or empty).
+    juce::String savedProviderId = appProperties.getUserSettings()->getValue("aiProvider", "ollama");
     juce::String savedOllamaHost = appProperties.getUserSettings()->getValue("ollamaHost", "http://localhost:11434");
 
     if (provider) {
         aiService.setProvider(std::move(provider));
-    } else if (savedProviderName == "Ollama") {
-        aiService.setProvider(std::make_unique<synth::OllamaProvider>(savedOllamaHost));
+    } else {
+        aiService.setProvider(registry.create(savedProviderId, {savedOllamaHost, {}}));
     }
 
     // ORDERING CONTRACT: aiChatComponent is a member, so its constructor (which calls

--- a/Source/MainComponent.h
+++ b/Source/MainComponent.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "AI/AIIntegrationService.h"
+#include "AI/AIProviderRegistry.h"
 #include "AppUndoManager.h"
 #include "AudioEngine.h"
 #include "PresetManager.h"
@@ -33,7 +34,8 @@ public:
     // Delegating ctor for tests and legacy call sites that don't inject theme objects.
     // Lazily owns private default ThemeManager + AppLookAndFeel instances
     // (stored in ownedThemeManager / ownedLookAndFeel below).
-    explicit MainComponent(std::unique_ptr<synth::AIProvider> provider = nullptr);
+    explicit MainComponent(std::unique_ptr<synth::AIProvider> provider = nullptr,
+                           synth::AIProviderRegistry registry = synth::AIProviderRegistry::createDefault());
 
     ~MainComponent() override;
 
@@ -105,7 +107,7 @@ private:
     void changeListenerCallback(juce::ChangeBroadcaster* source) override;
 
     // Shared initialisation body called from both constructors after appProperties is set up.
-    void initialiseCommon(std::unique_ptr<synth::AIProvider> provider);
+    void initialiseCommon(std::unique_ptr<synth::AIProvider> provider, synth::AIProviderRegistry registry);
 
     // Push the (themed, re-tinted) icon Drawables onto the 9 toolbar DrawableButtons + the
     // status-bar master-mute button, and manage icon-only vs icon+text text per narrow mode.

--- a/Source/UI/SettingsWindow.cpp
+++ b/Source/UI/SettingsWindow.cpp
@@ -1,5 +1,5 @@
 #include "SettingsWindow.h"
-#include "../AI/OllamaProvider.h"
+#include "../AI/AIProviderRegistry.h"
 #include "../ShortcutManager.h"
 #include "AppearanceSettingsTab.h"
 #include "ShortcutsSettingsTab.h"
@@ -13,24 +13,31 @@ public:
                   synth::AIChatComponent& aiChatComp)
         : appProperties(props)
         , aiService(aiServ)
-        , aiChatComponent(aiChatComp) {
+        , aiChatComponent(aiChatComp)
+        , providerRegistry(synth::AIProviderRegistry::createDefault()) {
         addAndMakeVisible(providerLabel);
         providerLabel.setText("AI Provider:", juce::dontSendNotification);
 
         addAndMakeVisible(providerCombo);
-        providerCombo.addItem("Ollama", 1);
-        providerCombo.setSelectedId(appProperties.getUserSettings()->getValue("aiProvider", "Ollama") == "Ollama" ? 1
-                                                                                                                  : 0,
-                                    juce::dontSendNotification);
+        juce::String savedProviderId = appProperties.getUserSettings()->getValue("aiProvider", "ollama");
+        int selectedItemId = 1;
+        const auto& allProviders = providerRegistry.listAll();
+        for (size_t i = 0; i < allProviders.size(); ++i) {
+            int itemId = (int)i + 1;
+            providerCombo.addItem(allProviders[i].displayName, itemId);
+            if (allProviders[i].id == savedProviderId)
+                selectedItemId = itemId;
+        }
+        providerCombo.setSelectedId(selectedItemId, juce::dontSendNotification);
         providerCombo.onChange = [this] { updateSettings(); };
 
         addAndMakeVisible(hostLabel);
-        hostLabel.setText("Ollama Host:", juce::dontSendNotification);
-
         addAndMakeVisible(hostEditor);
         hostEditor.setText(appProperties.getUserSettings()->getValue("ollamaHost", "http://localhost:11434"));
         hostEditor.onReturnKey = [this] { updateSettings(); };
         hostEditor.onFocusLost = [this] { updateSettings(); };
+
+        updateHostFieldForSelectedProvider();
     }
 
     void paint(juce::Graphics& g) override { g.fillAll(findColour(juce::ResizableWindow::backgroundColourId)); }
@@ -49,24 +56,42 @@ public:
     }
 
     void updateSettings() {
-        juce::String selectedProvider = providerCombo.getText();
+        const auto* descriptor = selectedDescriptor();
+        juce::String providerId = descriptor != nullptr ? descriptor->id : juce::String("ollama");
         juce::String newOllamaHost = hostEditor.getText();
 
-        appProperties.getUserSettings()->setValue("aiProvider", selectedProvider);
+        appProperties.getUserSettings()->setValue("aiProvider", providerId);
         appProperties.getUserSettings()->setValue("ollamaHost", newOllamaHost);
         appProperties.saveIfNeeded();
 
-        // Re-initialize AI service with new provider/host
-        if (selectedProvider == "Ollama") {
-            aiService.setProvider(std::make_unique<synth::OllamaProvider>(newOllamaHost));
-        }
+        updateHostFieldForSelectedProvider();
+
+        aiService.setProvider(providerRegistry.create(providerId, {newOllamaHost, {}}));
         aiChatComponent.refreshModels();
     }
 
 private:
+    const synth::ProviderDescriptor* selectedDescriptor() const {
+        int selectedIndex = providerCombo.getSelectedItemIndex();
+        const auto& all = providerRegistry.listAll();
+        if (selectedIndex >= 0 && (size_t)selectedIndex < all.size())
+            return &all[(size_t)selectedIndex];
+        return nullptr;
+    }
+
+    void updateHostFieldForSelectedProvider() {
+        const auto* descriptor = selectedDescriptor();
+        bool showHost = descriptor == nullptr || descriptor->needsHost;
+        hostLabel.setVisible(showHost);
+        hostEditor.setVisible(showHost);
+        hostLabel.setText(descriptor != nullptr ? (descriptor->displayName + " Host:") : juce::String("Host:"),
+                          juce::dontSendNotification);
+    }
+
     juce::ApplicationProperties& appProperties;
     synth::AIIntegrationService& aiService;
     synth::AIChatComponent& aiChatComponent;
+    synth::AIProviderRegistry providerRegistry;
 
     juce::Label providerLabel;
     juce::ComboBox providerCombo;

--- a/Tests/AIProviderRegistryTests.cpp
+++ b/Tests/AIProviderRegistryTests.cpp
@@ -1,0 +1,91 @@
+#include "../Source/AI/AIProvider.h"
+#include "../Source/AI/AIProviderRegistry.h"
+#include <gtest/gtest.h>
+
+namespace {
+
+class StubProvider : public synth::AIProvider {
+public:
+    explicit StubProvider(juce::String name)
+        : name(std::move(name)) {}
+
+    juce::String getProviderName() const override { return name; }
+    void fetchAvailableModels(std::function<void(const juce::StringArray&, bool)> callback) override {
+        callback({}, true);
+    }
+    void sendPrompt(const std::vector<synth::AIProvider::Message>&, CompletionCallback callback,
+                    const juce::var& = juce::var()) override {
+        callback("", true);
+    }
+    void setModel(const juce::String&) override {}
+    juce::String getCurrentModel() const override { return {}; }
+
+private:
+    juce::String name;
+};
+
+} // namespace
+
+TEST(AIProviderRegistryTest, RegisteredProviderIsConstructibleById) {
+    synth::AIProviderRegistry registry;
+    registry.registerProvider(
+        {"stub", "Stub Provider", false, false, [](const synth::ProviderConfig&) -> std::unique_ptr<synth::AIProvider> {
+             return std::make_unique<StubProvider>("Stub Provider");
+         }});
+
+    auto provider = registry.create("stub", {});
+    ASSERT_NE(provider, nullptr);
+    EXPECT_EQ(provider->getProviderName(), "Stub Provider");
+}
+
+TEST(AIProviderRegistryTest, UnknownIdFallsBackToFirstRegistered) {
+    synth::AIProviderRegistry registry;
+    registry.registerProvider({"first", "First Provider", false, false,
+                               [](const synth::ProviderConfig&) -> std::unique_ptr<synth::AIProvider> {
+                                   return std::make_unique<StubProvider>("First Provider");
+                               }});
+    registry.registerProvider({"second", "Second Provider", false, false,
+                               [](const synth::ProviderConfig&) -> std::unique_ptr<synth::AIProvider> {
+                                   return std::make_unique<StubProvider>("Second Provider");
+                               }});
+
+    auto provider = registry.create("does-not-exist", {});
+    ASSERT_NE(provider, nullptr);
+    EXPECT_EQ(provider->getProviderName(), "First Provider");
+}
+
+TEST(AIProviderRegistryTest, ListAllReturnsEveryRegisteredDescriptor) {
+    synth::AIProviderRegistry registry;
+    registry.registerProvider({"first", "First Provider", false, false, nullptr});
+    registry.registerProvider({"second", "Second Provider", true, true, nullptr});
+
+    const auto& all = registry.listAll();
+    ASSERT_EQ(all.size(), 2u);
+    EXPECT_EQ(all[0].id, "first");
+    EXPECT_EQ(all[1].id, "second");
+    EXPECT_TRUE(all[1].needsHost);
+    EXPECT_TRUE(all[1].needsAuth);
+}
+
+TEST(AIProviderRegistryTest, PersistedIdIsIndependentOfDisplayName) {
+    auto makeRegistry = [](const juce::String& displayName) {
+        synth::AIProviderRegistry registry;
+        registry.registerProvider({"ollama", displayName, true, false,
+                                   [](const synth::ProviderConfig&) -> std::unique_ptr<synth::AIProvider> {
+                                       return std::make_unique<StubProvider>("Ollama");
+                                   }});
+        return registry;
+    };
+
+    // Simulates renaming the UI-facing label between versions — the persisted key is "ollama"
+    // regardless of what displayName the descriptor carries.
+    auto oldRegistry = makeRegistry("Ollama");
+    auto newRegistry = makeRegistry("Ollama (local)");
+
+    ASSERT_NE(oldRegistry.find("ollama"), nullptr);
+    ASSERT_NE(newRegistry.find("ollama"), nullptr);
+    EXPECT_EQ(oldRegistry.find("ollama")->id, newRegistry.find("ollama")->id);
+
+    auto provider = newRegistry.create("ollama", {});
+    ASSERT_NE(provider, nullptr);
+}

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -23,6 +23,7 @@ add_executable(GravisynthTests
     LFOModuleTests.cpp
     SequencerModuleTests.cpp
     AIStateMapperTests.cpp
+    AIProviderRegistryTests.cpp
     OllamaProviderTests.cpp
     MainComponentTests.cpp
     GraphEditorTests.cpp

--- a/Tests/MainComponentTests.cpp
+++ b/Tests/MainComponentTests.cpp
@@ -1,4 +1,5 @@
 #include "../Source/AI/AIProvider.h"
+#include "../Source/AI/AIProviderRegistry.h"
 #include "MainComponent.h"
 #include "UI/ToolbarComponent.h"
 #include <gtest/gtest.h>
@@ -321,6 +322,23 @@ TEST_F(MainComponentTest, AiProviderGetsModelSelectedOnStartup) {
     MainComponent mc(std::move(ownedProvider));
 
     EXPECT_GE(rawProvider->fetchCallCount, 1);
+    EXPECT_FALSE(mc.getAiServiceForTest().getCurrentModel().isEmpty());
+    EXPECT_EQ(mc.getAiServiceForTest().getCurrentModel(), "mock-model-a");
+}
+
+// Confirms MainComponent's no-injected-provider path goes through AIProviderRegistry
+// (not a hardcoded OllamaProvider construction) and that the post-setProvider()
+// refreshModels() contract (see AiProviderGetsModelSelectedOnStartup above) still holds
+// when the provider comes from the registry.
+TEST_F(MainComponentTest, StartupUsesRegistryAndStillSelectsAModel) {
+    synth::AIProviderRegistry registry;
+    registry.registerProvider({"ollama", "Ollama (local)", true, false,
+                               [](const synth::ProviderConfig&) -> std::unique_ptr<synth::AIProvider> {
+                                   return std::make_unique<ModelTrackingMockProvider>();
+                               }});
+
+    MainComponent mc(nullptr, registry);
+
     EXPECT_FALSE(mc.getAiServiceForTest().getCurrentModel().isEmpty());
     EXPECT_EQ(mc.getAiServiceForTest().getCurrentModel(), "mock-model-a");
 }

--- a/docs/AI_Engine.md
+++ b/docs/AI_Engine.md
@@ -133,7 +133,7 @@ provider installed and is therefore a no-op (it issues no `/api/tags` request at
 **Any owner that constructs `AIChatComponent` before installing a provider on the
 `AIIntegrationService` it was given MUST call `chatComponent.refreshModels()` again AFTER
 `aiService.setProvider(...)`.** `MainComponent::initialiseCommon()` does this immediately
-after its `setProvider(...)` if/else block. Skipping this step means `currentModel` stays
+after constructing the provider (either the one injected by a caller/test, or the one built via `synth::AIProviderRegistry` from the persisted provider id — see `Source/AI/AIProviderRegistry.h`). Skipping this step means `currentModel` stays
 empty and every subsequent `/api/chat` request is sent with `"model": ""`, which Ollama
 rejects with HTTP 400 `"model is required"`.
 
@@ -141,6 +141,17 @@ Regression: this call was mistakenly deleted in commit `f7cba4a` (issue #96) and
 with a comment incorrectly claiming the ctor-time call already covered discovery. Locked by
 `MainComponentTest.AiProviderGetsModelSelectedOnStartup` and
 `AIChatComponentTest.RefreshModelsSelectsModelWhenProviderInstalledAfterConstruction`.
+
+### AI Provider Registry
+
+Providers are registered once, in `synth::AIProviderRegistry::createDefault()`
+(`Source/AI/AIProviderRegistry.cpp`) — adding a new hosted provider is a single
+`registerProvider(...)` call there, not edits scattered across `MainComponent` and
+`SettingsWindow`. Each `ProviderDescriptor` carries a stable `id` (persisted to the
+`"aiProvider"` setting) separately from its `displayName` (shown in the UI), so renaming
+the UI label never breaks a user's saved selection. `AIProviderRegistry::create()` falls
+back to the first registered provider when given an unknown or empty id — this covers
+both a stale pre-registry saved value and any future case of a provider being removed.
 
 ### OllamaProvider: Fail-Fast on Empty Model + HTTP-Status-Aware Errors
 


### PR DESCRIPTION
Supersedes #131 (that PR's source branch got deleted as a side effect of a branch rename and GitHub auto-closed it; same commit, no code changes).

## Summary
- Adds `synth::AIProviderRegistry` (`Source/AI/AIProviderRegistry.h/.cpp`): a small registry of `ProviderDescriptor`s (stable persisted `id`, UI `displayName`, `needsHost`/`needsAuth` flags, and a `create()` factory), registered once via `AIProviderRegistry::createDefault()` (currently just Ollama).
- `MainComponent` now constructs its AI provider via the registry instead of a hardcoded `if (savedProviderName == "Ollama")` branch; unknown/missing persisted ids fall back to the first registered provider.
- `SettingsWindow`'s `AISettingsTab` populates its dropdown from the registry, shows the host field only when `needsHost` is true, and persists the provider `id` (not the display label) so renaming UI text can never orphan a user's saved setting.
- Preserves the model-discovery ordering contract from `docs/AI_Engine.md`: the provider is still constructed and `setProvider()`'d before `aiChatComponent.refreshModels()` runs.

## Test plan
- [x] New `Tests/AIProviderRegistryTests.cpp`: `RegisteredProviderIsConstructibleById`, `UnknownIdFallsBackToFirstRegistered`, `ListAllReturnsEveryRegisteredDescriptor`, `PersistedIdIsIndependentOfDisplayName`
- [x] New `MainComponentTest.StartupUsesRegistryAndStillSelectsAModel` — confirms the no-injected-provider startup path goes through the registry and still selects a model
- [x] Existing contract tests still pass: `MainComponentTest.AiProviderGetsModelSelectedOnStartup`, `AIChatComponentTest.RefreshModelsSelectsModelWhenProviderInstalledAfterConstruction`
- [x] `cmake -S . -B build -DENABLE_TESTS=ON && cmake --build build --target GravisynthTests && ./build/Tests/GravisynthTests` — 630/630 tests pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cmty7Zwi9Vcdzy1SjXoRE1