### PR TITLE
refactor: widen AIProvider interface for hosted/authenticated backends

### DIFF
--- a/Source/AI/AIIntegrationService.cpp
+++ b/Source/AI/AIIntegrationService.cpp
@@ -32,23 +32,27 @@ void AIIntegrationService::sendMessage(const juce::String& text, AIProvider::Com
 
         provider->sendPrompt(
             request,
-            [weakThis, callback](const juce::String& response, bool success) {
+            [weakThis, callback](const AIProvider::AIResponse& response) {
                 if (weakThis.get() == nullptr)
                     return; // Service was destroyed
 
                 auto* self = weakThis.get();
-                if (success) {
-                    self->chatHistory.push_back({"assistant", response});
+                if (response.success) {
+                    self->chatHistory.push_back({"assistant", response.content});
                     self->trimHistory();
                 }
                 if (callback) {
-                    callback(response, success);
+                    callback(response);
                 }
             },
             schema);
     } else {
         if (callback) {
-            callback("Error: No AI provider selected.", false);
+            AIProvider::AIResponse response;
+            response.success = false;
+            response.error.kind = AIProvider::AIErrorKind::Schema; // no provider configured — client precondition
+            response.error.message = "Error: No AI provider selected.";
+            callback(response);
         }
     }
 }

--- a/Source/AI/AIProvider.h
+++ b/Source/AI/AIProvider.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <functional>
 #include <juce_core/juce_core.h>
 #include <vector>
@@ -8,7 +9,8 @@ namespace synth {
 
 /**
  * @class AIProvider
- * @brief Abstract interface for AI backends (Ollama, OpenAI, etc.)
+ * @brief Abstract interface for AI backends (local Ollama, hosted/authenticated/metered
+ *        services, etc.)
  */
 class AIProvider {
 public:
@@ -22,16 +24,59 @@ public:
         juce::String content;
     };
 
-    using CompletionCallback = std::function<void(const juce::String& response, bool success)>;
+    /**
+     * @brief Identifies a single sendPrompt() request, so a provider can be asked to cancel it.
+     */
+    struct RequestId {
+        uint64_t value = 0;
+
+        bool operator==(const RequestId& other) const { return value == other.value; }
+        bool operator!=(const RequestId& other) const { return value != other.value; }
+    };
+
+    /**
+     * @brief Categorizes why a request failed, so callers can react appropriately
+     *        (retry, prompt sign-in, show an upgrade path, etc.) instead of parsing error text.
+     */
+    enum class AIErrorKind { None, Network, Auth, Quota, RateLimit, Server, Schema, Cancelled, Timeout };
+
+    struct AIError {
+        AIErrorKind kind = AIErrorKind::None;
+        juce::String message;
+        int retryAfterSeconds = 0;
+        juce::String requestId;
+    };
+
+    /**
+     * @brief Single result payload delivered to a CompletionCallback.
+     */
+    struct AIResponse {
+        bool success = false;
+        juce::String content;
+        AIError error;
+        juce::String requestId;
+    };
+
+    using CompletionCallback = std::function<void(const AIResponse& response)>;
 
     /**
      * @brief Sends a prompt to the AI and calls the callback when the response is ready.
      * @param conversation The chat history
      * @param callback Callback for result
      * @param responseSchema Optional JSON schema for structured output
+     * @param onDelta Optional streaming callback, invoked with incremental content as it
+     *                arrives. Providers that cannot stream simply never call it.
+     * @return An id identifying this request, usable with cancel().
      */
-    virtual void sendPrompt(const std::vector<Message>& conversation, CompletionCallback callback,
-                            const juce::var& responseSchema = juce::var()) = 0;
+    virtual RequestId sendPrompt(const std::vector<Message>& conversation, CompletionCallback callback,
+                                 const juce::var& responseSchema = juce::var(),
+                                 std::function<void(const juce::String& delta)> onDelta = {}) = 0;
+
+    /**
+     * @brief Requests cancellation of a previously started sendPrompt(). Providers that cannot
+     *        cancel in-flight requests may implement this as a no-op.
+     */
+    virtual void cancel(RequestId requestId) = 0;
 
     /**
      * @brief Returns the name of the provider.
@@ -52,6 +97,12 @@ public:
      * @brief Fetches all available models from the provider.
      */
     virtual void fetchAvailableModels(std::function<void(const juce::StringArray& models, bool success)> callback) = 0;
+
+    /**
+     * @brief Sets the authentication token for hosted/authenticated backends. No-op by
+     *        default, so providers with no notion of auth (e.g. local Ollama) are unaffected.
+     */
+    virtual void setAuthToken(const juce::String&) {}
 };
 
 } // namespace synth

--- a/Source/AI/OllamaProvider.cpp
+++ b/Source/AI/OllamaProvider.cpp
@@ -16,6 +16,8 @@ constexpr int kWorkerHandoverTimeoutMs = 2000;
 const char* const kShuttingDownMessage = "Error: Request cancelled - the Ollama provider is shutting down.";
 } // namespace
 
+using AIErrorKind = OllamaProvider::AIErrorKind;
+
 // Default constructor implementation
 OllamaProvider::OllamaProvider(const juce::String& host)
     : Thread("OllamaProviderThread")
