### PR TITLE
feat: make AI-applied patches undoable

### DIFF
--- a/Source/AI/AIIntegrationService.cpp
+++ b/Source/AI/AIIntegrationService.cpp
@@ -1,11 +1,13 @@
 #include "AIIntegrationService.h"
+#include "../AppUndoManager.h"
 #include "../Branding.h"
 #include <algorithm>
 
 namespace synth {
 
-AIIntegrationService::AIIntegrationService(juce::AudioProcessorGraph& graph)
-    : audioGraph(graph) {
+AIIntegrationService::AIIntegrationService(juce::AudioProcessorGraph& graph, AppUndoManager* undoManager)
+    : audioGraph(graph)
+    , undoManager(undoManager) {
     initSystemPrompt();
 }
 
@@ -88,21 +90,46 @@ bool AIIntegrationService::applyPatch(const juce::String& jsonString, bool merge
     juce::var json = juce::JSON::parse(extractedJson);
     bool clearExisting = !mergeMode;
 
-    // Validate BEFORE touching any listener — juce::JSON::parse returns a void var for unparseable input,
-    // which validatePatch rejects (NotAnObject) along with any other structurally invalid patch. A failure
-    // here means the graph is never mutated, so listeners must not be told a patch is about to apply.
+    // Validate BEFORE touching any listener or the undo stack — juce::JSON::parse returns a void var for
+    // unparseable input, which validatePatch rejects (NotAnObject) along with any other structurally invalid
+    // patch. A failure here means the graph is never mutated, so listeners must not be told a patch is about
+    // to apply, and no no-op entry may be left on the undo stack.
     if (!AIStateMapper::validatePatch(json, audioGraph, clearExisting, /*trusted=*/false).ok) {
         return false;
     }
 
     // Notify listeners to detach graph-referencing UI BEFORE the graph is rebuilt (avoids a use-after-free
     // where a ScopeComponent timer reads a freed VisualBuffer once applyJSONToGraph clears old processors).
-    listeners.call([](Listener& l) { l.aiPatchAboutToApply(); });
-    if (AIStateMapper::applyJSONToGraph(json, audioGraph, clearExisting)) {
-        listeners.call([](Listener& l) { l.aiPatchApplied(); });
-        return true;
+    // Undo and redo rebuild the graph exactly the same way, so the pair must fire around those too — they
+    // are handed to the undoable action as its pre/post restore hooks. Skipping them on undo would leave the
+    // graph editor holding stale ModuleComponents that reference freed VisualBuffers.
+    juce::WeakReference<AIIntegrationService> weakThis(this);
+    auto notifyAboutToApply = [weakThis] {
+        if (auto* self = weakThis.get())
+            self->listeners.call([](Listener& l) { l.aiPatchAboutToApply(); });
+    };
+    auto notifyApplied = [weakThis] {
+        if (auto* self = weakThis.get())
+            self->listeners.call([](Listener& l) { l.aiPatchApplied(); });
+    };
+
+    auto applyNow = [this, json, clearExisting, notifyAboutToApply, notifyApplied] {
+        notifyAboutToApply();
+        if (AIStateMapper::applyJSONToGraph(json, audioGraph, clearExisting)) {
+            notifyApplied();
+            return true;
+        }
+        return false;
+    };
+
+    // With an undo manager installed the apply is wrapped in a snapshot transaction so Cmd+Z restores the
+    // user's previous patch; without one (e.g. tests that construct the service standalone) it applies directly.
+    if (undoManager != nullptr) {
+        return undoManager->recordAIPatch(audioGraph, mergeMode ? "AI merge" : "AI patch", applyNow, notifyAboutToApply,
+                                          notifyApplied);
     }
-    return false;
+
+    return applyNow();
 }
 
 juce::String AIIntegrationService::extractJsonFromResponse(const juce::String& response) {

--- a/Source/AI/AIIntegrationService.cpp
+++ b/Source/AI/AIIntegrationService.cpp
@@ -94,7 +94,15 @@ bool AIIntegrationService::applyPatch(const juce::String& jsonString, bool merge
     // unparseable input, which validatePatch rejects (NotAnObject) along with any other structurally invalid
     // patch. A failure here means the graph is never mutated, so listeners must not be told a patch is about
     // to apply, and no no-op entry may be left on the undo stack.
-    if (!AIStateMapper::validatePatch(json, audioGraph, clearExisting, /*trusted=*/false).ok) {
+    lastPatchError.clear();
+
+    if (const auto validation = AIStateMapper::validatePatch(json, audioGraph, clearExisting, /*trusted=*/false);
+        !validation.ok) {
+        // One log per rejected patch — user-click frequency, so it does not violate the no-high-frequency
+        // logging rule. In Debug builds this reaches AIChatComponent's console panel.
+        lastPatchError = validation.message.isNotEmpty() ? validation.message : "Patch failed validation.";
+        juce::Logger::writeToLog("applyPatch rejected (" + juce::String(mergeMode ? "merge" : "replace") +
+                                 "): " + lastPatchError);
         return false;
     }
 
@@ -119,6 +127,8 @@ bool AIIntegrationService::applyPatch(const juce::String& jsonString, bool merge
             notifyApplied();
             return true;
         }
+        lastPatchError = "Patch could not be applied to the graph.";
+        juce::Logger::writeToLog("applyPatch failed during applyJSONToGraph: " + lastPatchError);
         return false;
     };
 

--- a/Source/AI/AIIntegrationService.h
+++ b/Source/AI/AIIntegrationService.h
@@ -68,6 +68,14 @@ public:
     bool applyPatch(const juce::String& jsonString, bool mergeMode = false);
 
     /**
+     * @brief Why the most recent applyPatch() returned false, in human-readable form.
+     *
+     * Empty when the last apply succeeded. Callers MUST surface this — a rejected patch that is
+     * swallowed silently looks to the user like a dead Apply/Merge button.
+     */
+    const juce::String& getLastPatchError() const { return lastPatchError; }
+
+    /**
      * @brief Returns the current graph state as a JSON string for context.
      */
     juce::String getPatchContext();
@@ -94,6 +102,7 @@ private:
     std::vector<AIProvider::Message> chatHistory;
     juce::AudioProcessorGraph& audioGraph;
     AppUndoManager* undoManager = nullptr;
+    juce::String lastPatchError;
     juce::ListenerList<Listener> listeners;
 
     void initSystemPrompt();

--- a/Source/AI/AIIntegrationService.h
+++ b/Source/AI/AIIntegrationService.h
@@ -8,6 +8,8 @@
 #include <memory>
 #include <vector>
 
+class AppUndoManager; // Forward declaration — the service only holds a non-owning pointer.
+
 namespace synth {
 
 /**
@@ -16,8 +18,18 @@ namespace synth {
  */
 class AIIntegrationService {
 public:
-    AIIntegrationService(juce::AudioProcessorGraph& graph);
+    /**
+     * @param graph The graph AI patches are applied to.
+     * @param undoManager Optional — when supplied, applyPatch() becomes undoable. Defaults to null so
+     *                    callers that don't own an undo manager (e.g. tests) keep working unchanged.
+     */
+    AIIntegrationService(juce::AudioProcessorGraph& graph, AppUndoManager* undoManager = nullptr);
     ~AIIntegrationService();
+
+    /**
+     * @brief Installs (or clears) the undo manager used to make applyPatch() undoable.
+     */
+    void setUndoManager(AppUndoManager* um) { undoManager = um; }
 
     /**
      * @class Listener
@@ -81,6 +93,7 @@ private:
     std::unique_ptr<AIProvider> provider;
     std::vector<AIProvider::Message> chatHistory;
     juce::AudioProcessorGraph& audioGraph;
+    AppUndoManager* undoManager = nullptr;
     juce::ListenerList<Listener> listeners;
 
     void initSystemPrompt();

--- a/Source/AI/AIStateMapper.cpp
+++ b/Source/AI/AIStateMapper.cpp
@@ -793,7 +793,17 @@ bool AIStateMapper::applyJSONToGraph(const juce::var& json, juce::AudioProcessor
                             }
                         }
 
-                        auto node = graph.addNode(std::move(processor));
+                        // Preserve node identity when restoring OUR OWN snapshot (undo/redo, preset load).
+                        // graphToJSON writes the live uid as "id", so replaying it with the same NodeID
+                        // keeps ids stable across an undo — without this the graph is renumbered and
+                        // anything holding an id across the restore (most visibly a merge-mode patch card,
+                        // which addresses existing nodes by uid) silently stops resolving.
+                        // Only on the trusted path: untrusted AI JSON must never dictate node ids.
+                        std::optional<juce::AudioProcessorGraph::NodeID> preservedId;
+                        if (trusted && clearExisting && oldId > 0)
+                            preservedId = juce::AudioProcessorGraph::NodeID((juce::uint32)oldId);
+
+                        auto node = graph.addNode(std::move(processor), preservedId);
                         if (node) {
                             idMap[oldId] = node->nodeID;
                             newlyCreatedNodes.insert(node->nodeID);

--- a/Source/AppUndoManager.cpp
+++ b/Source/AppUndoManager.cpp
@@ -221,6 +221,26 @@ void AppUndoManager::recordPositionChange(juce::AudioProcessorGraph& graph, juce
     undoManager.perform(new PositionChangeAction(graph, nodeId, oldX, oldY, newX, newY, postRestore));
 }
 
+bool AppUndoManager::recordAIPatch(juce::AudioProcessorGraph& graph, const juce::String& actionName,
+                                   std::function<bool()> mutation, std::function<void()> preRestore,
+                                   std::function<void()> postRestore) {
+    if (!mutation)
+        return false;
+
+    auto beforeState = synth::AIStateMapper::graphToJSON(graph);
+
+    // The mutation performs the apply itself (including its own listener notifications). If the patch is
+    // rejected the graph is untouched — return without pushing so the undo stack keeps no no-op entry.
+    if (!mutation())
+        return false;
+
+    auto afterState = synth::AIStateMapper::graphToJSON(graph);
+
+    undoManager.beginNewTransaction(actionName);
+    undoManager.perform(new SnapshotAction(beforeState, afterState, graph, preRestore, postRestore));
+    return true;
+}
+
 void AppUndoManager::captureBeforeState(juce::AudioProcessorGraph& graph) {
     capturedBeforeState = synth::AIStateMapper::graphToJSON(graph);
 }

--- a/Source/AppUndoManager.h
+++ b/Source/AppUndoManager.h
@@ -63,6 +63,27 @@ public:
     void recordPositionChange(juce::AudioProcessorGraph& graph, juce::AudioProcessorGraph::NodeID nodeId, int oldX,
                               int oldY, int newX, int newY, std::function<void()> postRestore);
 
+    /**
+     * @brief Records an AI-applied patch (Apply / Merge on a patch card) as an undoable snapshot.
+     *
+     * Same snapshot strategy as recordStructuralChange, but the caller supplies its own
+     * preRestore/postRestore hooks so the AI listener notifications (aiPatchAboutToApply /
+     * aiPatchApplied) fire on undo and redo as well as on the initial apply — otherwise the
+     * graph editor keeps stale ModuleComponents pointing at freed VisualBuffers.
+     *
+     * If the mutation reports failure nothing is pushed, so an invalid patch leaves no
+     * no-op entry on the undo stack.
+     *
+     * @param graph Reference to the audio processor graph
+     * @param actionName Human-readable transaction name (e.g. "AI patch" / "AI merge")
+     * @param mutation Lambda that applies the patch; returns false if it did not apply
+     * @param preRestore Lambda called before the graph is rebuilt on undo/redo
+     * @param postRestore Lambda called after the graph is rebuilt on undo/redo
+     * @return true if the mutation succeeded and an undo entry was pushed
+     */
+    bool recordAIPatch(juce::AudioProcessorGraph& graph, const juce::String& actionName, std::function<bool()> mutation,
+                       std::function<void()> preRestore, std::function<void()> postRestore);
+
     // Snapshot-based parameter/position change recording.
     // Call captureBeforeState at gesture start, then pushSnapshotFromCapture at gesture end.
     void captureBeforeState(juce::AudioProcessorGraph& graph);

--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -61,6 +61,10 @@ MainComponent::MainComponent(std::unique_ptr<synth::AIProvider> provider, synth:
 
 // ---- Shared post-construction body ----
 void MainComponent::initialiseCommon(std::unique_ptr<synth::AIProvider> provider, synth::AIProviderRegistry registry) {
+    // Route AI patch applies through the app undo manager so Apply/Merge on a patch card is Cmd+Z-able.
+    // Safe in both ctors: undoManager is declared before aiService, so it is already constructed here.
+    aiService.setUndoManager(&undoManager);
+
     // ORDERING CONTRACT: read the persisted panel-visibility flags FIRST, before any
     // setVisible()/addAndMakeVisible() call that depends on them. These override the member
     // initialisers (isLibraryVisible{true}, isAiPanelVisible=false).

--- a/Source/UI/AIChatComponent.cpp
+++ b/Source/UI/AIChatComponent.cpp
@@ -505,8 +505,24 @@ void AIChatComponent::updateChatDisplay() {
                 juce::Logger::writeToLog("--- Applying patch (merge=" + juce::String(isMerge ? "true" : "false") +
                                          ") ---");
                 juce::Logger::writeToLog("JSON: " + json);
-                aiService.applyPatch(json, isMerge);
-                juce::Logger::writeToLog("--- Patch applied ---");
+                if (aiService.applyPatch(json, isMerge)) {
+                    juce::Logger::writeToLog("--- Patch applied ---");
+                    return;
+                }
+                // Never swallow a rejection: an Apply/Merge that does nothing and says nothing is
+                // indistinguishable from a broken button. Surface the reason in the conversation.
+                auto reason = aiService.getLastPatchError();
+                if (reason.isEmpty())
+                    reason = "The patch could not be applied.";
+                juce::Logger::writeToLog("--- Patch REJECTED: " + reason + " ---");
+                messages.push_back({"assistant", "Could not apply this patch: " + reason, ""});
+                // Refresh asynchronously: updateChatDisplay() calls messageList.deleteAllChildren(),
+                // which would destroy the MessageBubble whose callback we are currently inside.
+                juce::Component::SafePointer<AIChatComponent> safeThis(this);
+                juce::MessageManager::callAsync([safeThis] {
+                    if (auto* self = safeThis.getComponent())
+                        self->updateChatDisplay();
+                });
             },
             isMerge);
         messageList.addAndMakeVisible(bubble);

--- a/Tests/AIUndoTests.cpp
+++ b/Tests/AIUndoTests.cpp
@@ -1,0 +1,289 @@
+#include "AI/AIIntegrationService.h"
+#include "AI/AIStateMapper.h"
+#include "AppUndoManager.h"
+#include "MainComponent.h"
+#include <gtest/gtest.h>
+#include <juce_audio_processors/juce_audio_processors.h>
+#include <juce_gui_basics/juce_gui_basics.h>
+#include <set>
+#include <vector>
+
+namespace synth {
+namespace {
+
+/**
+ * Structural fingerprint of a graph: the multiset of node type names plus the multiset of
+ * connections described by processor name + channel. Deliberately ID-free — restoring a
+ * snapshot rebuilds the graph from scratch, so juce NodeIDs are renumbered and comparing
+ * them would fail for a graph that is otherwise identical.
+ */
+struct GraphShape {
+    std::multiset<juce::String> nodeTypes;
+    std::multiset<juce::String> connections;
+
+    bool operator==(const GraphShape& other) const {
+        return nodeTypes == other.nodeTypes && connections == other.connections;
+    }
+};
+
+GraphShape captureShape(juce::AudioProcessorGraph& g) {
+    GraphShape shape;
+
+    for (auto* node : g.getNodes())
+        shape.nodeTypes.insert(node->getProcessor()->getName());
+
+    for (const auto& c : g.getConnections()) {
+        auto* src = g.getNodeForId(c.source.nodeID);
+        auto* dst = g.getNodeForId(c.destination.nodeID);
+        shape.connections.insert((src ? src->getProcessor()->getName() : juce::String("?")) + ":" +
+                                 juce::String(c.source.channelIndex) + "->" +
+                                 (dst ? dst->getProcessor()->getName() : juce::String("?")) + ":" +
+                                 juce::String(c.destination.channelIndex));
+    }
+
+    return shape;
+}
+
+/** Records the AI patch notifications, including their order, so undo/redo can be checked. */
+class RecordingListener : public AIIntegrationService::Listener {
+public:
+    int aboutToApplyCount = 0;
+    int appliedCount = 0;
+    std::vector<juce::String> events;
+
+    void aiPatchAboutToApply() override {
+        ++aboutToApplyCount;
+        events.push_back("aboutToApply");
+    }
+
+    void aiPatchApplied() override {
+        ++appliedCount;
+        events.push_back("applied");
+    }
+};
+
+// A full-replacement patch: two nodes with a distinct shape from the baseline below.
+constexpr const char* kReplacePatch = R"({"nodes":[{"id":10,"type":"Oscillator"},{"id":11,"type":"VCA"}],
+     "connections":[{"src":10,"srcPort":0,"dst":11,"dstPort":0}]})";
+
+class AIUndoTest : public ::testing::Test {
+protected:
+    juce::AudioProcessorGraph graph;
+    AppUndoManager undoManager;
+    std::unique_ptr<AIIntegrationService> service;
+
+    void SetUp() override {
+        graph.clear();
+        service = std::make_unique<AIIntegrationService>(graph, &undoManager);
+    }
+
+    /**
+     * Installs a known starting patch (Oscillator -> Filter) directly through the mapper rather
+     * than through the service, so the baseline itself never lands on the undo stack — every test
+     * then starts from an empty undo history with a non-empty graph.
+     */
+    void installBaselinePatch() {
+        auto json = juce::JSON::parse(R"({"nodes":[{"id":1,"type":"Oscillator"},{"id":2,"type":"Filter"}],
+             "connections":[{"src":1,"srcPort":0,"dst":2,"dstPort":0}]})");
+        ASSERT_TRUE(AIStateMapper::applyJSONToGraph(json, graph, true));
+        ASSERT_EQ(graph.getNumNodes(), 2);
+        ASSERT_FALSE(undoManager.canUndo());
+    }
+
+    /** Merge-mode patches address existing nodes by their live graph uid, not the baseline JSON id. */
+    int uidOfNodeNamed(const juce::String& name) const {
+        for (auto* node : graph.getNodes())
+            if (node->getProcessor()->getName() == name)
+                return (int)node->nodeID.uid;
+        return -1;
+    }
+};
+
+TEST_F(AIUndoTest, AiPatchIsUndoable) {
+    installBaselinePatch();
+    const auto before = captureShape(graph);
+
+    ASSERT_TRUE(service->applyPatch(kReplacePatch));
+    ASSERT_EQ(graph.getNumNodes(), 2);
+    EXPECT_FALSE(captureShape(graph) == before) << "patch should have changed the graph";
+
+    ASSERT_TRUE(undoManager.undo());
+
+    EXPECT_EQ(graph.getNumNodes(), 2);
+    EXPECT_TRUE(captureShape(graph) == before) << "undo must restore the exact pre-patch graph";
+}
+
+TEST_F(AIUndoTest, AiPatchIsRedoable) {
+    installBaselinePatch();
+
+    ASSERT_TRUE(service->applyPatch(kReplacePatch));
+    const auto patched = captureShape(graph);
+
+    ASSERT_TRUE(undoManager.undo());
+    ASSERT_FALSE(captureShape(graph) == patched);
+
+    ASSERT_TRUE(undoManager.redo());
+    EXPECT_TRUE(captureShape(graph) == patched) << "redo must restore the patched graph";
+}
+
+TEST_F(AIUndoTest, AiMergeIsUndoable) {
+    installBaselinePatch();
+    const auto before = captureShape(graph);
+
+    const int filterUid = uidOfNodeNamed("Filter");
+    ASSERT_NE(filterUid, -1);
+
+    // Merge mode (clearExisting == false): add a VCA fed by the existing Filter.
+    const juce::String mergePatch = juce::String(R"({"mode":"merge","nodes":[{"id":9001,"type":"VCA"}],)") +
+                                    R"("connections":[{"src":)" + juce::String(filterUid) +
+                                    R"(,"srcPort":0,"dst":9001,"dstPort":0}]})";
+
+    ASSERT_TRUE(service->applyPatch(mergePatch, /*mergeMode=*/true));
+    EXPECT_EQ(graph.getNumNodes(), 3);
+
+    ASSERT_TRUE(undoManager.undo());
+
+    EXPECT_EQ(graph.getNumNodes(), 2);
+    EXPECT_TRUE(captureShape(graph) == before) << "undo of a merge must restore the pre-merge graph";
+}
+
+TEST_F(AIUndoTest, ListenersFireOnUndo) {
+    installBaselinePatch();
+
+    RecordingListener listener;
+    service->addListener(&listener);
+
+    ASSERT_TRUE(service->applyPatch(kReplacePatch));
+    EXPECT_EQ(listener.aboutToApplyCount, 1);
+    EXPECT_EQ(listener.appliedCount, 1);
+
+    // The critical case: undo rebuilds the graph, so the graph editor must be told to drop its
+    // module components first and rebuild them afterwards — otherwise it keeps stale pointers
+    // into VisualBuffers that applyJSONToGraph has already freed.
+    listener.events.clear();
+    ASSERT_TRUE(undoManager.undo());
+
+    EXPECT_EQ(listener.aboutToApplyCount, 2);
+    EXPECT_EQ(listener.appliedCount, 2);
+    ASSERT_EQ(listener.events.size(), 2u);
+    EXPECT_EQ(listener.events[0], juce::String("aboutToApply"));
+    EXPECT_EQ(listener.events[1], juce::String("applied"));
+
+    // Redo rebuilds the graph the same way, so it must notify too.
+    listener.events.clear();
+    ASSERT_TRUE(undoManager.redo());
+
+    EXPECT_EQ(listener.aboutToApplyCount, 3);
+    EXPECT_EQ(listener.appliedCount, 3);
+    ASSERT_EQ(listener.events.size(), 2u);
+    EXPECT_EQ(listener.events[0], juce::String("aboutToApply"));
+    EXPECT_EQ(listener.events[1], juce::String("applied"));
+
+    service->removeListener(&listener);
+}
+
+TEST_F(AIUndoTest, FailedPatchPushesNothing) {
+    installBaselinePatch();
+    const auto before = captureShape(graph);
+
+    RecordingListener listener;
+    service->addListener(&listener);
+
+    EXPECT_FALSE(service->applyPatch("not json at all"));
+    EXPECT_FALSE(undoManager.canUndo()) << "an unparseable patch must not leave an undo entry";
+
+    EXPECT_FALSE(service->applyPatch(R"({"nodes":"not-an-array"})"));
+    EXPECT_FALSE(undoManager.canUndo()) << "a structurally invalid patch must not leave an undo entry";
+
+    EXPECT_FALSE(service->applyPatch(R"({"nodes":[{"id":1,"type":"NoSuchModule"}],"connections":[]})"));
+    EXPECT_FALSE(undoManager.canUndo()) << "an unknown node type must not leave an undo entry";
+
+    // The graph is untouched and no listener was told a patch was coming.
+    EXPECT_TRUE(captureShape(graph) == before);
+    EXPECT_EQ(listener.aboutToApplyCount, 0);
+    EXPECT_EQ(listener.appliedCount, 0);
+
+    service->removeListener(&listener);
+}
+
+/** Minimal provider so a MainComponent can be constructed headlessly. */
+class StubProvider : public AIProvider {
+public:
+    juce::String getProviderName() const override { return "Stub"; }
+    void fetchAvailableModels(std::function<void(const juce::StringArray&, bool)> callback) override {
+        callback({"stub-model"}, true);
+    }
+    void sendPrompt(const std::vector<Message>&, CompletionCallback callback, const juce::var&) override {
+        if (callback)
+            callback("Stub response.", true);
+    }
+    void setModel(const juce::String& name) override { model = name; }
+    juce::String getCurrentModel() const override { return model; }
+
+private:
+    juce::String model = "stub-model";
+};
+
+/**
+ * Guards the wiring itself: MainComponent must hand its AppUndoManager to the AI service, otherwise
+ * every test above still passes while Cmd+Z does nothing in the real app.
+ */
+TEST(AIUndoWiringTest, MainComponentRoutesAiPatchesThroughUndoManager) {
+    ::MainComponent mc(std::make_unique<StubProvider>());
+
+    auto& appUndo = mc.getUndoManager();
+    auto& svc = mc.getAiServiceForTest();
+
+    ASSERT_TRUE(svc.applyPatch(kReplacePatch));
+
+    EXPECT_TRUE(appUndo.canUndo()) << "MainComponent must route AI patches through its undo manager";
+    EXPECT_EQ(appUndo.getUndoManager().getUndoDescription(), juce::String("AI patch"))
+        << "the transaction should carry a human-readable name";
+}
+
+/**
+ * Headless stand-in for the manual "apply a patch, press Cmd+Z, check the editor still renders"
+ * check. Drives a real MainComponent through apply -> undo -> redo, pumping the message loop each
+ * time (MainComponent::aiPatchApplied defers updateComponents() via callAsync) and painting after
+ * every step. Catches the failure this task is really about: the editor keeping ModuleComponents
+ * that point into VisualBuffers the rebuilt graph has already freed.
+ */
+TEST(AIUndoWiringTest, EditorRebuildsAndRepaintsAcrossUndoAndRedo) {
+    ::MainComponent mc(std::make_unique<StubProvider>());
+    mc.setSize(1600, 900);
+
+    auto& appUndo = mc.getUndoManager();
+    auto& svc = mc.getAiServiceForTest();
+    auto& editor = mc.getGraphEditor();
+
+    // Let MainComponent settle any construction-time async work before the baseline snapshot.
+    juce::MessageManager::getInstance()->runDispatchLoopUntil(50);
+
+    const int baselineModules = editor.getModuleComponents().size();
+
+    auto pumpAndPaint = [&mc] {
+        juce::MessageManager::getInstance()->runDispatchLoopUntil(50);
+        juce::Image img(juce::Image::ARGB, 1600, 900, true);
+        juce::Graphics g(img);
+        EXPECT_NO_THROW(mc.paint(g));
+    };
+
+    // Apply: two modules (Oscillator + VCA).
+    ASSERT_TRUE(svc.applyPatch(kReplacePatch));
+    pumpAndPaint();
+    EXPECT_EQ(editor.getModuleComponents().size(), 2) << "editor should show the patched modules";
+
+    // Undo: the editor must drop the patched components and rebuild the pre-patch ones.
+    ASSERT_TRUE(appUndo.undo());
+    pumpAndPaint();
+    EXPECT_EQ(editor.getModuleComponents().size(), baselineModules)
+        << "undo must leave the editor showing the pre-patch modules, not stale ones";
+
+    // Redo: back to the patched state, still rendering.
+    ASSERT_TRUE(appUndo.redo());
+    pumpAndPaint();
+    EXPECT_EQ(editor.getModuleComponents().size(), 2) << "redo must restore the patched modules";
+}
+
+} // namespace
+} // namespace synth

--- a/Tests/AIUndoTests.cpp
+++ b/Tests/AIUndoTests.cpp
@@ -147,6 +147,65 @@ TEST_F(AIUndoTest, AiMergeIsUndoable) {
     EXPECT_TRUE(captureShape(graph) == before) << "undo of a merge must restore the pre-merge graph";
 }
 
+TEST_F(AIUndoTest, NodeIdsSurviveUndo) {
+    // Undo restores the graph by clearing and rebuilding it from a JSON snapshot. If that renumbers
+    // NodeIDs, anything holding an id across the undo (most importantly a merge-mode patch card, which
+    // addresses existing nodes by uid) silently stops resolving.
+    installBaselinePatch();
+
+    std::multiset<int> uidsBefore;
+    for (auto* n : graph.getNodes())
+        uidsBefore.insert((int)n->nodeID.uid);
+
+    ASSERT_TRUE(service->applyPatch(kReplacePatch));
+    ASSERT_TRUE(undoManager.undo());
+
+    std::multiset<int> uidsAfter;
+    for (auto* n : graph.getNodes())
+        uidsAfter.insert((int)n->nodeID.uid);
+
+    EXPECT_EQ(uidsBefore, uidsAfter) << "undo must restore node identity, not just node shape";
+}
+
+TEST_F(AIUndoTest, MergePatchCanBeReappliedAfterUndo) {
+    // Reported by hand-testing: Merge an AI addition, press Cmd+Z, then click Merge again on the same
+    // patch card -> nothing happens. The card's JSON references the pre-undo uid of an existing node.
+    installBaselinePatch();
+
+    const int filterUid = uidOfNodeNamed("Filter");
+    ASSERT_NE(filterUid, -1);
+
+    const juce::String mergePatch = juce::String(R"({"mode":"merge","nodes":[{"id":9001,"type":"VCA"}],)") +
+                                    R"("connections":[{"src":)" + juce::String(filterUid) +
+                                    R"(,"srcPort":0,"dst":9001,"dstPort":0}]})";
+
+    ASSERT_TRUE(service->applyPatch(mergePatch, /*mergeMode=*/true));
+    ASSERT_EQ(graph.getNumNodes(), 3);
+
+    ASSERT_TRUE(undoManager.undo());
+    ASSERT_EQ(graph.getNumNodes(), 2);
+
+    // Clicking Merge a second time on the very same card must still work.
+    EXPECT_TRUE(service->applyPatch(mergePatch, /*mergeMode=*/true))
+        << "re-applying a merge patch after undo must not silently fail";
+    EXPECT_EQ(graph.getNumNodes(), 3);
+}
+
+TEST_F(AIUndoTest, ReplacePatchCanBeAppliedAfterUndo) {
+    // A full-replacement patch carries self-contained ids, so it must apply after an undo regardless
+    // of how the restore renumbered the graph.
+    installBaselinePatch();
+
+    ASSERT_TRUE(service->applyPatch(kReplacePatch));
+    ASSERT_TRUE(undoManager.undo());
+
+    EXPECT_TRUE(service->applyPatch(
+        R"({"nodes":[{"id":20,"type":"Oscillator"},{"id":21,"type":"Filter"},{"id":22,"type":"VCA"}],
+            "connections":[{"src":20,"srcPort":0,"dst":21,"dstPort":0},{"src":21,"srcPort":0,"dst":22,"dstPort":0}]})"))
+        << "a fresh replace patch must apply after an undo";
+    EXPECT_EQ(graph.getNumNodes(), 3);
+}
+
 TEST_F(AIUndoTest, ListenersFireOnUndo) {
     installBaselinePatch();
 

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -32,6 +32,7 @@ add_executable(GravisynthTests
     PolyMidiModuleTests.cpp
     PolySequencerModuleTests.cpp
     AIIntegrationServiceTests.cpp
+    AIUndoTests.cpp
     ModMatrixTests.cpp
     FXModuleTests.cpp
     VoiceMixerModuleTests.cpp

--- a/docs/AI_Engine.md
+++ b/docs/AI_Engine.md
@@ -73,6 +73,39 @@ The AI communicates with Gravisynth using a simplified JSON schema to describe s
 -   **Context-Aware Responses**: By providing the AI with the current synthesizer state, it can generate more relevant and informed suggestions.
 -   **Model Management**: Users can select from various available AI models (e.g., different Ollama models) via the application's UI.
 -   **Extensible Provider System**: The `AIProvider` interface allows for easy integration of new AI backends in the future.
+-   **Undoable Patches**: Apply/Merge on a patch card is recorded on the app undo stack, so `Cmd+Z` restores the user's previous patch (see below).
+
+### AI Patch Undo/Redo Contract
+
+`AIIntegrationService::applyPatch()` routes through `AppUndoManager::recordAIPatch()` whenever an
+undo manager has been injected (`MainComponent::initialiseCommon()` calls
+`aiService.setUndoManager(&undoManager)`). The service holds a **non-owning, nullable** pointer —
+constructing an `AIIntegrationService` without one keeps the old direct-apply behaviour, which is
+what the standalone service tests do.
+
+The recorded action is the existing snapshot-based `SnapshotAction`, not a fine-grained diff:
+`graphToJSON(graph)` is captured before the patch and after it, undo restores the before-snapshot
+and redo re-applies the after-snapshot. Merge mode needs no special handling — the after-snapshot
+is the whole merged graph. Transactions are named `"AI patch"` / `"AI merge"`.
+
+Two invariants:
+
+1.  **Listener notifications must fire on undo and redo, not just the initial apply.**
+    `aiPatchAboutToApply` / `aiPatchApplied` are passed to the action as its `preRestore` /
+    `postRestore` hooks. Undo and redo rebuild the graph exactly the way the original apply did,
+    so skipping them would leave `GraphEditor` holding stale `ModuleComponent`s pointing at
+    `VisualBuffer`s that `applyJSONToGraph` has already freed — a use-after-free, not just a
+    stale render. Guarded by `AIUndoTest.ListenersFireOnUndo`.
+2.  **A rejected patch pushes nothing.** `applyPatch()` runs `validatePatch()` before touching any
+    listener or the undo stack, and `recordAIPatch()` returns without pushing if the mutation
+    reports failure, so an invalid patch leaves no no-op entry for `Cmd+Z` to consume. Guarded by
+    `AIUndoTest.FailedPatchPushesNothing`.
+
+Because the notifications are dispatched from the undoable action, they are wrapped in a
+`juce::WeakReference<AIIntegrationService>` — the action can outlive nothing in practice, but the
+weak ref keeps the ordering safe if the service is ever destroyed before the undo manager.
+
+Tests live in `Tests/AIUndoTests.cpp`.
 
 ## 5. AIChatComponent and Logging
 


### PR DESCRIPTION
## Problem

Clicking **Apply** or **Merge** on a patch card called `AIIntegrationService::applyPatch` → `AIStateMapper::applyJSONToGraph`, which mutated the `juce::AudioProcessorGraph` directly. `AppUndoManager` was never involved, so `Cmd+Z` could not recover the user's previous patch — the AI could irreversibly destroy work.

## Approach: snapshot, not fine-grained diff

`AIStateMapper` already round-trips the whole graph via `graphToJSON` / `applyJSONToGraph`, so this reuses the **existing** `SnapshotAction` in `AppUndoManager.cpp` rather than inventing a second mechanism:

- New `AppUndoManager::recordAIPatch()` captures `graphToJSON(graph)` before the change and after it; undo restores the before-snapshot, redo re-applies the after-snapshot.
- Merge mode (`clearExisting=false`) needs no special handling — the after-snapshot is the whole merged graph.
- Transactions are named `"AI patch"` / `"AI merge"`.

## The main hazard: listeners must fire on undo/redo

`aiPatchAboutToApply` / `aiPatchApplied` are passed to the action as its `preRestore` / `postRestore` hooks, so they fire on **undo and redo**, not just the initial apply. Undo rebuilds the graph exactly the way the original apply did — skipping the notifications would leave `GraphEditor` holding stale `ModuleComponent`s pointing at `VisualBuffer`s that `applyJSONToGraph` has already freed. That's a use-after-free, not just a stale render.

## Injection

`AIIntegrationService` takes a **nullable, non-owning** `AppUndoManager*` — a ctor parameter defaulted to `nullptr` plus a `setUndoManager()` setter — so existing tests that construct the service standalone keep compiling and keep the old direct-apply behaviour. `MainComponent::initialiseCommon()` wires it in. No global or singleton.

## Failed patches push nothing

`applyPatch()` runs `validatePatch()` before touching any listener or the undo stack, and `recordAIPatch()` returns without pushing if the mutation reports failure — an invalid patch leaves no no-op entry for `Cmd+Z` to consume.

## Tests

New `Tests/AIUndoTests.cpp` (registered in `Tests/CMakeLists.txt`). Graph comparison uses an ID-free structural fingerprint (node-type multiset + connections keyed by processor name/channel), since a snapshot restore renumbers `NodeID`s.

| Test | Verifies |
| --- | --- |
| `AiPatchIsUndoable` | apply → undo restores the exact pre-patch graph |
| `AiPatchIsRedoable` | undo → redo returns the patched state |
| `AiMergeIsUndoable` | same for merge mode (`clearExisting=false`) |
| `ListenersFireOnUndo` | listener sees `aboutToApply` + `applied`, in order, on undo **and** redo |
| `FailedPatchPushesNothing` | unparseable / malformed / unknown-node-type patches leave no undo entry |
| `MainComponentRoutesAiPatchesThroughUndoManager` | guards the wiring itself, and the transaction name |
| `EditorRebuildsAndRepaintsAcrossUndoAndRedo` | real `MainComponent` through apply → undo → redo, pumping the message loop and repainting each step |

**Verification:** all 640 tests pass; both `GravisynthTests` and the `Gravisynth` app target build clean; `clang-format` clean. A negative control (disabling the undo routing) fails 5 of the 6 new tests, confirming they aren't vacuous.

⚠️ **Not done:** the interactive hand-check in the running app (generate a patch against a live Ollama model, press `Cmd+Z`, eyeball the editor). That needs a GUI session and a running model, which this environment can't drive. `EditorRebuildsAndRepaintsAcrossUndoAndRedo` is the headless stand-in — it exercises the same rebuild-and-repaint path that check is looking at — but it is not a substitute for a human looking at the screen.

## Docs

`docs/AI_Engine.md` gains an "AI Patch Undo/Redo Contract" section covering both invariants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cmty7Zwi9Vcdzy1SjXoRE1