### PR TITLE
fix: heap-use-after-free when a mod-matrix row outlives its attenuverter

### DIFF
--- a/Source/UI/ModMatrixComponent.cpp
+++ b/Source/UI/ModMatrixComponent.cpp
@@ -236,6 +236,10 @@ ModMatrixComponent::ModRow::ModRow(ModMatrixComponent& o, juce::AudioProcessorGr
 
     // Attach to attenuverter params
     if (auto* node = owner.audioEngine.getGraph().getNodeForId(attenuverterId)) {
+        // Retain the node so the processor (and therefore the parameters the attachments below
+        // reference) cannot be freed out from under us while this row is still alive.
+        attenuverterNode = node;
+
         const auto& params = node->getProcessor()->getParameters();
         if (params.size() > 0) {
             if (auto* bParam = dynamic_cast<juce::AudioParameterBool*>(params[0])) {

--- a/Source/UI/ModMatrixComponent.h
+++ b/Source/UI/ModMatrixComponent.h
@@ -69,6 +69,15 @@ private:
         ModMatrixComponent& owner;
         juce::AudioProcessorGraph::NodeID attenuverterId;
 
+        // Keeps the attenuverter's processor alive for at least as long as this row holds parameter
+        // attachments into it. juce::ParameterAttachment's destructor unconditionally calls
+        // parameter.removeListener() on the reference it captured at construction, so the processor
+        // MUST outlive amountAttachment/bypassAttachment — including when the node has already been
+        // removed from the graph (removeModRouting) before updateRowsFromGraph() erases this row.
+        // Graph nodes are reference counted; removeNode() drops the node from the processing list
+        // immediately, and holding this Ptr only defers destruction of the object itself.
+        juce::AudioProcessorGraph::Node::Ptr attenuverterNode;
+
         juce::ComboBox sourceCombo;
         juce::ComboBox destCombo;
         juce::Slider amountSlider;

--- a/Tests/ModMatrixTests.cpp
+++ b/Tests/ModMatrixTests.cpp
@@ -535,6 +535,46 @@ TEST_F(ModMatrixTest, ModMatrixComponentPaintSmokeTest) {
     EXPECT_EQ(matrix.getHoveredRow(), -1);
 }
 
+TEST_F(ModMatrixTest, RowErasedAfterRoutingRemovedDoesNotTouchFreedProcessor) {
+    // Regression (heap-use-after-free): removeModRouting() removes the attenuverter node, then the
+    // next updateRowsFromGraph() erases the corresponding ModRow. ~ModRow resets its
+    // Slider/ButtonParameterAttachments, and juce::ParameterAttachment's destructor unconditionally
+    // calls parameter.removeListener() on the reference it captured at construction — so the
+    // attenuverter's processor must still be alive at that point. ModRow retains the node
+    // (Node::Ptr) to guarantee that.
+    //
+    // Without the fix this reads freed memory. That is invisible to a normal build, so this test
+    // passes either way here — it exists as the trigger for the ASAN job, which aborts on it.
+    ModMatrixComponent matrix(engine);
+
+    auto& graph = engine.getGraph();
+    graph.clear();
+
+    auto lfoNode = graph.addNode(std::make_unique<LFOModule>());
+    auto filterNode = graph.addNode(std::make_unique<FilterModule>());
+    ASSERT_NE(lfoNode, nullptr);
+    ASSERT_NE(filterNode, nullptr);
+
+    engine.addModRouting(lfoNode->nodeID, 0, filterNode->nodeID, 1);
+    engine.addModRouting(lfoNode->nodeID, 0, filterNode->nodeID, 2);
+
+    matrix.setBounds(0, 0, 600, 400);
+    matrix.updateRowsFromGraph();
+
+    // Drop both routings, freeing each attenuverter node from the graph...
+    auto routings = engine.getActiveModRoutings();
+    ASSERT_EQ(routings.size(), 2u);
+    for (const auto& r : routings)
+        engine.removeModRouting(r.attenuverterNodeID);
+
+    // ...then let the matrix erase the now-orphaned rows. This is the destruction path that
+    // previously touched a freed AudioProcessorParameter.
+    EXPECT_NO_THROW(matrix.updateRowsFromGraph());
+
+    EXPECT_TRUE(engine.getActiveModRoutings().empty());
+    EXPECT_EQ(matrix.getHoveredRow(), -1);
+}
+
 TEST_F(ModMatrixTest, HoverResetsAfterRowRemoval) {
     // Regression: when a row is erased and remaining rows shift indices, hoveredRow_
     // must be cleared so the wrong (now-shifted) row is not painted as hovered.


### PR DESCRIPTION
Found by AddressSanitizer while working on an unrelated PR (#133). **Pre-existing on `main`** — confirmed by reproducing the identical abort at `23fb112` with the change from #133 absent.

## The bug

`AudioEngine::removeModRouting()` removes the attenuverter node and frees its processor. The matching `ModMatrixComponent::ModRow` survives until the next `updateRowsFromGraph()`, and `~ModRow` resets its `Slider`/`ButtonParameterAttachment`s. `juce::ParameterAttachment::~ParameterAttachment()` unconditionally calls `parameter.removeListener(this)` on the reference it captured at construction — which by then points at freed memory.

```
ModMatrixComponent::updateRowsFromGraph()   ModMatrixComponent.cpp:131
  → ~ModRow → ModRow::detach()              ModMatrixComponent.cpp:316
  → ~SliderParameterAttachment
  → AudioProcessorParameter::removeListener()   ← reads freed memory
```

Worth noting `detach()` *already* guarded its manual listener loop behind a `getNodeForId()` lookup, so the hazard was known. But the attachments can't be guarded that way: the destructor runs regardless and there's no way to tell it its parameter is gone.

## The fix

Fix the **lifetime**, not the access. Graph nodes are reference-counted, so `ModRow` now retains a `Node::Ptr` to its attenuverter:

```cpp
juce::AudioProcessorGraph::Node::Ptr attenuverterNode;  // ModRow member
...
attenuverterNode = node;  // where the attachments are created
```

`removeNode()` still drops the node from the processing list immediately, so **audio behaviour is unchanged** — only destruction of the object is deferred until the row referencing its parameters goes away.

## Verification

- Full suite under ASAN: **634 tests, zero sanitizer findings** (`-fsanitize=address`, matching the CI job's flags).
- Before the fix, the same build aborted on `ModMatrixTest.HoverResetsAfterRowRemoval`.
- Full suite green in a normal build; clang-format clean.

## Tests

Adds `RowErasedAfterRoutingRemovedDoesNotTouchFreedProcessor`, exercising remove-routings-then-erase-rows directly rather than incidentally via the hover test.

⚠️ Be aware this test **passes with or without the fix in a normal build** — a use-after-free is silent unless a sanitizer is watching. It's a *trigger* for the ASAN job, not a standalone regression guard.

That raises a policy question worth your call: ASAN is gated behind the `run-asan` label, and from the CI history it appears not to have run before this. This class of bug is only caught when it runs. **This PR needs the `run-asan` label to be verified in CI** — I've deliberately not added it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cmty7Zwi9Vcdzy1SjXoRE1