@@ -38,7 +40,7 @@ OllamaProvider::~OllamaProvider() {
 
     // Belt and braces: covers the case where no worker ever ran (so nothing retired)
     // and anything that slipped into the queue during teardown.
-    failAllPending(kShuttingDownMessage);
+    failAllPending(AIErrorKind::Cancelled, kShuttingDownMessage);
 
     // Join the discovery worker so it cannot touch our members after we are
     // destroyed (it captures `this`). With the short 4s connection timeout
@@ -50,15 +52,21 @@ OllamaProvider::~OllamaProvider() {
         discoveryThread.join();
 }
 
-void OllamaProvider::sendPrompt(const std::vector<Message>& conversation, CompletionCallback callback,
-                                const juce::var& responseSchema) {
-    const Request request{conversation, std::move(callback), responseSchema};
+OllamaProvider::RequestId OllamaProvider::sendPrompt(const std::vector<Message>& conversation,
+                                                     CompletionCallback callback, const juce::var& responseSchema,
+                                                     std::function<void(const juce::String&)> onDelta) {
+    // Streaming is not implemented for OllamaProvider: onDelta is accepted for interface
+    // compatibility but intentionally never invoked.
+    juce::ignoreUnused(onDelta);
 
+    Request request{RequestId{}, conversation, std::move(callback), responseSchema};
     bool rejected = false;
     bool mustStartWorker = false;
 
     {
         const juce::ScopedLock sl(queueLock);
+
+        request.id.value = nextRequestId++;
 
         if (isShuttingDown) {
             rejected = true;
@@ -87,21 +95,33 @@ void OllamaProvider::sendPrompt(const std::vector<Message>& conversation, Comple
         }
     }
 
+    const RequestId requestId = request.id;
+
     if (rejected) {
-        deliverResult(request, kShuttingDownMessage, false, /*forceSynchronous=*/true);
-        return;
+        deliverError(request, AIErrorKind::Cancelled, kShuttingDownMessage, /*retryAfterSeconds=*/0,
+                     /*forceSynchronous=*/true);
+        return requestId;
     }
 
     if (mustStartWorker && !ensureWorkerRunning()) {
         // No worker could take the queue. Failing loudly beats the UI waiting forever.
-        failAllPending("Error: Could not start the Ollama request worker thread.");
-        return;
+        failAllPending(AIErrorKind::Server, "Error: Could not start the Ollama request worker thread.");
+        return requestId;
     }
 
     // Wake a worker parked in run()'s wait(). Harmless if it is busy or just started:
     // the event is auto-reset and every loop iteration re-checks the queue under lock,
     // so a stale signal only costs one extra iteration and a wakeup is never lost.
     notify();
+
+    return requestId;
+}
+
+void OllamaProvider::cancel(RequestId requestId) {
+    // Not implemented: OllamaProvider cannot cancel an in-flight or queued request yet.
+    // Declared per the AIProvider interface so future providers can implement real
+    // cancellation without an interface change.
+    juce::ignoreUnused(requestId);
 }
 
 bool OllamaProvider::ensureWorkerRunning() {
@@ -126,7 +146,7 @@ bool OllamaProvider::ensureWorkerRunning() {
     return startThread();
 }
 
-void OllamaProvider::failAllPending(const juce::String& message) {
+void OllamaProvider::failAllPending(AIErrorKind kind, const juce::String& message) {
     std::vector<Request> stranded;
     bool deliverSynchronously = false;
 
@@ -143,23 +163,51 @@ void OllamaProvider::failAllPending(const juce::String& message) {
     }
 
     for (const auto& req : stranded)
-        deliverResult(req, message, false, deliverSynchronously);
+        deliverError(req, kind, message, /*retryAfterSeconds=*/0, deliverSynchronously);
 }
 
-void OllamaProvider::deliverResult(const Request& req, const juce::String& responseText, bool success,
-                                   bool forceSynchronous) {
+void OllamaProvider::deliverResult(const Request& req, const juce::String& responseText, bool forceSynchronous) {
     if (!req.callback)
         return;
 
+    AIResponse response;
+    response.success = true;
+    response.content = responseText;
+    response.requestId = juce::String(req.id.value);
+
     if (isTestMode || forceSynchronous) {
-        req.callback(responseText, success);
+        req.callback(response);
         return;
     }
 
     // Copy just the callback (not the whole conversation) and never `this`, so a
     // message already in flight cannot touch a destroyed provider.
     auto callback = req.callback;
-    juce::MessageManager::callAsync([callback, responseText, success]() { callback(responseText, success); });
+    juce::MessageManager::callAsync([callback, response]() { callback(response); });
+}
+
+void OllamaProvider::deliverError(const Request& req, AIErrorKind kind, const juce::String& message,
+                                  int retryAfterSeconds, bool forceSynchronous) {
+    if (!req.callback)
+        return;
+
+    AIResponse response;
+    response.success = false;
+    response.requestId = juce::String(req.id.value);
+    response.error.kind = kind;
+    response.error.message = message;
+    response.error.retryAfterSeconds = retryAfterSeconds;
+    response.error.requestId = response.requestId;
+
+    if (isTestMode || forceSynchronous) {
+        req.callback(response);
+        return;
+    }
+
+    // Copy just the callback (not the whole conversation) and never `this`, so a
+    // message already in flight cannot touch a destroyed provider.
+    auto callback = req.callback;
+    juce::MessageManager::callAsync([callback, response]() { callback(response); });
 }
 
 void OllamaProvider::setModel(const juce::String& name) { currentModel = name; }
@@ -295,23 +343,27 @@ void OllamaProvider::run() {
 
     // Retire: hand the queue back and fail anything still in it, atomically, so no
     // request can slip in behind us unnoticed.
-    failAllPending(kShuttingDownMessage);
+    failAllPending(AIErrorKind::Cancelled, kShuttingDownMessage);
 }
 
 void OllamaProvider::processRequest(const Request& req) {
-    // Delivers (responseText, success) through the same test-mode-aware channel used by
-    // every exit path below, so the fail-fast path and the network paths stay identical.
-    auto deliver = [this, &req](const juce::String& responseText, bool success) {
-        deliverResult(req, responseText, success, /*forceSynchronous=*/false);
+    // Delivers a success/error through the same test-mode-aware channel used by every
+    // exit path below, so the fail-fast path and the network paths stay identical.
+    auto deliverSuccess = [this, &req](const juce::String& responseText) {
+        deliverResult(req, responseText, /*forceSynchronous=*/false);
+    };
+    auto deliverErr = [this, &req](AIErrorKind kind, const juce::String& message, int retryAfterSeconds = 0) {
+        deliverError(req, kind, message, retryAfterSeconds, /*forceSynchronous=*/false);
     };
 
     // Fail fast: never hit the network with an empty model. Ollama rejects such requests
     // with HTTP 400 "model is required", which previously surfaced as a misleading
-    // "Could not connect to Ollama" error even when the server was reachable.
+    // "Could not connect to Ollama" error even when the server was reachable. This is a
+    // client-side precondition, so it maps to Schema rather than Network.
     if (currentModel.isEmpty()) {
-        deliver("Error: No Ollama model selected. Check that Ollama is running and that a model is available "
-                "(ollama list).",
-                false);
+        deliverErr(AIErrorKind::Schema,
+                   "Error: No Ollama model selected. Check that Ollama is running and that a model is available "
+                   "(ollama list).");
         return;
     }
 
@@ -336,37 +388,66 @@ void OllamaProvider::processRequest(const Request& req) {
 
     juce::String jsonString = juce::JSON::toString(juce::var(body.get()));
 
-    juce::String responseText;
-    bool success = false;
     int httpStatus = 0;
+    juce::StringPairArray responseHeaders;
 
-    if (auto stream = createStream(url.withPOSTData(jsonString),
-                                   juce::URL::InputStreamOptions(juce::URL::ParameterHandling::inPostData)
-                                       .withConnectionTimeoutMs(120000)
-                                       .withStatusCode(&httpStatus))) {
-        responseText = stream->readEntireStreamAsString();
-        // DBG("AI Chat Response (before JSON parse): [" + responseText + "]"); // Potentially expensive
+    auto stream = createStream(url.withPOSTData(jsonString),
+                               juce::URL::InputStreamOptions(juce::URL::ParameterHandling::inPostData)
+                                   .withConnectionTimeoutMs(120000)
+                                   .withStatusCode(&httpStatus)
+                                   .withResponseHeaders(&responseHeaders));
 
-        juce::var jsonResponse = juce::JSON::parse(responseText);
-        if (jsonResponse.isObject()) {
-            if (auto* obj = jsonResponse.getDynamicObject()) {
-                if (obj->hasProperty("message")) {
-                    auto msgObj = obj->getProperty("message");
-                    if (msgObj.getDynamicObject()) {
-                        responseText = msgObj.getDynamicObject()->getProperty("content").toString();
-                        success = true;
-                    }
+    // httpStatus is populated by the pointer above as soon as HTTP response headers are
+    // received, independent of whether createStream() went on to hand back a stream — so
+    // an explicit error status always takes priority over inspecting (or the absence of)
+    // a body.
+    if (httpStatus == 401 || httpStatus == 403) {
+        deliverErr(AIErrorKind::Auth, "Error: Ollama at " + ollamaHost +
+                                          " rejected the request as unauthorized (HTTP " + juce::String(httpStatus) +
+                                          ").");
+        return;
+    }
+
+    if (httpStatus == 429) {
+        int retryAfterSeconds = responseHeaders.getValue("Retry-After", "").getIntValue();
+        deliverErr(AIErrorKind::RateLimit, "Error: Ollama at " + ollamaHost + " rate-limited the request (HTTP 429).",
+                   retryAfterSeconds);
+        return;
+    }
+
+    if (httpStatus == 402) {
+        deliverErr(AIErrorKind::Quota, "Error: Ollama at " + ollamaHost + " reported insufficient quota (HTTP 402).");
+        return;
+    }
+
+    if (httpStatus != 0 && (httpStatus < 200 || httpStatus >= 300)) {
+        deliverErr(AIErrorKind::Server,
+                   "Error: Ollama at " + ollamaHost + " rejected the request (HTTP " + juce::String(httpStatus) + ").");
+        return;
+    }
+
+    if (stream == nullptr) {
+        deliverErr(AIErrorKind::Network, "Error: Could not connect to Ollama at " + ollamaHost);
+        return;
+    }
+
+    juce::String responseText = stream->readEntireStreamAsString();
+    // DBG("AI Chat Response (before JSON parse): [" + responseText + "]"); // Potentially expensive
+
+    juce::var jsonResponse = juce::JSON::parse(responseText);
+    if (jsonResponse.isObject()) {
+        if (auto* obj = jsonResponse.getDynamicObject()) {
+            if (obj->hasProperty("message")) {
+                auto msgObj = obj->getProperty("message");
+                if (msgObj.getDynamicObject()) {
+                    deliverSuccess(msgObj.getDynamicObject()->getProperty("content").toString());
+                    return;
                 }
             }
         }
-    } else if (httpStatus != 0) {
-        responseText =
-            "Error: Ollama at " + ollamaHost + " rejected the request (HTTP " + juce::String(httpStatus) + ").";
-    } else {
-        responseText = "Error: Could not connect to Ollama at " + ollamaHost;
     }
 
-    deliver(responseText, success);
+    deliverErr(AIErrorKind::Schema, "Error: Ollama at " + ollamaHost + " returned an unparseable response.");
 }
 
 } // namespace synth

--- a/Source/AI/OllamaProvider.h
+++ b/Source/AI/OllamaProvider.h
@@ -33,11 +33,18 @@ public:
     /** Queues a chat request for the worker thread.
 
         Contract: every accepted request eventually gets its callback invoked — either
-        with the model's answer, or with an error string. It is never silently dropped,
+        with the model's answer, or with a typed error. It is never silently dropped,
         including when it lands while the worker is shutting down or already gone.
+
+        Streaming is not implemented here: onDelta is accepted for interface compatibility
+        but never invoked.
     */
-    void sendPrompt(const std::vector<Message>& conversation, CompletionCallback callback,
-                    const juce::var& responseSchema = juce::var()) override;
+    RequestId sendPrompt(const std::vector<Message>& conversation, CompletionCallback callback,
+                         const juce::var& responseSchema = juce::var(),
+                         std::function<void(const juce::String& delta)> onDelta = {}) override;
+
+    /** Cancellation is not implemented for OllamaProvider yet; this is a declared no-op. */
+    void cancel(RequestId requestId) override;
 
     juce::String getProviderName() const override { return "Ollama"; }
 
@@ -61,10 +68,15 @@ private:
     std::atomic<bool> discoveryInFlight{false};
 
     struct Request {
+        RequestId id;
         std::vector<Message> conversation;
         AIProvider::CompletionCallback callback;
         juce::var responseSchema;
     };
+
+    // Monotonically increasing; only ever accessed from sendPrompt() callers, so a plain
+    // counter guarded by queueLock (taken for every sendPrompt() anyway) is sufficient.
+    uint64_t nextRequestId = 1; // guarded by queueLock
 
     juce::CriticalSection queueLock;
     std::vector<Request> pendingRequests;
@@ -95,14 +107,20 @@ private:
         worker could be started, in which case the caller MUST fail the queue. */
     bool ensureWorkerRunning();
 
-    /** Releases queue ownership (workerState = idle) and fails everything left in it,
-        both in one locked section so nothing can slip in unnoticed behind it. */
-    void failAllPending(const juce::String& message);
+    /** Releases queue ownership (workerState = idle) and fails everything left in it with
+        the given typed error, both in one locked section so nothing can slip in unnoticed
+        behind it. */
+    void failAllPending(AIErrorKind kind, const juce::String& message);
 
-    /** Single delivery channel for every result and error. `forceSynchronous` bypasses
+    /** Single delivery channel for every successful result. `forceSynchronous` bypasses
         MessageManager::callAsync for shutdown paths, where the message loop cannot be
         relied on to run the callback before this object is gone. */
-    void deliverResult(const Request& req, const juce::String& responseText, bool success, bool forceSynchronous);
+    void deliverResult(const Request& req, const juce::String& responseText, bool forceSynchronous);
+
+    /** Single delivery channel for every error. Same `forceSynchronous` contract as
+        deliverResult(). */
+    void deliverError(const Request& req, AIErrorKind kind, const juce::String& message, int retryAfterSeconds,
+                      bool forceSynchronous);
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(OllamaProvider)
 };

--- a/Source/UI/AIChatComponent.cpp
+++ b/Source/UI/AIChatComponent.cpp
@@ -406,9 +406,9 @@ void AIChatComponent::sendButtonClicked() {
 
     aiService.sendMessage(
         text,
-        [this, useStructuredOutput](const juce::String& response, bool success) {
+        [this, useStructuredOutput](const AIProvider::AIResponse& aiResponse) {
             juce::Component::SafePointer<AIChatComponent> safeThis(this);
-            juce::MessageManager::callAsync([safeThis, response, success, useStructuredOutput]() {
+            juce::MessageManager::callAsync([safeThis, aiResponse, useStructuredOutput]() {
                 if (safeThis.getComponent() == nullptr)
                     return;
                 auto* self = safeThis.getComponent();
@@ -419,7 +419,8 @@ void AIChatComponent::sendButtonClicked() {
 
                 self->cancelRequest(); // stops timer, spinner, cancel btn, restores input
 
-                if (success) {
+                if (aiResponse.success) {
+                    const juce::String& response = aiResponse.content;
                     juce::String json;
                     juce::String cleanText = response;
 
@@ -447,7 +448,7 @@ void AIChatComponent::sendButtonClicked() {
 
                     self->messages.push_back({"assistant", cleanText.trim(), json});
                 } else {
-                    self->messages.push_back({"assistant", "Error: " + response, ""});
+                    self->messages.push_back({"assistant", "Error: " + aiResponse.error.message, ""});
                 }
 
                 self->updateChatDisplay();

--- a/Tests/AIChatComponentTests.cpp
+++ b/Tests/AIChatComponentTests.cpp
@@ -14,10 +14,18 @@ public:
         callback({"MockModel1", "MockModel2"}, true);
     }
 
-    void sendPrompt(const std::vector<synth::AIProvider::Message>& conversation, CompletionCallback callback,
-                    const juce::var& responseSchema = juce::var()) override {
-        callback("Mock response text.", true);
+    RequestId sendPrompt(const std::vector<synth::AIProvider::Message>& conversation, CompletionCallback callback,
+                         const juce::var& responseSchema = juce::var(),
+                         std::function<void(const juce::String&)> onDelta = {}) override {
+        juce::ignoreUnused(conversation, responseSchema, onDelta);
+        AIResponse response;
+        response.success = true;
+        response.content = "Mock response text.";
+        callback(response);
+        return {};
     }
+
+    void cancel(RequestId) override {}
 
     void setModel(const juce::String& name) override { currentModel = name; }
     juce::String getCurrentModel() const override { return currentModel; }

--- a/Tests/AIIntegrationServiceTests.cpp
+++ b/Tests/AIIntegrationServiceTests.cpp
@@ -6,16 +6,26 @@ namespace synth {
 
 class MockAIProvider : public AIProvider {
 public:
-    void sendPrompt(const std::vector<Message>& conversation, CompletionCallback callback,
-                    const juce::var& responseSchema) override {
-        juce::ignoreUnused(responseSchema);
+    RequestId sendPrompt(const std::vector<Message>& conversation, CompletionCallback callback,
+                         const juce::var& responseSchema,
+                         std::function<void(const juce::String&)> onDelta = {}) override {
+        juce::ignoreUnused(responseSchema, onDelta);
         lastConversation = conversation;
+        AIResponse response;
         if (shouldFail) {
-            callback("Error", false);
+            response.success = false;
+            response.error.kind = AIErrorKind::Server;
+            response.error.message = "Error";
         } else {
-            callback(mockResponse, true);
+            response.success = true;
+            response.content = mockResponse;
         }
+        if (callback)
+            callback(response);
+        return {};
     }
+
+    void cancel(RequestId) override {}
 
     void fetchAvailableModels(std::function<void(const juce::StringArray&, bool)> callback) override {
         if (shouldFail)
@@ -79,7 +89,7 @@ TEST_F(AIIntegrationServiceTest, SendMessageAddsToHistory) {
     rawProvider->mockResponse = "AI Response";
 
     bool called = false;
-    service->sendMessage("User msg", [&](const juce::String&, bool) { called = true; });
+    service->sendMessage("User msg", [&](const AIProvider::AIResponse&) { called = true; });
 
     EXPECT_TRUE(called);
     // History should have: system, user, assistant
@@ -162,7 +172,7 @@ TEST_F(AIIntegrationServiceTest, HistoryDoesNotRetainPatchContext) {
     service->setProvider(std::move(provider));
 
     bool called = false;
-    service->sendMessage("Add a filter", [&](const juce::String&, bool) { called = true; }, true);
+    service->sendMessage("Add a filter", [&](const AIProvider::AIResponse&) { called = true; }, true);
 
     EXPECT_TRUE(called);
     auto history = service->getHistory();

--- a/Tests/AIProviderRegistryTests.cpp
+++ b/Tests/AIProviderRegistryTests.cpp
@@ -13,10 +13,14 @@ public:
     void fetchAvailableModels(std::function<void(const juce::StringArray&, bool)> callback) override {
         callback({}, true);
     }
-    void sendPrompt(const std::vector<synth::AIProvider::Message>&, CompletionCallback callback,
-                    const juce::var& = juce::var()) override {
-        callback("", true);
+    RequestId sendPrompt(const std::vector<synth::AIProvider::Message>&, CompletionCallback callback,
+                         const juce::var& = juce::var(), std::function<void(const juce::String&)> = {}) override {
+        AIResponse response;
+        response.success = true;
+        callback(response);
+        return {};
     }
+    void cancel(RequestId) override {}
     void setModel(const juce::String&) override {}
     juce::String getCurrentModel() const override { return {}; }
 

--- a/Tests/AIUndoTests.cpp
+++ b/Tests/AIUndoTests.cpp
@@ -272,10 +272,17 @@ public:
     void fetchAvailableModels(std::function<void(const juce::StringArray&, bool)> callback) override {
         callback({"stub-model"}, true);
     }
-    void sendPrompt(const std::vector<Message>&, CompletionCallback callback, const juce::var&) override {
-        if (callback)
-            callback("Stub response.", true);
+    RequestId sendPrompt(const std::vector<Message>&, CompletionCallback callback, const juce::var&,
+                         std::function<void(const juce::String&)> = {}) override {
+        if (callback) {
+            AIResponse response;
+            response.success = true;
+            response.content = "Stub response.";
+            callback(response);
+        }
+        return {};
     }
+    void cancel(RequestId) override {}
     void setModel(const juce::String& name) override { model = name; }
     juce::String getCurrentModel() const override { return model; }
 

--- a/Tests/E2EWorkflowTests.cpp
+++ b/Tests/E2EWorkflowTests.cpp
@@ -35,9 +35,15 @@ public:
     void fetchAvailableModels(std::function<void(const juce::StringArray&, bool)> callback) override {
         callback({"MockModel"}, true);
     }
-    void sendPrompt(const std::vector<Message>&, CompletionCallback callback, const juce::var&) override {
-        callback("Mock response.", true);
+    RequestId sendPrompt(const std::vector<Message>&, CompletionCallback callback, const juce::var&,
+                         std::function<void(const juce::String&)> = {}) override {
+        AIResponse response;
+        response.success = true;
+        response.content = "Mock response.";
+        callback(response);
+        return {};
     }
+    void cancel(RequestId) override {}
     void setModel(const juce::String& name) override { model = name; }
     juce::String getCurrentModel() const override { return model; }
 

--- a/Tests/MainComponentTests.cpp
+++ b/Tests/MainComponentTests.cpp
@@ -11,9 +11,15 @@ public:
     void fetchAvailableModels(std::function<void(const juce::StringArray&, bool)> callback) override {
         callback({"MockModel"}, true);
     }
-    void sendPrompt(const std::vector<Message>&, CompletionCallback callback, const juce::var&) override {
-        callback("Mock response.", true);
+    RequestId sendPrompt(const std::vector<Message>&, CompletionCallback callback, const juce::var&,
+                         std::function<void(const juce::String&)> = {}) override {
+        AIResponse response;
+        response.success = true;
+        response.content = "Mock response.";
+        callback(response);
+        return {};
     }
+    void cancel(RequestId) override {}
     void setModel(const juce::String& name) override { model = name; }
     juce::String getCurrentModel() const override { return model; }
 
@@ -30,10 +36,13 @@ public:
         ++fetchCallCount;
         callback({"mock-model-a", "mock-model-b"}, true);
     }
-    void sendPrompt(const std::vector<Message>&, CompletionCallback callback, const juce::var&) override {
+    RequestId sendPrompt(const std::vector<Message>&, CompletionCallback callback, const juce::var&,
+                         std::function<void(const juce::String&)> = {}) override {
         if (callback)
-            callback("Mock response.", true);
+            callback(AIResponse{true, "Mock response.", {}, {}});
+        return {};
     }
+    void cancel(RequestId) override {}
     void setModel(const juce::String& name) override { model = name; }
     juce::String getCurrentModel() const override { return model; }
 

--- a/Tests/OllamaProviderTests.cpp
+++ b/Tests/OllamaProviderTests.cpp
@@ -16,10 +16,15 @@ struct MockCompletionCallback {
         promise.set_value({models.joinIntoString("|"), success});
     }
 
-    // Operator for sendPrompt (String)
-    void operator()(const juce::String& response, bool success) { promise.set_value({response, success}); }
-
     std::pair<juce::String, bool> getResult() { return promise.get_future().get(); }
+};
+
+struct MockPromptCallback {
+    std::promise<synth::AIProvider::AIResponse> promise;
+
+    void operator()(const synth::AIProvider::AIResponse& response) { promise.set_value(response); }
+
+    synth::AIProvider::AIResponse getResult() { return promise.get_future().get(); }
 };
 
 // Mock InputStream for testing network failures/successes
@@ -293,14 +298,14 @@ TEST_F(OllamaProviderTest, SendPromptSuccessWithMock) {
     mockProviderSuccessfulChat.setModel("mock-model:latest");
 
     std::vector<synth::AIProvider::Message> conversation = {{"user", "Hello AI"}};
-    MockCompletionCallback callback;
+    MockPromptCallback callback;
     mockProviderSuccessfulChat.sendPrompt(
-        conversation, [&callback](const juce::String& response, bool success) { callback(response, success); });
+        conversation, [&callback](const synth::AIProvider::AIResponse& response) { callback(response); });
 
     auto result = callback.getResult();
-    ASSERT_TRUE(std::get<1>(result));            // Should be successful
-    ASSERT_FALSE(std::get<0>(result).isEmpty()); // Response should not be empty
-    ASSERT_TRUE(std::get<0>(result).contains("Mocked AI response."));
+    ASSERT_TRUE(result.success);
+    ASSERT_FALSE(result.content.isEmpty());
+    ASSERT_TRUE(result.content.contains("Mocked AI response."));
 }
 
 // A stream whose read() blocks for ~300ms to simulate a slow/unreachable Ollama
@@ -392,15 +397,15 @@ TEST_F(OllamaProviderTest, SendPromptWithNoModelFailsWithoutHittingNetwork) {
     // Deliberately do NOT call setModel() — currentModel stays empty.
 
     std::vector<synth::AIProvider::Message> conversation = {{"user", "Hello AI"}};
-    MockCompletionCallback callback;
+    MockPromptCallback callback;
     provider.sendPrompt(conversation,
-                        [&callback](const juce::String& response, bool success) { callback(response, success); });
+                        [&callback](const synth::AIProvider::AIResponse& response) { callback(response); });
 
     auto result = callback.getResult();
     provider.stopThread(5000);
 
-    ASSERT_FALSE(std::get<1>(result)); // success == false
-    EXPECT_TRUE(std::get<0>(result).containsIgnoreCase("model"));
+    ASSERT_FALSE(result.success);
+    EXPECT_TRUE(result.error.message.containsIgnoreCase("model"));
     EXPECT_FALSE(networkFactoryInvoked) << "sendPrompt() must not hit the network when no model is selected";
 }
 
@@ -424,14 +429,14 @@ TEST_F(OllamaProviderTest, SendPromptIncludesSelectedModelInRequestBody) {
     provider.setModel("mock-model:latest");
 
     std::vector<synth::AIProvider::Message> conversation = {{"user", "Hello AI"}};
-    MockCompletionCallback callback;
+    MockPromptCallback callback;
     provider.sendPrompt(conversation,
-                        [&callback](const juce::String& response, bool success) { callback(response, success); });
+                        [&callback](const synth::AIProvider::AIResponse& response) { callback(response); });
 
     auto result = callback.getResult();
     provider.stopThread(5000);
 
-    ASSERT_TRUE(std::get<1>(result)); // success == true
+    ASSERT_TRUE(result.success);
 
     juce::var parsedBody = juce::JSON::parse(capturedPostData);
     ASSERT_TRUE(parsedBody.isObject());
@@ -460,10 +465,11 @@ TEST_F(OllamaProviderTest, QueuedRequestDuringThreadShutdownStillCompletes) {
         provider.setTestMode(true);
         provider.setModel("mock-model:latest");
 
-        provider.sendPrompt(conversation, [](const juce::String&, bool) {});
+        provider.sendPrompt(conversation, [](const synth::AIProvider::AIResponse&) {});
         ASSERT_TRUE(workerEntered->waitFor(kCallbackTimeout)) << "the worker never started the first request";
 
-        provider.sendPrompt(conversation, [queuedBehind](const juce::String&, bool) { queuedBehind->fire(); });
+        provider.sendPrompt(conversation,
+                            [queuedBehind](const synth::AIProvider::AIResponse&) { queuedBehind->fire(); });
 
         provider.stopThread(5000);
 
@@ -487,7 +493,7 @@ TEST_F(OllamaProviderTest, QueuedRequestDuringThreadShutdownStillCompletes) {
             // The drain callback is delivered on the worker thread from inside
             // processRequest(), i.e. just before the worker looks at the queue again.
             auto drained = std::make_shared<CallbackLatch>();
-            provider.sendPrompt(conversation, [drained](const juce::String&, bool) { drained->fire(); });
+            provider.sendPrompt(conversation, [drained](const synth::AIProvider::AIResponse&) { drained->fire(); });
             ASSERT_TRUE(drained->waitFor(kCallbackTimeout))
                 << "attempt " << attempt << ": first request never completed";
 
@@ -498,7 +504,7 @@ TEST_F(OllamaProviderTest, QueuedRequestDuringThreadShutdownStillCompletes) {
             }
 
             auto raced = std::make_shared<CallbackLatch>();
-            provider.sendPrompt(conversation, [raced](const juce::String&, bool) { raced->fire(); });
+            provider.sendPrompt(conversation, [raced](const synth::AIProvider::AIResponse&) { raced->fire(); });
             ASSERT_TRUE(raced->waitFor(kCallbackTimeout))
                 << "attempt " << attempt
                 << ": a request enqueued while the worker was winding down never got a callback";
@@ -508,7 +514,8 @@ TEST_F(OllamaProviderTest, QueuedRequestDuringThreadShutdownStillCompletes) {
             provider.stopThread(5000);
 
             auto afterShutdown = std::make_shared<CallbackLatch>();
-            provider.sendPrompt(conversation, [afterShutdown](const juce::String&, bool) { afterShutdown->fire(); });
+            provider.sendPrompt(conversation,
+                                [afterShutdown](const synth::AIProvider::AIResponse&) { afterShutdown->fire(); });
             ASSERT_TRUE(afterShutdown->waitFor(kCallbackTimeout))
                 << "attempt " << attempt << ": a request enqueued right after stopThread() never got a callback";
         }
@@ -541,12 +548,13 @@ TEST_F(OllamaProviderTest, PendingRequestsAreFailedOnDestruction) {
         provider.setModel("mock-model:latest");
 
         // Pin the worker inside the first request's stream read.
-        provider.sendPrompt(conversation, [inFlight](const juce::String&, bool) { inFlight->fire(); });
+        provider.sendPrompt(conversation, [inFlight](const synth::AIProvider::AIResponse&) { inFlight->fire(); });
         ASSERT_TRUE(workerEntered->waitFor(kCallbackTimeout)) << "the worker never started the first request";
 
         // These two are still queued, unstarted, when the provider goes away.
-        provider.sendPrompt(conversation, [queuedFirst](const juce::String&, bool) { queuedFirst->fire(); });
-        provider.sendPrompt(conversation, [queuedSecond](const juce::String&, bool) { queuedSecond->fire(); });
+        provider.sendPrompt(conversation, [queuedFirst](const synth::AIProvider::AIResponse&) { queuedFirst->fire(); });
+        provider.sendPrompt(conversation,
+                            [queuedSecond](const synth::AIProvider::AIResponse&) { queuedSecond->fire(); });
     } // ~OllamaProvider(): stops the worker and fails whatever is left in the queue
 
     // Checked without waiting: by the time the destructor has returned, every callback
@@ -563,14 +571,148 @@ TEST_F(OllamaProviderTest, SendPromptTimeoutFails) {
     mockProviderSlowStream.setModel("mock-model:latest");
 
     std::vector<synth::AIProvider::Message> conversation = {{"user", "Simulate timeout"}};
-    MockCompletionCallback callback;
+    MockPromptCallback callback;
     mockProviderSlowStream.sendPrompt(
-        conversation, [&callback](const juce::String& response, bool success) { callback(response, success); });
+        conversation, [&callback](const synth::AIProvider::AIResponse& response) { callback(response); });
 
     auto result = callback.getResult();
     mockProviderSlowStream.stopThread(5000);
-    ASSERT_FALSE(std::get<1>(result)); // Should be unsuccessful
-    // The response text on timeout is "Error: Could not connect to Ollama at "
-    // So we can check for that string or a part of it.
-    ASSERT_TRUE(std::get<0>(result).isEmpty()); // The response text should be empty string on timeout
+    ASSERT_FALSE(result.success);
+    ASSERT_TRUE(result.content.isEmpty());
+}
+
+// REGRESSION LOCK: httpStatus 401/403 must map to AIErrorKind::Auth so the UI can
+// distinguish "sign in again" from other failure modes.
+TEST_F(OllamaProviderTest, MapsUnauthorizedToAuthError) {
+    auto factory = [](const juce::URL&,
+                      const juce::URL::InputStreamOptions& options) -> std::unique_ptr<juce::InputStream> {
+        if (auto* statusCode = options.getStatusCode())
+            *statusCode = 401;
+        return nullptr;
+    };
+
+    synth::OllamaProvider provider{"http://mock-host:11434", factory};
+    provider.setTestMode(true);
+    provider.setModel("mock-model:latest");
+
+    std::vector<synth::AIProvider::Message> conversation = {{"user", "Hello AI"}};
+    MockPromptCallback callback;
+    provider.sendPrompt(conversation,
+                        [&callback](const synth::AIProvider::AIResponse& response) { callback(response); });
+
+    auto result = callback.getResult();
+    provider.stopThread(5000);
+
+    EXPECT_FALSE(result.success);
+    EXPECT_EQ(result.error.kind, synth::AIProvider::AIErrorKind::Auth);
+}
+
+// REGRESSION LOCK: httpStatus 429 must map to AIErrorKind::RateLimit and parse a
+// Retry-After header when the server provides one.
+TEST_F(OllamaProviderTest, MapsTooManyRequestsToRateLimit) {
+    auto factory = [](const juce::URL&,
+                      const juce::URL::InputStreamOptions& options) -> std::unique_ptr<juce::InputStream> {
+        if (auto* statusCode = options.getStatusCode())
+            *statusCode = 429;
+        if (auto* headers = options.getResponseHeaders())
+            headers->set("Retry-After", "30");
+        return nullptr;
+    };
+
+    synth::OllamaProvider provider{"http://mock-host:11434", factory};
+    provider.setTestMode(true);
+    provider.setModel("mock-model:latest");
+
+    std::vector<synth::AIProvider::Message> conversation = {{"user", "Hello AI"}};
+    MockPromptCallback callback;
+    provider.sendPrompt(conversation,
+                        [&callback](const synth::AIProvider::AIResponse& response) { callback(response); });
+
+    auto result = callback.getResult();
+    provider.stopThread(5000);
+
+    EXPECT_FALSE(result.success);
+    EXPECT_EQ(result.error.kind, synth::AIProvider::AIErrorKind::RateLimit);
+    EXPECT_EQ(result.error.retryAfterSeconds, 30);
+}
+
+// REGRESSION LOCK: a genuine connection failure (no HTTP response at all) must map to
+// AIErrorKind::Network, distinct from an authenticated-but-rejected request.
+TEST_F(OllamaProviderTest, MapsConnectionFailureToNetwork) {
+    mockProviderFailingStreams.setModel("mock-model:latest");
+
+    std::vector<synth::AIProvider::Message> conversation = {{"user", "Hello AI"}};
+    MockPromptCallback callback;
+    mockProviderFailingStreams.sendPrompt(
+        conversation, [&callback](const synth::AIProvider::AIResponse& response) { callback(response); });
+
+    auto result = callback.getResult();
+
+    EXPECT_FALSE(result.success);
+    EXPECT_EQ(result.error.kind, synth::AIProvider::AIErrorKind::Network);
+}
+
+// REGRESSION LOCK: a 2xx response whose body is not the expected {message:{content:...}}
+// shape must map to AIErrorKind::Schema rather than silently reporting a generic failure.
+TEST_F(OllamaProviderTest, MapsUnparseableBodyToSchema) {
+    auto factory = [](const juce::URL&, const juce::URL::InputStreamOptions&) -> std::unique_ptr<juce::InputStream> {
+        return std::make_unique<MockInputStream>("not json at all", false);
+    };
+
+    synth::OllamaProvider provider{"http://mock-host:11434", factory};
+    provider.setTestMode(true);
+    provider.setModel("mock-model:latest");
+
+    std::vector<synth::AIProvider::Message> conversation = {{"user", "Hello AI"}};
+    MockPromptCallback callback;
+    provider.sendPrompt(conversation,
+                        [&callback](const synth::AIProvider::AIResponse& response) { callback(response); });
+
+    auto result = callback.getResult();
+    provider.stopThread(5000);
+
+    EXPECT_FALSE(result.success);
+    EXPECT_EQ(result.error.kind, synth::AIProvider::AIErrorKind::Schema);
+}
+
+// REGRESSION LOCK: a successful response must carry AIErrorKind::None, so callers can
+// treat "no error" as a first-class, checkable value rather than inferring it from success.
+TEST_F(OllamaProviderTest, SuccessfulResponseHasNoneErrorKind) {
+    mockProviderSuccessfulChat.setModel("mock-model:latest");
+
+    std::vector<synth::AIProvider::Message> conversation = {{"user", "Hello AI"}};
+    MockPromptCallback callback;
+    mockProviderSuccessfulChat.sendPrompt(
+        conversation, [&callback](const synth::AIProvider::AIResponse& response) { callback(response); });
+
+    auto result = callback.getResult();
+
+    EXPECT_TRUE(result.success);
+    EXPECT_EQ(result.error.kind, synth::AIProvider::AIErrorKind::None);
+}
+
+// REGRESSION LOCK: every response — success or failure — must carry the requestId of the
+// request it answers, so a caller juggling multiple in-flight requests can match them up.
+TEST_F(OllamaProviderTest, EveryResponseCarriesRequestId) {
+    mockProviderSuccessfulChat.setModel("mock-model:latest");
+    mockProviderFailingStreams.setModel("mock-model:latest");
+
+    std::vector<synth::AIProvider::Message> conversation = {{"user", "Hello AI"}};
+
+    MockPromptCallback successCallback;
+    auto successId = mockProviderSuccessfulChat.sendPrompt(
+        conversation, [&successCallback](const synth::AIProvider::AIResponse& response) { successCallback(response); });
+    auto successResult = successCallback.getResult();
+
+    MockPromptCallback failureCallback;
+    auto failureId = mockProviderFailingStreams.sendPrompt(
+        conversation, [&failureCallback](const synth::AIProvider::AIResponse& response) { failureCallback(response); });
+    auto failureResult = failureCallback.getResult();
+
+    EXPECT_FALSE(successResult.requestId.isEmpty());
+    EXPECT_EQ(successResult.requestId, juce::String(successId.value));
+
+    EXPECT_FALSE(failureResult.requestId.isEmpty());
+    EXPECT_EQ(failureResult.requestId, juce::String(failureId.value));
+    EXPECT_EQ(failureResult.error.requestId, failureResult.requestId);
 }

--- a/Tests/PanelAnimationAndLoadingTests.cpp
+++ b/Tests/PanelAnimationAndLoadingTests.cpp
@@ -27,10 +27,13 @@ public:
     void fetchAvailableModels(std::function<void(const juce::StringArray&, bool)> callback) override {
         callback({"MockModel"}, true);
     }
-    void sendPrompt(const std::vector<Message>&, CompletionCallback callback, const juce::var&) override {
+    RequestId sendPrompt(const std::vector<Message>&, CompletionCallback callback, const juce::var&,
+                         std::function<void(const juce::String&)> = {}) override {
         // Intentionally never completes so we can test the cancel path.
         juce::ignoreUnused(callback);
+        return {};
     }
+    void cancel(RequestId) override {}
     void setModel(const juce::String& name) override { model = name; }
     juce::String getCurrentModel() const override { return model; }
 

--- a/Tests/SettingsWindowTests.cpp
+++ b/Tests/SettingsWindowTests.cpp
@@ -17,10 +17,16 @@ public:
         callback({"MockModel1", "MockModel2"}, true);
     }
 
-    void sendPrompt(const std::vector<synth::AIProvider::Message>&, CompletionCallback callback,
-                    const juce::var& = juce::var()) override {
-        callback("Mock response", true);
+    RequestId sendPrompt(const std::vector<synth::AIProvider::Message>&, CompletionCallback callback,
+                         const juce::var& = juce::var(), std::function<void(const juce::String&)> = {}) override {
+        AIResponse response;
+        response.success = true;
+        response.content = "Mock response";
+        callback(response);
+        return {};
     }
+
+    void cancel(RequestId) override {}
 
     void setModel(const juce::String& name) override { currentModel = name; }
     juce::String getCurrentModel() const override { return currentModel; }


### PR DESCRIPTION
## Summary
- Replace the `(String, bool)` callback payload with a typed `AIResponse`/`AIError` (`AIErrorKind`: Network, Auth, Quota, RateLimit, Server, Schema, Cancelled, Timeout), so the UI can eventually distinguish "out of quota" (upgrade) from "offline" (retry) from "token expired" (sign-in) instead of parsing error text.
- `sendPrompt` now returns a `RequestId` (struct wrapping a `uint64_t`) and the interface gains a declared (but currently unimplemented) `cancel(RequestId)`, an optional `onDelta` streaming callback (accepted, never invoked by OllamaProvider), and a default no-op `setAuthToken()` for providers with no notion of auth.
- `OllamaProvider` maps its HTTP failure paths onto the new typed errors: 401/403 → Auth, 429 → RateLimit (parses `Retry-After`), 402 → Quota, other non-2xx → Server, no response → Network, empty-model precondition / unparseable body → Schema.
- `AIIntegrationService::sendMessage` and `AIChatComponent`'s response handler are updated to the new callback shape; UI presentation is unchanged (same "Error: ..." message format).
- All mock `AIProvider` implementations across the test suite (`AIIntegrationServiceTests`, `MainComponentTests`, `AIChatComponentTests`, `PanelAnimationAndLoadingTests`, `E2EWorkflowTests`, `AIProviderRegistryTests`, `SettingsWindowTests`) are updated to the new signature.

This is interface-widening only — cancellation and streaming are declared but not implemented (follow-up work), and there is no UI/presentation change (no quota badges, no new buttons).

## Tests
Added to `Tests/OllamaProviderTests.cpp`:
- `MapsUnauthorizedToAuthError` — HTTP 401/403 → `AIErrorKind::Auth`
- `MapsTooManyRequestsToRateLimit` — HTTP 429 → `AIErrorKind::RateLimit`, parses `Retry-After`
- `MapsConnectionFailureToNetwork` — no HTTP response → `AIErrorKind::Network`
- `MapsUnparseableBodyToSchema` — malformed body → `AIErrorKind::Schema`
- `SuccessfulResponseHasNoneErrorKind` — success path carries `AIErrorKind::None`
- `EveryResponseCarriesRequestId` — success and failure responses both carry the originating `RequestId`

All existing tests were mechanically updated to the new callback signature (no test intent changed).

## Test plan
- [x] `cmake -S . -B build -DENABLE_TESTS=ON && cmake --build build --target GravisynthTests`
- [x] `./build/Tests/GravisynthTests` — 640/640 tests passing
- [x] `clang-format --dry-run --Werror` clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012CXsoqPDwYGdkmFDNSDFov