### PR TITLE
feat(ai): implement real cancellation in OllamaProvider

### DIFF
--- a/Source/AI/AIIntegrationService.cpp
+++ b/Source/AI/AIIntegrationService.cpp
@@ -15,38 +15,15 @@ AIIntegrationService::~AIIntegrationService() {}
 
 void AIIntegrationService::setProvider(std::unique_ptr<AIProvider> newProvider) { provider = std::move(newProvider); }
 
-void AIIntegrationService::sendMessage(const juce::String& text, AIProvider::CompletionCallback callback,
-                                       bool useStructuredOutput) {
+AIProvider::RequestId AIIntegrationService::sendMessage(const juce::String& text,
+                                                        AIProvider::CompletionCallback callback,
+                                                        bool useStructuredOutput) {
     // The stored history always keeps the user's original text. Patch context is ephemeral:
     // it is spliced into the outgoing request only, never retained in chatHistory.
     chatHistory.push_back({"user", text});
     trimHistory();
 
-    if (provider) {
-        std::vector<AIProvider::Message> request = chatHistory;
-        if (useStructuredOutput && !request.empty())
-            request.back().content = buildPatchAugmentedContent(text);
-
-        auto weakThis = juce::WeakReference<AIIntegrationService>(this);
-        auto schema = useStructuredOutput ? AIStateMapper::getPatchSchema() : juce::var();
-
-        provider->sendPrompt(
-            request,
-            [weakThis, callback](const AIProvider::AIResponse& response) {
-                if (weakThis.get() == nullptr)
-                    return; // Service was destroyed
-
-                auto* self = weakThis.get();
-                if (response.success) {
-                    self->chatHistory.push_back({"assistant", response.content});
-                    self->trimHistory();
-                }
-                if (callback) {
-                    callback(response);
-                }
-            },
-            schema);
-    } else {
+    if (!provider) {
         if (callback) {
             AIProvider::AIResponse response;
             response.success = false;
@@ -54,7 +31,43 @@ void AIIntegrationService::sendMessage(const juce::String& text, AIProvider::Com
             response.error.message = "Error: No AI provider selected.";
             callback(response);
         }
+        return {};
     }
+
+    std::vector<AIProvider::Message> request = chatHistory;
+    if (useStructuredOutput && !request.empty())
+        request.back().content = buildPatchAugmentedContent(text);
+
+    auto weakThis = juce::WeakReference<AIIntegrationService>(this);
+    auto schema = useStructuredOutput ? AIStateMapper::getPatchSchema() : juce::var();
+
+    return provider->sendPrompt(
+        request,
+        [weakThis, callback](const AIProvider::AIResponse& response) {
+            if (weakThis.get() == nullptr)
+                return; // Service was destroyed
+
+            auto* self = weakThis.get();
+
+            // A cancelled request produced no assistant turn. Recording one would put words in the
+            // model's mouth that the user never saw and — because chatHistory is replayed as
+            // context — feed that invention back on every later message. The user's own turn
+            // stays: they did say it, and it is still on screen.
+            if (response.error.kind != AIProvider::AIErrorKind::Cancelled && response.success) {
+                self->chatHistory.push_back({"assistant", response.content});
+                self->trimHistory();
+            }
+
+            if (callback) {
+                callback(response);
+            }
+        },
+        schema);
+}
+
+void AIIntegrationService::cancelRequest(AIProvider::RequestId requestId) {
+    if (provider)
+        provider->cancel(requestId);
 }
 
 juce::String AIIntegrationService::buildPatchAugmentedContent(const juce::String& text) {

--- a/Source/AI/AIIntegrationService.h
+++ b/Source/AI/AIIntegrationService.h
@@ -59,8 +59,16 @@ public:
     /**
      * @brief Sends a user message and gets a response.
      */
-    void sendMessage(const juce::String& text, AIProvider::CompletionCallback callback,
-                     bool useStructuredOutput = false);
+    AIProvider::RequestId sendMessage(const juce::String& text, AIProvider::CompletionCallback callback,
+                                      bool useStructuredOutput = false);
+
+    /**
+     * @brief Abandons an in-flight request obtained from sendMessage().
+     *
+     * The caller's callback still fires exactly once, with AIErrorKind::Cancelled, and no
+     * assistant turn is added to the history. A stale or unknown handle is a safe no-op.
+     */
+    void cancelRequest(AIProvider::RequestId requestId);
 
     /**
      * @brief Applies a JSON patch to the graph.

--- a/Source/AI/OllamaProvider.cpp
+++ b/Source/AI/OllamaProvider.cpp
@@ -1,4 +1,5 @@
 #include "OllamaProvider.h"
+#include <algorithm>
 
 namespace synth {
 
@@ -14,6 +15,34 @@ constexpr int kIdleWaitMs = 1000;
 constexpr int kWorkerHandoverTimeoutMs = 2000;
 
 const char* const kShuttingDownMessage = "Error: Request cancelled - the Ollama provider is shutting down.";
+
+// Delivered with AIErrorKind::Cancelled. Callers are expected to branch on the kind rather than
+// show this text; it exists so a caller that ignores the kind still sees something sane.
+const char* const kCancelledMessage = "Request cancelled.";
+
+/** Unblocks a stream that is parked in a blocking read — or in the connect that precedes it.
+
+    juce::WebInputStream::cancel() is the real mechanism: documented to "cancel a blocking read and
+    prevent any subsequent connection attempts", and meant to be called from another thread. That
+    second half matters as much as the first here, because an Ollama chat request is non-streaming
+    and therefore spends nearly all its time inside connect() waiting for the server to finish
+    generating — see StreamPublisher for why the stream is published to us before it is connected.
+
+    CancellableStream is the escape hatch for injected test factories, which are not
+    WebInputStreams.
+
+    Anything else falls back to the cancelled flag alone: the worker finishes the read and throws
+    the response away. Still correct — the callback fires with Cancelled and the queue moves on —
+    just not prompt. */
+void abortStream(juce::InputStream& stream) {
+    if (auto* web = dynamic_cast<juce::WebInputStream*>(&stream)) {
+        web->cancel();
+        return;
+    }
+
+    if (auto* cancellable = dynamic_cast<CancellableStream*>(&stream))
+        cancellable->cancelRead();
+}
 } // namespace
 
 using AIErrorKind = OllamaProvider::AIErrorKind;
@@ -22,8 +51,48 @@ using AIErrorKind = OllamaProvider::AIErrorKind;
 OllamaProvider::OllamaProvider(const juce::String& host)
     : Thread("OllamaProviderThread")
     , ollamaHost(host)
-    , createStream([](const juce::URL& url, const juce::URL::InputStreamOptions& options) {
-        return url.createInputStream(options);
+    , createStream([](const juce::URL& url, const juce::URL::InputStreamOptions& options,
+                      const StreamPublisher& publish) -> std::unique_ptr<juce::InputStream> {
+        // Deliberately NOT juce::URL::createInputStream(). That helper connects internally and
+        // only hands the stream back afterwards, which is useless to us: an Ollama chat request
+        // is non-streaming, so the server sends nothing — not even headers — until the generation
+        // is complete, and connect() is where the whole request is spent. Building the
+        // WebInputStream here lets us publish it for cancellation BEFORE connecting, which is the
+        // difference between Cancel aborting the request and Cancel just hiding the spinner.
+        //
+        // Verified against a live Ollama: publishing after connect leaves cancel() unable to stop
+        // a long generation at all; publishing before it frees the worker in 1-2 ms.
+        const bool usePost = options.getParameterHandling() == juce::URL::ParameterHandling::inPostData;
+        auto stream = std::make_unique<juce::WebInputStream>(url, usePost);
+
+        if (const auto extraHeaders = options.getExtraHeaders(); extraHeaders.isNotEmpty())
+            stream->withExtraHeaders(extraHeaders);
+
+        if (const auto timeout = options.getConnectionTimeoutMs(); timeout != 0)
+            stream->withConnectionTimeout(timeout);
+
+        if (const auto requestCmd = options.getHttpRequestCmd(); requestCmd.isNotEmpty())
+            stream->withCustomRequestCommand(requestCmd);
+
+        stream->withNumRedirectsToFollow(options.getNumRedirectsToFollow());
+
+        publish(stream.get());
+
+        const bool connected = stream->connect(nullptr);
+
+        if (auto* status = options.getStatusCode())
+            *status = stream->getStatusCode();
+
+        if (auto* responseHeaders = options.getResponseHeaders())
+            *responseHeaders = stream->getResponseHeaders();
+
+        if (!connected || stream->isError()) {
+            // Retract before destroying it, so a concurrent cancel() cannot reach a dead stream.
+            publish(nullptr);
+            return nullptr;
+        }
+
+        return stream;
     }) {}
 
 OllamaProvider::~OllamaProvider() {
@@ -59,7 +128,7 @@ OllamaProvider::RequestId OllamaProvider::sendPrompt(const std::vector<Message>&
     // compatibility but intentionally never invoked.
     juce::ignoreUnused(onDelta);
 
-    Request request{RequestId{}, conversation, std::move(callback), responseSchema};
+    Request request{RequestId{}, conversation, std::move(callback), responseSchema, nullptr};
     bool rejected = false;
     bool mustStartWorker = false;
 
@@ -67,10 +136,14 @@ OllamaProvider::RequestId OllamaProvider::sendPrompt(const std::vector<Message>&
         const juce::ScopedLock sl(queueLock);
 
         request.id.value = nextRequestId++;
+        request.state = std::make_shared<RequestState>(request.id);
 
         if (isShuttingDown) {
             rejected = true;
         } else {
+            // Registered under the same lock as the queue push, so a cancel() racing this call
+            // either does not see the request at all or sees it in both places.
+            inFlight.emplace(request.id.value, request.state);
             pendingRequests.push_back(request);
 
             // Self-heal: `running` plus a dead thread means run() entered but ended
@@ -118,10 +191,73 @@ OllamaProvider::RequestId OllamaProvider::sendPrompt(const std::vector<Message>&
 }
 
 void OllamaProvider::cancel(RequestId requestId) {
-    // Not implemented: OllamaProvider cannot cancel an in-flight or queued request yet.
-    // Declared per the AIProvider interface so future providers can implement real
-    // cancellation without an interface change.
-    juce::ignoreUnused(requestId);
+    if (requestId.value == 0)
+        return;
+
+    std::shared_ptr<RequestState> state;
+    Request abandoned;
+    bool tookFromQueue = false;
+
+    {
+        const juce::ScopedLock sl(queueLock);
+
+        const auto entry = inFlight.find(requestId.value);
+        if (entry == inFlight.end())
+            return; // Unknown id, or the request already completed and was delivered: nothing to do.
+
+        state = entry->second;
+        state->cancelled.store(true);
+
+        // If the worker has not picked this up yet we own it outright. Taking it out of the queue
+        // here — under the same lock the worker pops with, so exactly one of us ends up holding
+        // it — is what stops an abandoned request delaying the ones behind it.
+        const auto queued = std::find_if(pendingRequests.begin(), pendingRequests.end(),
+                                         [&state](const Request& r) { return r.state == state; });
+
+        if (queued != pendingRequests.end()) {
+            abandoned = *queued;
+            pendingRequests.erase(queued);
+            tookFromQueue = true;
+        }
+    }
+
+    if (tookFromQueue) {
+        // Delivered outside the lock: in test mode the callback runs inline, and one that
+        // re-entered sendPrompt() while we held queueLock would be a surprise at best.
+        deliverError(abandoned, AIErrorKind::Cancelled, kCancelledMessage, /*retryAfterSeconds=*/0,
+                     /*forceSynchronous=*/false);
+        return;
+    }
+
+    // Already in flight. Unblock the read (or the connect it is still inside); the worker sees the
+    // cancelled flag on the way out and delivers the Cancelled callback itself. Leaving delivery to
+    // the worker keeps a single owner for the request and means it is genuinely free before we
+    // return, rather than still holding the queue behind a socket nobody is waiting on.
+    abortActiveStream(*state);
+}
+
+void OllamaProvider::abortActiveStream(RequestState& state) {
+    const juce::ScopedLock sl(state.streamLock);
+    if (state.activeStream != nullptr)
+        abortStream(*state.activeStream);
+}
+
+bool OllamaProvider::claimDelivery(const Request& req) {
+    if (req.state == nullptr)
+        return true; // Default-constructed Request (no state): nothing to arbitrate.
+
+    // cancel(), the worker and failAllPending() can all reach the same request, and cancelling one
+    // that is completing right now makes that a real race. Whoever wins the exchange owns the
+    // callback; everyone else backs off having done nothing.
+    if (req.state->delivered.exchange(true))
+        return false;
+
+    // Deregister before the caller calls out, so a cancel() issued from inside the callback (or
+    // from another thread the instant it fires) sees a completed id and no-ops instead of trying
+    // to abort a stream that is on its way out.
+    const juce::ScopedLock sl(queueLock);
+    inFlight.erase(req.state->id.value);
+    return true;
 }
 
 bool OllamaProvider::ensureWorkerRunning() {
@@ -167,6 +303,11 @@ void OllamaProvider::failAllPending(AIErrorKind kind, const juce::String& messag
 }
 
 void OllamaProvider::deliverResult(const Request& req, const juce::String& responseText, bool forceSynchronous) {
+    // Claimed before the callback check, so a request with no callback is still deregistered and
+    // a later cancel() of its id stays a no-op.
+    if (!claimDelivery(req))
+        return;
+
     if (!req.callback)
         return;
 
@@ -188,6 +329,9 @@ void OllamaProvider::deliverResult(const Request& req, const juce::String& respo
 
 void OllamaProvider::deliverError(const Request& req, AIErrorKind kind, const juce::String& message,
                                   int retryAfterSeconds, bool forceSynchronous) {
+    if (!claimDelivery(req))
+        return;
+
     if (!req.callback)
         return;
 
@@ -256,9 +400,12 @@ void OllamaProvider::fetchAvailableModels(std::function<void(const juce::StringA
         juce::StringArray models;
         bool success = false;
 
+        // Model discovery is not cancellable (bounded by its own 4 s connection timeout and with
+        // no user-visible Cancel), so it publishes nothing.
         if (auto stream = createStream(
                 url,
-                juce::URL::InputStreamOptions(juce::URL::ParameterHandling::inAddress).withConnectionTimeoutMs(4000))) {
+                juce::URL::InputStreamOptions(juce::URL::ParameterHandling::inAddress).withConnectionTimeoutMs(4000),
+                [](juce::InputStream*) {})) {
             juce::String responseText = stream->readEntireStreamAsString();
             // DBG("AI Discovery Response (before JSON parse): [" + responseText + "]"); // Potentially expensive
             // DBG("AI Discovery Response: " + responseText); // Redundant
@@ -367,6 +514,15 @@ void OllamaProvider::processRequest(const Request& req) {
         return;
     }
 
+    auto wasCancelled = [&req] { return req.state != nullptr && req.state->cancelled.load(); };
+
+    // Cancelled while it sat in the queue, or during the handoff to this thread. Bail before
+    // opening a connection — the whole point is not to spend money on abandoned work.
+    if (wasCancelled()) {
+        deliverErr(AIErrorKind::Cancelled, kCancelledMessage);
+        return;
+    }
+
     juce::URL url(ollamaHost + "/api/chat");
 
     // Build JSON body
@@ -391,11 +547,58 @@ void OllamaProvider::processRequest(const Request& req) {
     int httpStatus = 0;
     juce::StringPairArray responseHeaders;
 
-    auto stream = createStream(url.withPOSTData(jsonString),
-                               juce::URL::InputStreamOptions(juce::URL::ParameterHandling::inPostData)
-                                   .withConnectionTimeoutMs(120000)
-                                   .withStatusCode(&httpStatus)
-                                   .withResponseHeaders(&responseHeaders));
+    // Declared before the guard below so it is destroyed AFTER it: the guard must have already
+    // cleared activeStream by the time the stream itself goes away, or cancel() could reach a
+    // destroyed object.
+    std::unique_ptr<juce::InputStream> stream;
+
+    // Retracts the published pointer however this scope is left. Every store and load of
+    // activeStream is under streamLock, which is the only thing standing between cancel() and a
+    // dangling pointer. streamLock is never held while taking queueLock, so the two cannot
+    // deadlock against each other.
+    struct ScopedActiveStream {
+        RequestState* state;
+        ~ScopedActiveStream() {
+            if (state == nullptr)
+                return;
+            const juce::ScopedLock sl(state->streamLock);
+            state->activeStream = nullptr;
+        }
+    };
+
+    ScopedActiveStream activeStreamScope{req.state.get()};
+
+    // Handed to the factory, which calls it as soon as the stream exists and before it blocks —
+    // see StreamPublisher for why publishing has to happen that early.
+    auto publish = [&req](juce::InputStream* published) {
+        if (req.state == nullptr)
+            return;
+
+        {
+            const juce::ScopedLock sl(req.state->streamLock);
+            req.state->activeStream = published;
+        }
+
+        // A cancel() that arrived before this point found nothing to abort, so apply it now that
+        // the stream is visible. Without this, such a request would run to completion.
+        if (published != nullptr && req.state->cancelled.load())
+            abortStream(*published);
+    };
+
+    stream = createStream(url.withPOSTData(jsonString),
+                          juce::URL::InputStreamOptions(juce::URL::ParameterHandling::inPostData)
+                              .withConnectionTimeoutMs(120000)
+                              .withStatusCode(&httpStatus)
+                              .withResponseHeaders(&responseHeaders),
+                          publish);
+
+    // Checked before the HTTP-status branches below: an aborted connect or read looks exactly like
+    // a network failure from here, and reporting a cancellation the user asked for as an error
+    // they might try to debug would be actively misleading.
+    if (wasCancelled()) {
+        deliverErr(AIErrorKind::Cancelled, kCancelledMessage);
+        return;
+    }
 
     // httpStatus is populated by the pointer above as soon as HTTP response headers are
     // received, independent of whether createStream() went on to hand back a stream — so
@@ -433,6 +636,12 @@ void OllamaProvider::processRequest(const Request& req) {
 
     juce::String responseText = stream->readEntireStreamAsString();
     // DBG("AI Chat Response (before JSON parse): [" + responseText + "]"); // Potentially expensive
+
+    // A cancel that landed while we were reading: throw away whatever partial text came back.
+    if (wasCancelled()) {
+        deliverErr(AIErrorKind::Cancelled, kCancelledMessage);
+        return;
+    }
 
     juce::var jsonResponse = juce::JSON::parse(responseText);
     if (jsonResponse.isObject()) {

--- a/Source/AI/OllamaProvider.h
+++ b/Source/AI/OllamaProvider.h
@@ -4,10 +4,28 @@
 #include <atomic>
 #include <juce_core/juce_core.h>
 #include <juce_events/juce_events.h>
+#include <map>
+#include <memory>
 #include <thread>
 #include <vector>
 
 namespace synth {
+
+/**
+ * @class CancellableStream
+ * @brief Opt-in mix-in letting cancel() abort a stream that is parked in a blocking read.
+ *
+ * Real requests do not need this — they are juce::WebInputStreams, which OllamaProvider aborts
+ * natively. It exists for injected test factories, so a test double can be unblocked by exactly
+ * the mechanism a real socket is, instead of the test having to model cancellation some other way.
+ */
+struct CancellableStream {
+    virtual ~CancellableStream() = default;
+
+    /** Must unblock a concurrent read() promptly. Called from a thread other than the one
+        inside read(), and may be called more than once. */
+    virtual void cancelRead() = 0;
+};
 
 /**
  * @class OllamaProvider
@@ -17,8 +35,23 @@ class OllamaProvider
     : public AIProvider
     , protected juce::Thread {
 public:
-    using InputStreamFactory =
-        std::function<std::unique_ptr<juce::InputStream>(const juce::URL&, const juce::URL::InputStreamOptions&)>;
+    /** Hands a stream to the cancellation machinery the moment it exists.
+
+        A factory MUST call this with the stream before doing anything blocking with it, and MUST
+        call it with nullptr before destroying a stream it is not going to return. Ownership does
+        not transfer; the provider only borrows the pointer, under a lock, for as long as the
+        factory says it is alive.
+
+        This exists because of where an Ollama request actually blocks. The request asks for a
+        non-streaming response, so the server sends nothing — not even headers — until the whole
+        generation is finished, which means connect() is where the entire request is spent.
+        juce::URL::createInputStream() connects internally and only then hands back the stream, so
+        a factory built on it cannot publish in time and cancel() would have nothing to abort for
+        the full generation. Publishing first is what makes cancellation real rather than cosmetic. */
+    using StreamPublisher = std::function<void(juce::InputStream*)>;
+
+    using InputStreamFactory = std::function<std::unique_ptr<juce::InputStream>(
+        const juce::URL&, const juce::URL::InputStreamOptions&, const StreamPublisher&)>;
 
     OllamaProvider(const juce::String& host = "http://localhost:11434");
 
@@ -43,7 +76,11 @@ public:
                          const juce::var& responseSchema = juce::var(),
                          std::function<void(const juce::String& delta)> onDelta = {}) override;
 
-    /** Cancellation is not implemented for OllamaProvider yet; this is a declared no-op. */
+    /** Abandons a queued or in-flight request.
+
+        The callback still fires exactly once, with AIErrorKind::Cancelled; the request cannot go
+        on blocking the ones queued behind it; and an unknown, completed or already-cancelled id
+        is a safe no-op. See cancel()'s implementation for how promptly each stream type unblocks. */
     void cancel(RequestId requestId) override;
 
     juce::String getProviderName() const override { return "Ollama"; }
@@ -67,11 +104,35 @@ private:
     // worker launches, cleared by the worker when it finishes.
     std::atomic<bool> discoveryInFlight{false};
 
+    /** Per-request cancellation state, shared between the queue entry, the registry and the
+        worker so cancel() can reach a request wherever it currently is. */
+    struct RequestState {
+        explicit RequestState(RequestId requestId)
+            : id(requestId) {}
+
+        const RequestId id;
+
+        // Set by cancel(). Checked by the worker before it opens a connection and again after the
+        // read returns, so a request cancelled at any point is abandoned.
+        std::atomic<bool> cancelled{false};
+
+        // Exactly-once gate on the callback. cancel(), the worker and the shutdown path can all
+        // race to finish the same request; whoever flips this first owns delivery.
+        std::atomic<bool> delivered{false};
+
+        // Non-owning, valid only while the factory or the worker says the stream is alive, so
+        // cancel() can abort it. Guarded by streamLock, which is what stops cancel() touching a
+        // destroyed stream.
+        juce::CriticalSection streamLock;
+        juce::InputStream* activeStream = nullptr;
+    };
+
     struct Request {
         RequestId id;
         std::vector<Message> conversation;
         AIProvider::CompletionCallback callback;
         juce::var responseSchema;
+        std::shared_ptr<RequestState> state; // null only for a default-constructed Request
     };
 
     // Monotonically increasing; only ever accessed from sendPrompt() callers, so a plain
@@ -80,6 +141,11 @@ private:
 
     juce::CriticalSection queueLock;
     std::vector<Request> pendingRequests;
+
+    // Every request that has been accepted and not yet delivered, so cancel() can find one the
+    // worker has already popped off pendingRequests. Guarded by queueLock; entries are removed by
+    // the delivery path, which is what makes cancel() of a completed id a no-op.
+    std::map<uint64_t, std::shared_ptr<RequestState>> inFlight;
 
     // Who owns the queue. This - NOT isThreadRunning() - is what says "a worker will
     // drain this queue". juce::Thread only clears its handle after run() has already
@@ -121,6 +187,15 @@ private:
         deliverResult(). */
     void deliverError(const Request& req, AIErrorKind kind, const juce::String& message, int retryAfterSeconds,
                       bool forceSynchronous);
+
+    /** Claims the sole right to deliver `req`, and deregisters it. Returns false if someone else
+        got there first, in which case the caller must not invoke the callback. This is what makes
+        "exactly one callback per request" hold when a cancel races a completion. */
+    bool claimDelivery(const Request& req);
+
+    /** Aborts the read the given request is parked in, if any. Safe when the request has no
+        active stream (already finished, or not started yet). */
+    void abortActiveStream(RequestState& state);
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(OllamaProvider)
 };

--- a/Source/UI/AIChatComponent.cpp
+++ b/Source/UI/AIChatComponent.cpp
@@ -201,6 +201,12 @@ AIChatComponent::AIChatComponent(AIIntegrationService& service, juce::Applicatio
     addAndMakeVisible(inputField);
     inputField.setReturnKeyStartsNewLine(false);
     inputField.onReturnKey = [this]() { sendButtonClicked(); };
+    // Belt and braces for Escape: keyPressed() catches the bubbled press, but a TextEditor with an
+    // onEscapeKey handler consumes it before it can bubble, so the two must agree.
+    inputField.onEscapeKey = [this]() {
+        if (isWaitingForResponse)
+            handleUserCancel();
+    };
     inputField.addListener(this);
     inputField.setTextToShowWhenEmpty("Ask AI to create or modify a patch...", juce::Colours::grey);
     inputField.setTooltip("Type a message and press Enter or Send");
@@ -213,12 +219,7 @@ AIChatComponent::AIChatComponent(AIIntegrationService& service, juce::Applicatio
     // Cancel button — hidden until a request is in flight.
     cancelButton.setButtonText("Cancel");
     cancelButton.setColour(juce::TextButton::buttonColourId, juce::Colours::darkred);
-    cancelButton.onClick = [this]() {
-        cancelRequest();
-        messages.push_back({"assistant", "Cancelled.", ""});
-        updateChatDisplay();
-        inputField.grabKeyboardFocus();
-    };
+    cancelButton.onClick = [this]() { handleUserCancel(); };
     cancelButton.setTooltip("Cancel the in-flight AI request");
     cancelButton.setVisible(false);
     addChildComponent(cancelButton);
@@ -286,7 +287,35 @@ void AIChatComponent::timerCallback() {
     inputField.grabKeyboardFocus();
 }
 
+bool AIChatComponent::keyPressed(const juce::KeyPress& key) {
+    // Escape only means "cancel" while something is actually in flight; otherwise let it through
+    // so it keeps whatever meaning the enclosing window gives it (closing a panel).
+    if (key == juce::KeyPress::escapeKey && isWaitingForResponse) {
+        handleUserCancel();
+        return true;
+    }
+
+    return juce::Component::keyPressed(key);
+}
+
+void AIChatComponent::handleUserCancel() {
+    cancelRequest();
+    messages.push_back({"assistant", "Cancelled.", ""});
+    updateChatDisplay();
+    inputField.grabKeyboardFocus();
+}
+
 void AIChatComponent::cancelRequest() {
+    // Actually abandon the request rather than just hiding the UI for it. Until this call existed
+    // the HTTP request ran to completion — billed on a metered backend, and (because
+    // OllamaProvider drains its queue serially) blocking the next message the user sent. Cleared
+    // first so a provider that completes the cancellation synchronously and re-enters here cannot
+    // cancel the same id twice.
+    const auto cancelling = activeRequestId;
+    activeRequestId = {};
+    if (cancelling.value != 0)
+        aiService.cancelRequest(cancelling);
+
     // Stop the timeout timer.
     stopTimer();
 
@@ -404,7 +433,7 @@ void AIChatComponent::sendButtonClicked() {
     // Start timeout timer (120 seconds)
     startTimer(120000);
 
-    aiService.sendMessage(
+    const auto requestId = aiService.sendMessage(
         text,
         [this, useStructuredOutput](const AIProvider::AIResponse& aiResponse) {
             juce::Component::SafePointer<AIChatComponent> safeThis(this);
@@ -417,7 +446,16 @@ void AIChatComponent::sendButtonClicked() {
                     return;
                 } // Ignore late responses if a timeout already occurred
 
+                // The request is finished, so there is nothing left to cancel. Clearing the handle
+                // before teardown keeps cancelRequest() from asking the provider to cancel a
+                // completed id.
+                self->activeRequestId = {};
                 self->cancelRequest(); // stops timer, spinner, cancel btn, restores input
+
+                // The user already got their "Cancelled." bubble from handleUserCancel(); the
+                // provider is just confirming. An error bubble here would contradict it.
+                if (aiResponse.error.kind == AIProvider::AIErrorKind::Cancelled)
+                    return;
 
                 if (aiResponse.success) {
                     const juce::String& response = aiResponse.content;
@@ -456,6 +494,12 @@ void AIChatComponent::sendButtonClicked() {
             });
         },
         useStructuredOutput);
+
+    // Only record the handle if we are still waiting. A provider that answers synchronously (test
+    // doubles, or the "no provider selected" path) has already run the teardown above by now, and
+    // storing the handle here would leave a stale id for the next cancel.
+    if (isWaitingForResponse)
+        activeRequestId = requestId;
 }
 
 void AIChatComponent::updateChatDisplay() {

--- a/Source/UI/AIChatComponent.h
+++ b/Source/UI/AIChatComponent.h
@@ -35,17 +35,20 @@ public:
     void resized() override;
     void paint(juce::Graphics& g) override;
 
+    // Escape cancels an in-flight request. Reached by bubbling: while waiting, the read-only
+    // inputField holds focus and does not consume Escape, so the press walks up to us.
+    bool keyPressed(const juce::KeyPress& key) override;
+
     void refreshModels();
     void sendButtonClicked();
     void triggerSend() { sendButtonClicked(); }
 
     // Testing hook: directly invokes the cancel action synchronously (mirrors triggerSend).
     // Use in headless tests instead of cancelButton->triggerClick(), which posts async.
-    void simulateCancelClick() {
-        cancelRequest();
-        messages.push_back({"assistant", "Cancelled.", ""});
-        updateChatDisplay();
-    }
+    void simulateCancelClick() { handleUserCancel(); }
+
+    // Testing hook: the Escape-key path, without needing real keyboard focus.
+    void simulateEscapeKey() { keyPressed(juce::KeyPress(juce::KeyPress::escapeKey)); }
 
     // Testing hook: returns true if the cancel button is currently visible.
     bool isCancelVisible() const { return cancelButton.isVisible(); }
@@ -59,6 +62,10 @@ private:
     // Stops the in-flight request and resets all waiting state.
     // Called both by the cancel button and by the timeout path.
     void cancelRequest();
+
+    // The user-initiated cancel: cancelRequest() plus the "Cancelled." bubble and focus restore.
+    // Shared by the Cancel button and the Escape key so the two cannot drift.
+    void handleUserCancel();
 
     class MessageBubble;
     class PatchCard;
@@ -121,6 +128,11 @@ private:
     AIIntegrationService& aiService;
     juce::ApplicationProperties& appProperties;
     bool isWaitingForResponse = false;
+
+    // Handle for the request currently in flight, so cancelRequest() can tell the provider to
+    // actually abandon it. Default (value 0) whenever nothing is outstanding — cleared by the
+    // response handler before teardown so a completed request is never "cancelled".
+    AIProvider::RequestId activeRequestId{};
 
     juce::Viewport viewport;
     juce::Component messageList;

--- a/Tests/AIIntegrationServiceTests.cpp
+++ b/Tests/AIIntegrationServiceTests.cpp
@@ -44,6 +44,62 @@ public:
     std::vector<Message> lastConversation;
 };
 
+// Holds the request instead of answering it, so a test can decide how it ends. cancel() resolves
+// it the way a real provider does: one callback, kind Cancelled.
+class CancellableMockAIProvider : public AIProvider {
+public:
+    RequestId sendPrompt(const std::vector<Message>&, CompletionCallback callback, const juce::var&,
+                         std::function<void(const juce::String&)> = {}) override {
+        pending = std::move(callback);
+        return RequestId{++lastRequestId};
+    }
+
+    void cancel(RequestId requestId) override {
+        cancelledIds.push_back(requestId.value);
+        if (!pending)
+            return;
+
+        auto callback = std::move(pending);
+        pending = nullptr;
+
+        AIResponse response;
+        response.success = false;
+        response.error.kind = AIErrorKind::Cancelled;
+        response.error.message = "Request cancelled.";
+        callback(response);
+    }
+
+    /** Resolves the held request normally, for the "a real answer still lands in history" half of
+        the comparison. */
+    void completeWith(const juce::String& content) {
+        if (!pending)
+            return;
+
+        auto callback = std::move(pending);
+        pending = nullptr;
+
+        AIResponse response;
+        response.success = true;
+        response.content = content;
+        callback(response);
+    }
+
+    void fetchAvailableModels(std::function<void(const juce::StringArray&, bool)> callback) override {
+        callback({"model1"}, true);
+    }
+
+    void setModel(const juce::String& name) override { currentModel = name; }
+    juce::String getCurrentModel() const override { return currentModel; }
+    juce::String getProviderName() const override { return "CancellableMockProvider"; }
+
+    std::vector<uint64_t> cancelledIds;
+    uint64_t lastRequestId = 0;
+
+private:
+    CompletionCallback pending;
+    juce::String currentModel;
+};
+
 class CountingListener : public AIIntegrationService::Listener {
 public:
     int aboutToApplyCount = 0;
@@ -264,6 +320,86 @@ TEST_F(AIIntegrationServiceTest, ValidPatchFiresBothCallbacksInOrder) {
     EXPECT_LT(listener.aboutToApplyOrder, listener.appliedOrder);
 
     service->removeListener(&listener);
+}
+
+// A cancelled request produced no assistant turn, so none may be recorded. Appending one would
+// both put words in the model's mouth in the transcript and -- because chatHistory is replayed as
+// context -- feed that invention back on every later message.
+TEST_F(AIIntegrationServiceTest, CancelledRequestDoesNotAppendToHistory) {
+    auto provider = std::make_unique<CancellableMockAIProvider>();
+    auto* rawProvider = provider.get();
+    service->setProvider(std::move(provider));
+
+    AIProvider::AIErrorKind reportedKind = AIProvider::AIErrorKind::None;
+    int callCount = 0;
+    const auto id = service->sendMessage("Make me a huge patch", [&](const AIProvider::AIResponse& response) {
+        ++callCount;
+        reportedKind = response.error.kind;
+    });
+
+    // The user's own turn is recorded on send, before any answer exists.
+    ASSERT_EQ(service->getHistory().size(), 2u);
+
+    service->cancelRequest(id);
+
+    EXPECT_EQ(callCount, 1) << "the caller must still be told exactly once that its request ended";
+    EXPECT_EQ(reportedKind, AIProvider::AIErrorKind::Cancelled);
+    ASSERT_EQ(rawProvider->cancelledIds.size(), 1u) << "the service did not forward the cancel to the provider";
+    EXPECT_EQ(rawProvider->cancelledIds[0], id.value);
+
+    // Still just system + user: the user did say their part and it stays, but nothing was added on
+    // the assistant's behalf.
+    ASSERT_EQ(service->getHistory().size(), 2u) << "a cancelled request added an assistant turn to the history";
+    EXPECT_EQ(service->getHistory()[0].role, "system");
+    EXPECT_EQ(service->getHistory()[1].role, "user");
+}
+
+// The counterpart to the above: the "don't append" rule must be specific to cancellation and must
+// not have quietly broken the normal path.
+TEST_F(AIIntegrationServiceTest, CompletedRequestStillAppendsToHistory) {
+    auto provider = std::make_unique<CancellableMockAIProvider>();
+    auto* rawProvider = provider.get();
+    service->setProvider(std::move(provider));
+
+    service->sendMessage("Hello", nullptr);
+    rawProvider->completeWith("Hi there");
+
+    ASSERT_EQ(service->getHistory().size(), 3u);
+    EXPECT_EQ(service->getHistory()[2].role, "assistant");
+    EXPECT_EQ(service->getHistory()[2].content, "Hi there");
+}
+
+// A stale handle is the normal case in the UI (a response and a Cancel click cross), so cancelling
+// something already finished must be inert rather than merely survivable.
+TEST_F(AIIntegrationServiceTest, CancelAfterCompletionIsInert) {
+    auto provider = std::make_unique<CancellableMockAIProvider>();
+    auto* rawProvider = provider.get();
+    service->setProvider(std::move(provider));
+
+    int callCount = 0;
+    const auto id = service->sendMessage("Hello", [&](const AIProvider::AIResponse&) { ++callCount; });
+    rawProvider->completeWith("Hi there");
+    ASSERT_EQ(callCount, 1);
+
+    service->cancelRequest(id);
+
+    EXPECT_EQ(callCount, 1) << "cancelling a completed request fired a second callback";
+    EXPECT_EQ(service->getHistory().size(), 3u) << "cancelling a completed request disturbed the history";
+}
+
+// Without a provider there is nothing to cancel; sendMessage() reports the failure inline and must
+// hand back the reserved handle rather than something a later cancel could act on.
+TEST_F(AIIntegrationServiceTest, SendMessageWithoutProviderReturnsInvalidRequestId) {
+    bool called = false;
+    const auto id = service->sendMessage("Hello", [&](const AIProvider::AIResponse& response) {
+        called = true;
+        EXPECT_FALSE(response.success);
+    });
+
+    EXPECT_TRUE(called);
+    EXPECT_EQ(id.value, 0u);
+
+    service->cancelRequest(id); // must not crash
 }
 
 } // namespace synth

--- a/Tests/OllamaProviderTests.cpp
+++ b/Tests/OllamaProviderTests.cpp
@@ -1,11 +1,13 @@
 #include "../Source/AI/OllamaProvider.h" // Correct path
-#include <chrono>                        // For steady_clock timing
-#include <condition_variable>            // For bounded callback waits
-#include <future>                        // For std::promise/std::future
+#include <atomic>
+#include <chrono>             // For steady_clock timing
+#include <condition_variable> // For bounded callback waits
+#include <future>             // For std::promise/std::future
 #include <gtest/gtest.h>
 #include <juce_core/juce_core.h>
 #include <memory>
 #include <mutex>
+#include <thread> // For racing cancel() against completion
 
 // Mock AIProvider::CompletionCallback for testing
 struct MockCompletionCallback {
@@ -181,22 +183,112 @@ private:
     bool readCalled = false;
 };
 
+// The thing a gated read parks on. Deliberately owned separately from the stream (both hold a
+// shared_ptr): the worker destroys its stream the moment a cancelled read returns, so a test
+// thread that released the gate through the stream itself would be racing a use-after-free.
+// Releasing through the gate is safe whatever the stream's lifetime is doing.
+struct StreamGate {
+    // Manual reset, so a release that lands before read() is even entered still counts.
+    juce::WaitableEvent released{true};
+
+    void release() { released.signal(); }
+
+    // Hard cap so a cancel that never arrives fails the test instead of hanging it. A working
+    // cancel returns from here in microseconds, so the cap is never hit on the happy path.
+    void awaitRelease() { released.wait(15000); }
+};
+
+// A stream that parks inside read() until the provider cancels it (via CancellableStream — the
+// same hook a real juce::WebInputStream services through its own cancel()) or the test releases
+// the gate directly. This is how a test pins a request "mid-flight" and then proves cancel() is
+// what freed it.
+class CancellableGatedStream
+    : public juce::InputStream
+    , public synth::CancellableStream {
+public:
+    CancellableGatedStream(std::shared_ptr<CallbackLatch> enteredLatch, std::shared_ptr<StreamGate> streamGate)
+        : entered(std::move(enteredLatch))
+        , gate(std::move(streamGate)) {}
+
+    bool failedToOpen() const { return false; }
+    juce::int64 getTotalLength() override { return 1; }
+    juce::int64 getPosition() override { return readCalled ? 1 : 0; }
+    bool setPosition(juce::int64 newPosition) override {
+        juce::ignoreUnused(newPosition);
+        return false;
+    }
+    bool isExhausted() override { return readCalled; }
+
+    int read(void* destBuffer, int maxBytesToRead) override {
+        juce::ignoreUnused(destBuffer, maxBytesToRead);
+        if (readCalled)
+            return 0;
+
+        readCalled = true;
+
+        if (entered != nullptr)
+            entered->fire();
+
+        gate->awaitRelease();
+        return 0;
+    }
+
+    void cancelRead() override { gate->release(); }
+
+private:
+    std::shared_ptr<CallbackLatch> entered;
+    std::shared_ptr<StreamGate> gate;
+    bool readCalled = false;
+};
+
+// Gates the FIRST request and hands later requests an ordinary successful response, so a test can
+// cancel one in-flight request and still watch the next one complete.
+struct CancellableGatedFactory {
+    std::shared_ptr<CallbackLatch> entered = std::make_shared<CallbackLatch>();
+    std::shared_ptr<StreamGate> gate = std::make_shared<StreamGate>();
+    std::shared_ptr<std::atomic<int>> callCount = std::make_shared<std::atomic<int>>(0);
+
+    synth::OllamaProvider::InputStreamFactory operator()() const {
+        auto enteredLatch = entered;
+        auto sharedGate = gate;
+        auto counter = callCount;
+
+        return [enteredLatch, sharedGate,
+                counter](const juce::URL& url, const juce::URL::InputStreamOptions& options,
+                         const synth::OllamaProvider::StreamPublisher& publish) -> std::unique_ptr<juce::InputStream> {
+            juce::ignoreUnused(url, options);
+
+            if (counter->fetch_add(1) == 0) {
+                auto stream = std::make_unique<CancellableGatedStream>(enteredLatch, sharedGate);
+                // Published before returning, exactly as the production factory does before it
+                // connects — without this the provider has no handle to abort and cancel() could
+                // not reach the gated read at all.
+                publish(stream.get());
+                return stream;
+            }
+
+            return std::make_unique<MockInputStream>(
+                R"({"model":"mock-model","message":{"role":"assistant","content":"Mocked AI response."}})", false);
+        };
+    }
+};
+
 // Builds a factory that gates only the FIRST request - later requests get an ordinary
 // successful chat response, so a test can pin one worker without stalling the next.
 inline synth::OllamaProvider::InputStreamFactory makeOneShotGatedFactory(std::shared_ptr<CallbackLatch> enteredLatch) {
     auto callCount = std::make_shared<std::atomic<int>>(0);
 
-    return
-        [enteredLatch, callCount](const juce::URL& url,
-                                  const juce::URL::InputStreamOptions& options) -> std::unique_ptr<juce::InputStream> {
-            juce::ignoreUnused(url, options);
+    return [enteredLatch,
+            callCount](const juce::URL& url, const juce::URL::InputStreamOptions& options,
+                       const synth::OllamaProvider::StreamPublisher& publish) -> std::unique_ptr<juce::InputStream> {
+        juce::ignoreUnused(url, options, publish);
 
-            if (callCount->fetch_add(1) == 0)
-                return std::make_unique<GatedInputStream>(enteredLatch);
+        if (callCount->fetch_add(1) == 0)
+            return std::make_unique<GatedInputStream>(enteredLatch);
 
-            return std::make_unique<MockInputStream>(
-                R"({"model":"mock-model","message":{"role":"assistant","content":"Mocked AI response."}})", false);
-        };
+        return std::make_unique<MockInputStream>(
+            R"({"model":"mock-model","message":{"role":"assistant","content":"Mocked AI response."}})", false);
+    };
 }
 
 } // namespace
@@ -211,24 +303,27 @@ protected:
     juce::String validOllamaHost = "http://127.0.0.1:11434"; // Assuming local Ollama instance runs here
 
     // A factory that always returns a stream simulating an an error (returns nullptr)
-    static std::unique_ptr<juce::InputStream> createFailingStream(const juce::URL& url,
-                                                                  const juce::URL::InputStreamOptions& options) {
-        juce::ignoreUnused(url, options);
+    static std::unique_ptr<juce::InputStream>
+    createFailingStream(const juce::URL& url, const juce::URL::InputStreamOptions& options,
+                        const synth::OllamaProvider::StreamPublisher& publish) {
+        juce::ignoreUnused(url, options, publish);
         return nullptr; // Simulate failed to open stream
     }
 
     // A factory that returns a stream with a predefined success response
     static std::unique_ptr<juce::InputStream>
-    createSuccessfulModelsStream(const juce::URL& url, const juce::URL::InputStreamOptions& options) {
-        juce::ignoreUnused(url, options);
+    createSuccessfulModelsStream(const juce::URL& url, const juce::URL::InputStreamOptions& options,
+                                 const synth::OllamaProvider::StreamPublisher& publish) {
+        juce::ignoreUnused(url, options, publish);
         juce::String jsonResponse = R"({"models":[{"name":"mock-model:latest","model":"mock-model:latest"}]})";
         return std::make_unique<MockInputStream>(jsonResponse, false);
     }
 
     // A factory that returns a stream with a predefined chat response
-    static std::unique_ptr<juce::InputStream> createSuccessfulChatStream(const juce::URL& url,
-                                                                         const juce::URL::InputStreamOptions& options) {
-        juce::ignoreUnused(url, options);
+    static std::unique_ptr<juce::InputStream>
+    createSuccessfulChatStream(const juce::URL& url, const juce::URL::InputStreamOptions& options,
+                               const synth::OllamaProvider::StreamPublisher& publish) {
+        juce::ignoreUnused(url, options, publish);
         juce::String jsonResponse =
             R"({"model":"mock-model","message":{"role":"assistant","content":"Mocked AI response."}})";
         return std::make_unique<MockInputStream>(jsonResponse, false);
@@ -236,8 +331,9 @@ protected:
 
     // A factory that returns a stream that takes a long time to respond
     static std::unique_ptr<juce::InputStream> createSlowStream(const juce::URL& url,
-                                                               const juce::URL::InputStreamOptions& options) {
-        juce::ignoreUnused(url, options);
+                                                               const juce::URL::InputStreamOptions& options,
+                                                               const synth::OllamaProvider::StreamPublisher& publish) {
+        juce::ignoreUnused(url, options, publish);
         // Always use a short delay — the test verifies timeout behavior,
         // not the actual timeout duration. 4 seconds is enough.
         return std::make_unique<SlowInputStream>(4000);
@@ -347,9 +443,10 @@ private:
 // call must return immediately because discovery runs on a worker thread. A second
 // immediate call must also return immediately (it must not join the first worker).
 TEST_F(OllamaProviderTest, FetchAvailableModelsDoesNotBlockCaller) {
-    auto blockingFactory = [](const juce::URL& url,
-                              const juce::URL::InputStreamOptions& options) -> std::unique_ptr<juce::InputStream> {
-        juce::ignoreUnused(url, options);
+    auto blockingFactory =
+        [](const juce::URL& url, const juce::URL::InputStreamOptions& options,
+           const synth::OllamaProvider::StreamPublisher& publish) -> std::unique_ptr<juce::InputStream> {
+        juce::ignoreUnused(url, options, publish);
         return std::make_unique<BlockingDiscoveryStream>();
     };
 
@@ -383,9 +480,10 @@ TEST_F(OllamaProviderTest, FetchAvailableModelsDoesNotBlockCaller) {
 TEST_F(OllamaProviderTest, SendPromptWithNoModelFailsWithoutHittingNetwork) {
     bool networkFactoryInvoked = false;
     auto trackingFactory =
-        [&networkFactoryInvoked](const juce::URL& url,
-                                 const juce::URL::InputStreamOptions& options) -> std::unique_ptr<juce::InputStream> {
-        juce::ignoreUnused(url, options);
+        [&networkFactoryInvoked](
+            const juce::URL& url, const juce::URL::InputStreamOptions& options,
+            const synth::OllamaProvider::StreamPublisher& publish) -> std::unique_ptr<juce::InputStream> {
+        juce::ignoreUnused(url, options, publish);
         networkFactoryInvoked = true;
         juce::String jsonResponse =
             R"({"model":"mock-model","message":{"role":"assistant","content":"Should not be reached."}})";
@@ -415,9 +513,10 @@ TEST_F(OllamaProviderTest, SendPromptWithNoModelFailsWithoutHittingNetwork) {
 TEST_F(OllamaProviderTest, SendPromptIncludesSelectedModelInRequestBody) {
     juce::String capturedPostData;
     auto capturingFactory =
-        [&capturedPostData](const juce::URL& url,
-                            const juce::URL::InputStreamOptions& options) -> std::unique_ptr<juce::InputStream> {
-        juce::ignoreUnused(options);
+        [&capturedPostData](
+            const juce::URL& url, const juce::URL::InputStreamOptions& options,
+            const synth::OllamaProvider::StreamPublisher& publish) -> std::unique_ptr<juce::InputStream> {
+        juce::ignoreUnused(options, publish);
         capturedPostData = url.getPostData();
         juce::String jsonResponse =
             R"({"model":"mock-model","message":{"role":"assistant","content":"Mocked AI response."}})";
@@ -584,8 +683,8 @@ TEST_F(OllamaProviderTest, SendPromptTimeoutFails) {
 // REGRESSION LOCK: httpStatus 401/403 must map to AIErrorKind::Auth so the UI can
 // distinguish "sign in again" from other failure modes.
 TEST_F(OllamaProviderTest, MapsUnauthorizedToAuthError) {
-    auto factory = [](const juce::URL&,
-                      const juce::URL::InputStreamOptions& options) -> std::unique_ptr<juce::InputStream> {
+    auto factory = [](const juce::URL&, const juce::URL::InputStreamOptions& options,
+                      const synth::OllamaProvider::StreamPublisher& publish) -> std::unique_ptr<juce::InputStream> {
         if (auto* statusCode = options.getStatusCode())
             *statusCode = 401;
         return nullptr;
@@ -610,8 +709,8 @@ TEST_F(OllamaProviderTest, MapsUnauthorizedToAuthError) {
 // REGRESSION LOCK: httpStatus 429 must map to AIErrorKind::RateLimit and parse a
 // Retry-After header when the server provides one.
 TEST_F(OllamaProviderTest, MapsTooManyRequestsToRateLimit) {
-    auto factory = [](const juce::URL&,
-                      const juce::URL::InputStreamOptions& options) -> std::unique_ptr<juce::InputStream> {
+    auto factory = [](const juce::URL&, const juce::URL::InputStreamOptions& options,
+                      const synth::OllamaProvider::StreamPublisher& publish) -> std::unique_ptr<juce::InputStream> {
         if (auto* statusCode = options.getStatusCode())
             *statusCode = 429;
         if (auto* headers = options.getResponseHeaders())
@@ -655,7 +754,8 @@ TEST_F(OllamaProviderTest, MapsConnectionFailureToNetwork) {
 // REGRESSION LOCK: a 2xx response whose body is not the expected {message:{content:...}}
 // shape must map to AIErrorKind::Schema rather than silently reporting a generic failure.
 TEST_F(OllamaProviderTest, MapsUnparseableBodyToSchema) {
-    auto factory = [](const juce::URL&, const juce::URL::InputStreamOptions&) -> std::unique_ptr<juce::InputStream> {
+    auto factory = [](const juce::URL&, const juce::URL::InputStreamOptions&,
+                      const synth::OllamaProvider::StreamPublisher&) -> std::unique_ptr<juce::InputStream> {
         return std::make_unique<MockInputStream>("not json at all", false);
     };
 
@@ -715,4 +815,257 @@ TEST_F(OllamaProviderTest, EveryResponseCarriesRequestId) {
     EXPECT_FALSE(failureResult.requestId.isEmpty());
     EXPECT_EQ(failureResult.requestId, juce::String(failureId.value));
     EXPECT_EQ(failureResult.error.requestId, failureResult.requestId);
+}
+
+// ============================================================================
+// Cancellation
+//
+// The Cancel button used to be cosmetic: it hid the spinner while the HTTP request ran to
+// completion, so a metered backend still billed for the abandoned work and the serial request
+// queue still made the user's next message wait behind it. These lock the real behaviour in.
+// ============================================================================
+
+// A cancelled request must still get its callback — exactly one — and it must say Cancelled, not
+// "connection failed". An aborted read is indistinguishable from a dead socket at the stream
+// level, so reporting it as a network error would send the user off debugging a problem they
+// created on purpose.
+TEST_F(OllamaProviderTest, CancelledRequestInvokesCallbackWithCancelledKind) {
+    CancellableGatedFactory factory;
+
+    // Declared before the provider so it outlives it: the provider's destructor is a delivery path
+    // too, and a callback observing destroyed locals would be a crash, not a failure.
+    auto done = std::make_shared<CallbackLatch>();
+    std::atomic<int> callCount{0};
+    std::atomic<bool> reportedSuccess{true};
+    std::atomic<synth::AIProvider::AIErrorKind> reportedKind{synth::AIProvider::AIErrorKind::None};
+
+    synth::OllamaProvider provider{"http://mock-host:11434", factory()};
+    provider.setTestMode(true);
+    provider.setModel("mock-model:latest");
+
+    const auto id = provider.sendPrompt({{"user", "Write me a very long story"}},
+                                        [&](const synth::AIProvider::AIResponse& response) {
+                                            callCount.fetch_add(1);
+                                            reportedSuccess.store(response.success);
+                                            reportedKind.store(response.error.kind);
+                                            done->fire();
+                                        });
+
+    ASSERT_NE(id.value, 0u) << "sendPrompt() must hand back a cancellable handle";
+    ASSERT_TRUE(factory.entered->waitFor(kCallbackTimeout)) << "the worker never reached the gated read";
+
+    provider.cancel(id);
+
+    ASSERT_TRUE(done->waitFor(kCallbackTimeout)) << "cancel() left the caller hanging with no callback";
+    EXPECT_EQ(callCount.load(), 1);
+    EXPECT_FALSE(reportedSuccess.load());
+    EXPECT_EQ(reportedKind.load(), synth::AIProvider::AIErrorKind::Cancelled);
+
+    provider.stopThread(5000);
+}
+
+// The queue is drained serially, so an abandoned request that stays in it (or keeps the worker
+// parked in a read) delays every message sent afterwards. Cancelling must free the worker, not
+// just stop reporting to the UI.
+TEST_F(OllamaProviderTest, CancelDoesNotBlockSubsequentRequest) {
+    CancellableGatedFactory factory;
+
+    // Declared before the provider so the latches outlive every delivery path, destructor included.
+    auto firstDone = std::make_shared<CallbackLatch>();
+    auto secondDone = std::make_shared<CallbackLatch>();
+    std::atomic<bool> secondSucceeded{false};
+
+    synth::OllamaProvider provider{"http://mock-host:11434", factory()};
+    provider.setTestMode(true);
+    provider.setModel("mock-model:latest");
+
+    const auto first = provider.sendPrompt({{"user", "Long one"}},
+                                           [firstDone](const synth::AIProvider::AIResponse&) { firstDone->fire(); });
+
+    ASSERT_TRUE(factory.entered->waitFor(kCallbackTimeout)) << "the worker never reached the gated read";
+
+    provider.cancel(first);
+
+    // Sent immediately after the cancel, exactly as a user retyping would. It must be answered on
+    // its own merits rather than waiting out the abandoned generation — whose gate would otherwise
+    // hold the worker for 15 s.
+    provider.sendPrompt({{"user", "Short one"}},
+                        [secondDone, &secondSucceeded](const synth::AIProvider::AIResponse& r) {
+                            secondSucceeded.store(r.success);
+                            secondDone->fire();
+                        });
+
+    using clock = std::chrono::steady_clock;
+    const auto t0 = clock::now();
+    ASSERT_TRUE(secondDone->waitFor(kCallbackTimeout)) << "the request sent after a cancel never completed";
+    const auto elapsedMs = std::chrono::duration_cast<std::chrono::milliseconds>(clock::now() - t0).count();
+
+    EXPECT_TRUE(secondSucceeded.load());
+    EXPECT_LT(elapsedMs, 5000) << "the second request waited " << elapsedMs
+                               << " ms — it is queued behind the cancelled request instead of replacing it";
+
+    EXPECT_TRUE(firstDone->waitFor(kCallbackTimeout)) << "the cancelled request never got its callback";
+
+    provider.stopThread(5000);
+}
+
+// Cancelling a request that was never issued, already finished, or already cancelled must do
+// nothing at all. The UI holds stale handles routinely (a response and a Cancel click cross), so
+// this is the common case, not a defensive edge case.
+TEST_F(OllamaProviderTest, CancelOfUnknownRequestIdIsSafeNoOp) {
+    synth::OllamaProvider provider{"http://mock-host:11434", createSuccessfulChatStream};
+    provider.setTestMode(true);
+    provider.setModel("mock-model:latest");
+
+    // Never issued, and the reserved "nothing in flight" handle.
+    provider.cancel(synth::AIProvider::RequestId{});
+    provider.cancel(synth::AIProvider::RequestId{999999});
+
+    // Already completed: cancelling must not resurrect it or fire a second callback.
+    std::atomic<int> callCount{0};
+    auto done = std::make_shared<CallbackLatch>();
+    const auto id = provider.sendPrompt({{"user", "Hello"}}, [&](const synth::AIProvider::AIResponse&) {
+        callCount.fetch_add(1);
+        done->fire();
+    });
+    ASSERT_TRUE(done->waitFor(kCallbackTimeout));
+
+    provider.cancel(id);
+    provider.cancel(id); // ...and again, to cover double-cancel
+
+    // A stray callback would arrive on the worker thread; give it room to show up.
+    juce::Thread::sleep(200);
+    EXPECT_EQ(callCount.load(), 1) << "cancelling a completed request fired an extra callback";
+
+    provider.stopThread(5000);
+}
+
+// THE race: cancel() and the worker's completion path can reach the same request at the same
+// instant. Both want to finish it, and a caller that gets two callbacks corrupts chat history (or,
+// in the UI, tears down the waiting state twice). Run with --gtest_repeat=100.
+//
+// Each iteration sweeps the cancel across the completion by a growing offset. That matters:
+// spawning both threads with no offset is NOT enough, because cancel() sets the cancelled flag
+// before it releases the read, so the worker always observes the cancel and "completion wins"
+// never actually gets exercised — measured, it was 0 out of 1000 iterations. Offset 0 keeps the
+// simultaneous case; the later offsets give the completion a real head start.
+TEST_F(OllamaProviderTest, CallbackFiresExactlyOnceEvenIfCancelRacesCompletion) {
+    constexpr int kIterations = 25;
+
+    for (int i = 0; i < kIterations; ++i) {
+        CancellableGatedFactory factory;
+
+        // Both declared before the provider so they outlive it — the destructor is itself a
+        // delivery path, and a late callback reading destroyed locals would crash the suite
+        // instead of failing this assertion.
+        std::atomic<int> callCount{0};
+        auto done = std::make_shared<CallbackLatch>();
+
+        synth::OllamaProvider provider{"http://mock-host:11434", factory()};
+        provider.setTestMode(true);
+        provider.setModel("mock-model:latest");
+
+        const auto id = provider.sendPrompt({{"user", "Race me"}}, [&](const synth::AIProvider::AIResponse&) {
+            callCount.fetch_add(1);
+            done->fire();
+        });
+
+        ASSERT_TRUE(factory.entered->waitFor(kCallbackTimeout)) << "iteration " << i << ": worker never started";
+
+        // The completion is released through the shared gate, not the stream — the worker destroys
+        // its stream as soon as a cancelled read returns, so poking the stream from here would be
+        // racing a use-after-free rather than testing anything.
+        auto gate = factory.gate;
+        const auto cancelOffsetUs = std::chrono::microseconds(i * 4);
+
+        std::thread completer([gate]() { gate->release(); });
+        std::thread canceller([&provider, id, cancelOffsetUs]() {
+            // Bounded busy-wait, never a sleep, so the offset stays in the same order of magnitude
+            // as the delivery path it is sweeping across.
+            const auto spinUntil = std::chrono::steady_clock::now() + cancelOffsetUs;
+            while (std::chrono::steady_clock::now() < spinUntil) {
+            }
+            provider.cancel(id);
+        });
+
+        completer.join();
+        canceller.join();
+
+        ASSERT_TRUE(done->waitFor(kCallbackTimeout)) << "iteration " << i << ": no callback fired at all";
+
+        provider.stopThread(5000);
+
+        // Checked after the worker is fully stopped, so a second delivery has had every
+        // opportunity to appear.
+        EXPECT_EQ(callCount.load(), 1) << "iteration " << i << ": callback fired " << callCount.load()
+                                       << " times — cancel and completion both delivered";
+    }
+}
+
+// The two orderings above, pinned down deterministically rather than left to timing. Both must
+// produce exactly one callback, and the kind must reflect who actually won.
+TEST_F(OllamaProviderTest, CancelAndCompletionEachDeliverExactlyOnceInEitherOrder) {
+    // Ordering 1: the response lands first, then a late cancel arrives on a stale handle.
+    {
+        CancellableGatedFactory factory;
+
+        std::atomic<int> callCount{0};
+        std::atomic<synth::AIProvider::AIErrorKind> kind{synth::AIProvider::AIErrorKind::Cancelled};
+        auto done = std::make_shared<CallbackLatch>();
+
+        synth::OllamaProvider provider{"http://mock-host:11434", factory()};
+        provider.setTestMode(true);
+        provider.setModel("mock-model:latest");
+
+        const auto id =
+            provider.sendPrompt({{"user", "Finish first"}}, [&](const synth::AIProvider::AIResponse& response) {
+                callCount.fetch_add(1);
+                kind.store(response.error.kind);
+                done->fire();
+            });
+
+        ASSERT_TRUE(factory.entered->waitFor(kCallbackTimeout));
+
+        factory.gate->release();
+        ASSERT_TRUE(done->waitFor(kCallbackTimeout)) << "the request never completed";
+
+        provider.cancel(id); // stale handle — must be inert
+
+        provider.stopThread(5000);
+        EXPECT_EQ(callCount.load(), 1) << "a cancel after completion produced a second callback";
+        EXPECT_NE(kind.load(), synth::AIProvider::AIErrorKind::Cancelled)
+            << "a request that completed normally was reported as cancelled";
+    }
+
+    // Ordering 2: the cancel lands first, then the response the worker was waiting on arrives
+    // anyway (the server had already started sending). The late data must be discarded.
+    {
+        CancellableGatedFactory factory;
+
+        std::atomic<int> callCount{0};
+        std::atomic<synth::AIProvider::AIErrorKind> kind{synth::AIProvider::AIErrorKind::None};
+        auto done = std::make_shared<CallbackLatch>();
+
+        synth::OllamaProvider provider{"http://mock-host:11434", factory()};
+        provider.setTestMode(true);
+        provider.setModel("mock-model:latest");
+
+        const auto id =
+            provider.sendPrompt({{"user", "Cancel first"}}, [&](const synth::AIProvider::AIResponse& response) {
+                callCount.fetch_add(1);
+                kind.store(response.error.kind);
+                done->fire();
+            });
+
+        ASSERT_TRUE(factory.entered->waitFor(kCallbackTimeout));
+
+        provider.cancel(id);
+        ASSERT_TRUE(done->waitFor(kCallbackTimeout)) << "cancel left the caller hanging";
+
+        factory.gate->release(); // the response arriving too late
+
+        provider.stopThread(5000);
+        EXPECT_EQ(callCount.load(), 1) << "a late response produced a second callback after cancellation";
+        EXPECT_EQ(kind.load(), synth::AIProvider::AIErrorKind::Cancelled);
+    }
 }

--- a/Tests/PanelAnimationAndLoadingTests.cpp
+++ b/Tests/PanelAnimationAndLoadingTests.cpp
@@ -29,16 +29,52 @@ public:
     }
     RequestId sendPrompt(const std::vector<Message>&, CompletionCallback callback, const juce::var&,
                          std::function<void(const juce::String&)> = {}) override {
-        // Intentionally never completes so we can test the cancel path.
-        juce::ignoreUnused(callback);
-        return {};
+        // Intentionally never completes on its own, so a test can decide how the request ends.
+        pendingCallback = std::move(callback);
+        return RequestId{++lastRequestId};
     }
-    void cancel(RequestId) override {}
+
+    // Records what the UI asked us to cancel, so tests can prove the Cancel button and the Escape
+    // key reach the provider instead of only tidying up the UI.
+    void cancel(RequestId requestId) override {
+        cancelledIds.push_back(requestId.value);
+        if (!pendingCallback)
+            return;
+
+        auto callback = std::move(pendingCallback);
+        pendingCallback = nullptr;
+
+        AIResponse response;
+        response.success = false;
+        response.error.kind = AIErrorKind::Cancelled;
+        response.error.message = "Request cancelled.";
+        callback(response);
+    }
+
+    /** Resolves the held request normally, so a test can check what happens after a real response
+        rather than only after a cancel. */
+    void completePending(const juce::String& content) {
+        if (!pendingCallback)
+            return;
+
+        auto callback = std::move(pendingCallback);
+        pendingCallback = nullptr;
+
+        AIResponse response;
+        response.success = true;
+        response.content = content;
+        callback(response);
+    }
+
     void setModel(const juce::String& name) override { model = name; }
     juce::String getCurrentModel() const override { return model; }
 
+    std::vector<uint64_t> cancelledIds;
+    uint64_t lastRequestId = 0;
+
 private:
     juce::String model = "MockModel";
+    CompletionCallback pendingCallback;
 };
 
 // Fixture helper: owns an ApplicationProperties configured for tests.
@@ -308,4 +344,104 @@ TEST_F(PaintSmokeTest, AIChatComponentPaintWaitingState) {
     juce::Image img(juce::Image::ARGB, 400, 600, true);
     juce::Graphics g(img);
     EXPECT_NO_THROW(chat.paint(g));
+}
+
+namespace {
+// Puts the chat component into the waiting state with a request outstanding.
+void enterWaitingState(synth::AIChatComponent& chat) {
+    for (auto* child : chat.getChildren()) {
+        if (auto* editor = dynamic_cast<juce::TextEditor*>(child))
+            editor->setText("hello");
+    }
+    chat.triggerSend();
+}
+} // namespace
+
+// The whole point of the change: Cancel must reach the provider. Before this, cancelRequest() only
+// tidied the UI while the HTTP request ran on -- billed, and blocking the next message.
+TEST_F(AICancelTest, CancelButtonTellsProviderToCancelTheRequest) {
+    AudioEngine engine;
+    synth::AIIntegrationService service(engine.getGraph());
+    auto provider = std::make_unique<MockProviderPAL>();
+    auto* rawProvider = provider.get();
+    service.setProvider(std::move(provider));
+
+    TestPropsOwner propsOwner;
+    synth::AIChatComponent chat(service, propsOwner.props);
+    chat.setSize(400, 600);
+
+    enterWaitingState(chat);
+    ASSERT_TRUE(chat.isWaiting());
+
+    chat.simulateCancelClick();
+
+    ASSERT_EQ(rawProvider->cancelledIds.size(), 1u) << "Cancel did not reach the provider -- it is still cosmetic";
+    EXPECT_EQ(rawProvider->cancelledIds[0], rawProvider->lastRequestId) << "Cancel targeted the wrong request handle";
+    EXPECT_FALSE(chat.isWaiting());
+}
+
+// Escape must do what the Cancel button does. There was no keyPressed override at all before, so
+// this is new behaviour rather than a regression lock.
+TEST_F(AICancelTest, EscapeKeyCancelsInFlightRequest) {
+    AudioEngine engine;
+    synth::AIIntegrationService service(engine.getGraph());
+    auto provider = std::make_unique<MockProviderPAL>();
+    auto* rawProvider = provider.get();
+    service.setProvider(std::move(provider));
+
+    TestPropsOwner propsOwner;
+    synth::AIChatComponent chat(service, propsOwner.props);
+    chat.setSize(400, 600);
+
+    enterWaitingState(chat);
+    ASSERT_TRUE(chat.isWaiting());
+
+    chat.simulateEscapeKey();
+
+    EXPECT_EQ(rawProvider->cancelledIds.size(), 1u) << "Escape did not cancel the in-flight request";
+    EXPECT_FALSE(chat.isWaiting());
+    EXPECT_FALSE(chat.isCancelVisible());
+}
+
+// Escape when nothing is in flight must stay out of the way, so it keeps whatever meaning the
+// enclosing window gives it (closing a panel, dismissing a dialog).
+TEST_F(AICancelTest, EscapeKeyIsIgnoredWhenIdle) {
+    AudioEngine engine;
+    synth::AIIntegrationService service(engine.getGraph());
+    auto provider = std::make_unique<MockProviderPAL>();
+    auto* rawProvider = provider.get();
+    service.setProvider(std::move(provider));
+
+    TestPropsOwner propsOwner;
+    synth::AIChatComponent chat(service, propsOwner.props);
+    chat.setSize(400, 600);
+
+    ASSERT_FALSE(chat.isWaiting());
+    chat.simulateEscapeKey();
+
+    EXPECT_TRUE(rawProvider->cancelledIds.empty()) << "Escape cancelled something while idle";
+}
+
+// A completed request must not be cancelled afterwards: the handle is stale and, on a real
+// provider, could name a request the user has since sent.
+TEST_F(AICancelTest, CancelAfterResponseDoesNotCancelAnything) {
+    AudioEngine engine;
+    synth::AIIntegrationService service(engine.getGraph());
+    auto provider = std::make_unique<MockProviderPAL>();
+    auto* rawProvider = provider.get();
+    service.setProvider(std::move(provider));
+
+    TestPropsOwner propsOwner;
+    synth::AIChatComponent chat(service, propsOwner.props);
+    chat.setSize(400, 600);
+
+    enterWaitingState(chat);
+    ASSERT_TRUE(chat.isWaiting());
+
+    // The response handler posts through the message queue, so let it run.
+    rawProvider->completePending("All done.");
+    juce::MessageManager::getInstance()->runDispatchLoopUntil(50);
+
+    ASSERT_FALSE(chat.isWaiting()) << "the component never left the waiting state";
+    EXPECT_TRUE(rawProvider->cancelledIds.empty()) << "a completed request was cancelled after the fact";
 }

--- a/docs/AI_Engine.md
+++ b/docs/AI_Engine.md
@@ -240,6 +240,76 @@ Three rules make that hold:
 Locked by `OllamaProviderTest.QueuedRequestDuringThreadShutdownStillCompletes` and
 `OllamaProviderTest.PendingRequestsAreFailedOnDestruction`.
 
+### Request Cancellation
+
+`sendPrompt()` returns an `AIProvider::RequestId`; `cancel(id)` abandons that request. This is a
+real abort, not a UI dismissal — the Cancel button used to only hide the spinner while the HTTP
+request ran to completion, which billed a metered backend for work the user had abandoned and,
+because the queue is drained serially, made the *next* message wait behind it.
+
+The contract, which every provider must honour:
+
+1.  **A cancelled request still gets exactly one callback**, with `AIErrorKind::Cancelled`. A caller
+    is never left hanging, and never called twice.
+2.  **It must not block requests queued behind it.** If it is still in the queue, `cancel()` removes
+    it under `queueLock` — the same lock the worker pops with, so exactly one of them ends up owning
+    it. If it is already in flight, the read is aborted so the worker is genuinely free rather than
+    waiting out the response.
+3.  **An unknown, completed or already-cancelled id is a safe no-op.** The UI holds stale handles
+    routinely (a response and a Cancel click cross), so this is the common case. The delivery path
+    deregisters the request, which is what makes a later `cancel()` inert.
+
+`AIIntegrationService` must **not** append an assistant turn for a cancelled request: it produced no
+answer, and `chatHistory` is replayed as context, so an invented turn would be fed back on every
+later message. The user's own turn stays.
+
+#### Publish before connect — the part that makes it work
+
+**The provider does not use `juce::URL::createInputStream()`, and must not start.** A chat request
+sets `"stream": false`, so Ollama sends *nothing at all* — not even response headers — until the
+entire generation is finished. That means `connect()`, not `read()`, is where a request spends
+essentially all of its time. `createInputStream()` connects internally and only hands the stream
+back afterwards, so a factory built on it cannot expose the stream until the generation it was
+supposed to cancel has already completed.
+
+So `InputStreamFactory` takes a third argument, a `StreamPublisher`. The factory constructs the
+`WebInputStream`, calls `publish(stream.get())`, and only then calls `connect()`. A factory must
+also call `publish(nullptr)` before destroying a stream it is not returning, so a concurrent
+`cancel()` can never reach a dead object; every store and load of the pointer is under
+`RequestState::streamLock`.
+
+This was measured, not assumed. Against a live Ollama with a long generation in flight: publishing
+after connect, `cancel()` could not stop the request at all (still running after 10 s); publishing
+before it, the callback fires in **1–8 ms** and the next message is answered in ~100 ms.
+
+How the read is aborted, in order of preference:
+
+-   **`juce::WebInputStream::cancel()`** — the real mechanism, documented to cancel a blocking read
+    and prevent subsequent connection attempts, and safe to call from another thread.
+-   **`synth::CancellableStream`** — an opt-in mix-in for injected test factories, which are not
+    `WebInputStream`s, so tests can unblock a stream by the same route a real socket uses.
+-   **The `cancelled` flag alone** — the fallback for any other stream type. The worker finishes the
+    read and discards the response. Still correct, just not prompt.
+
+Model discovery (`fetchAvailableModels`) passes a no-op publisher: it is not cancellable and is
+bounded by its own 4 s connection timeout.
+
+Locked by `OllamaProviderTest.CancelledRequestInvokesCallbackWithCancelledKind`,
+`CancelDoesNotBlockSubsequentRequest`, `CancelOfUnknownRequestIdIsSafeNoOp`,
+`CallbackFiresExactlyOnceEvenIfCancelRacesCompletion` (run with `--gtest_repeat=100`),
+`CancelAndCompletionEachDeliverExactlyOnceInEitherOrder`,
+`AIIntegrationServiceTest.CancelledRequestDoesNotAppendToHistory`, and the `AICancelTest` UI locks.
+
+> The race test sweeps the cancel across the completion by a growing offset rather than just
+> spawning two threads. Without the offset "completion wins" is never exercised — `cancel()` sets the
+> cancelled flag before releasing the read, so the worker always observes the cancel (measured: 0
+> completion-wins in 1000 iterations; with the sweep, ~860 in 1000).
+
+> **Re-verifying by hand** (the unit tests use a mock stream and therefore cannot cover
+> `WebInputStream::cancel()`): with `ollama serve` running, send a prompt that generates for a while,
+> hit Cancel, and confirm the input frees immediately and the next message is answered without delay.
+> A regression here is invisible to the suite — the mock path would still pass.
+
 ## 6. Future Considerations
 
 -   **Direct Saving of AI Suggested Patches**: Implement functionality for users to directly save AI-generated patches as presets.

--- a/docs/shortcuts.md
+++ b/docs/shortcuts.md
@@ -14,3 +14,13 @@ Shortcuts are configurable in **Settings → Keyboard Shortcuts** tab (renamed f
 | Cmd+A | Toggle AI Panel |
 | Cmd+L | Auto Arrange |
 | Cmd+B | Toggle Module Library Sidebar |
+
+## Context-specific
+
+| Shortcut | Context | Action |
+|----------|---------|--------|
+| Escape | AI panel, request in flight | Cancel the in-flight AI request (same as the Cancel button — actually aborts it, see [`AI_Engine.md`](AI_Engine.md#request-cancellation)) |
+
+Escape is handled by `AIChatComponent::keyPressed()` and only acts while a request is in flight;
+otherwise it is passed through so it keeps whatever meaning the enclosing window gives it. It is not
+user-rebindable — it is a panel-local binding, not part of the `ShortcutManager` table.


### PR DESCRIPTION
Builds on #135, which widened `AIProvider` with `RequestId` / `cancel()` / `AIErrorKind` but left `OllamaProvider::cancel()` an explicit no-op stub. This fills it in.

## The problem

Cancel was cosmetic. `AIChatComponent::cancelRequest()` stopped the timeout timer, hid the spinner and re-enabled input — but never told the provider anything. The HTTP request ran to completion and the late response was swallowed by the `if (!self->isWaitingForResponse) return;` guard. So:

1. A metered hosted backend still billed for work the user had cancelled.
2. `OllamaProvider` drains its queue serially, so the next message silently waited behind the abandoned request.

## What changed

- **`OllamaProvider`** — registry of in-flight requests keyed by `RequestId`, each with an atomic cancelled flag. A still-queued request is removed under the same lock the worker pops with, so it can't block the ones behind it; an in-flight one has its read aborted and the worker delivers. `claimDelivery()` gates both delivery channels, so exactly one callback fires per request.
- **`AIIntegrationService`** — `sendMessage()` returns the `RequestId`, `cancelRequest()` forwards to the provider, and no assistant turn is appended for a cancelled request.
- **`AIChatComponent`** — threads the `RequestId` back so Cancel reaches the provider, and adds **Escape-to-cancel** while a request is in flight.

## The bit that actually made it work

The provider no longer uses `juce::URL::createInputStream()`.

A chat request sets `"stream": false`, so Ollama sends *nothing* — not even headers — until the whole generation finishes. `connect()`, not `read()`, is where the request is spent. `createInputStream()` connects internally and only *then* returns the stream, so `cancel()` had nothing to abort until the generation it was cancelling had already completed. `InputStreamFactory` now takes a `StreamPublisher` and the factory hands over the `WebInputStream` **before** connecting.

**This gap was invisible to the mock-based tests** — they pass either way. It was caught by checking against a live Ollama, with a long generation in flight:

| | cancel latency | next message |
|---|---|---|
| publish *after* connect | never aborted (still running at 10 s) | blocked behind it |
| publish *before* connect | **1–8 ms** | **~100 ms** |

## Tests

New in `OllamaProviderTests.cpp`: `CancelledRequestInvokesCallbackWithCancelledKind`, `CancelDoesNotBlockSubsequentRequest`, `CancelOfUnknownRequestIdIsSafeNoOp`, `CallbackFiresExactlyOnceEvenIfCancelRacesCompletion`, `CancelAndCompletionEachDeliverExactlyOnceInEitherOrder`. Plus `CancelledRequestDoesNotAppendToHistory` (+3 siblings) in `AIIntegrationServiceTests.cpp`, and `AICancelTest` locks that Cancel and Escape actually reach the provider.

One note on the race test: spawning two bare threads **never** exercises "completion wins" — `cancel()` sets the flag before releasing the read, so the worker always observes the cancel (measured 0/1000). It sweeps the cancel across the completion by a growing offset instead, which gets ~860/1000 completion-wins.

## Verification

- Full suite: **663/663 pass** (56 s; my additions add ~1.7 s)
- Race test `--gtest_repeat=100`: 100/100 clean (2,500 racing iterations)
- Both CMake targets build clean; `clang-format` clean
- Manual check against live Ollama (`gemma4:e4b-mlx`), repeated: cancel frees the worker in 1–8 ms, next message answered in 85–870 ms

## Docs

`docs/AI_Engine.md` gains a **Request Cancellation** section covering the contract, the publish-before-connect rationale, and a manual re-verification recipe — the suite structurally cannot cover `WebInputStream::cancel()`, so a regression there would be invisible. `docs/shortcuts.md` documents Escape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011qZ8o9SfgwX1E14Wiho2eJ