### PR TITLE
fix(ai): clear model picker before repopulating on refresh

### DIFF
--- a/Source/UI/AIChatComponent.cpp
+++ b/Source/UI/AIChatComponent.cpp
@@ -618,6 +618,13 @@ void AIChatComponent::updateChatDisplay() {
 void AIChatComponent::scrollToBottom() { viewport.setViewPosition(0, messageList.getHeight()); }
 
 void AIChatComponent::refreshModels() {
+    // refreshModels() is called repeatedly over the component's lifetime (once at
+    // construction with no provider yet, again after MainComponent installs one, and
+    // again whenever Settings triggers a re-fetch) — never just once. Without this
+    // clear(), the second call's addItem(..., 1) collides with whatever already holds
+    // ID 1 (a previously listed model, or the "Error fetching models" placeholder from
+    // a synchronous no-provider callback) and trips ComboBox's duplicate-ID jassert.
+    modelPicker.clear(juce::dontSendNotification);
     modelPicker.addItem("Loading models...", 1);
     modelPicker.setSelectedId(1, juce::dontSendNotification);
     modelPicker.setEnabled(false);

--- a/Tests/AIChatComponentTests.cpp
+++ b/Tests/AIChatComponentTests.cpp
@@ -37,6 +37,41 @@ private:
     juce::String currentModel;
 };
 
+// Like MockChatProvider, but fetchAvailableModels() does not resolve until the test calls
+// resolvePending() — mirrors the real OllamaProvider, whose discovery hop is asynchronous.
+// This lets a test observe modelPicker's state mid-refresh, before the fetch that would
+// otherwise immediately clear() and repopulate it.
+class DeferredChatProvider : public synth::AIProvider {
+public:
+    juce::String getProviderName() const override { return "DeferredChatProvider"; }
+
+    void fetchAvailableModels(std::function<void(const juce::StringArray&, bool)> callback) override {
+        pendingCallback = callback;
+    }
+
+    void resolvePending(const juce::StringArray& models, bool success) {
+        auto callback = pendingCallback;
+        pendingCallback = nullptr;
+        if (callback)
+            callback(models, success);
+    }
+
+    RequestId sendPrompt(const std::vector<synth::AIProvider::Message>&, CompletionCallback callback,
+                         const juce::var& = juce::var(), std::function<void(const juce::String&)> = {}) override {
+        callback(AIResponse{});
+        return {};
+    }
+
+    void cancel(RequestId) override {}
+
+    void setModel(const juce::String& name) override { currentModel = name; }
+    juce::String getCurrentModel() const override { return currentModel; }
+
+private:
+    std::function<void(const juce::StringArray&, bool)> pendingCallback;
+    juce::String currentModel;
+};
+
 class AIChatComponentTest : public ::testing::Test {
 protected:
 };
@@ -141,4 +176,54 @@ TEST_F(AIChatComponentTest, RefreshModelsSelectsModelWhenProviderInstalledAfterC
     chatComponent.refreshModels();
 
     EXPECT_FALSE(service.getCurrentModel().isEmpty());
+}
+
+// REGRESSION LOCK: refreshModels() is called repeatedly over the component's lifetime — once
+// at construction, again whenever SettingsWindow triggers a re-fetch (e.g. after the user
+// changes host/provider). The real OllamaProvider resolves fetchAvailableModels()
+// asynchronously, so there is a window, between the call and its resolution, where a second
+// refresh's "Loading models..." placeholder (item ID 1) coexists with whatever a prior
+// successful fetch already put in the picker (real models, also starting at ID 1). Without
+// clearing first, that second addItem(..., 1) collides with the existing ID — ComboBox::addItem()
+// jasserts on duplicate IDs, and the picker is left holding both the stale and fresh entries
+// for the duration of the fetch. DeferredChatProvider holds its callback so the test can
+// inspect the picker in exactly that window.
+TEST_F(AIChatComponentTest, RefreshModelsClearsStaleItemsBeforeSecondFetchResolves) {
+    AudioEngine engine;
+    synth::AIIntegrationService service(engine.getGraph());
+    auto ownedProvider = std::make_unique<DeferredChatProvider>();
+    auto* provider = ownedProvider.get();
+    service.setProvider(std::move(ownedProvider));
+
+    juce::ApplicationProperties props;
+    juce::PropertiesFile::Options options;
+    options.applicationName = "Test";
+    options.filenameSuffix = "test";
+    options.storageFormat = juce::PropertiesFile::storeAsXML;
+    props.setStorageParameters(options);
+
+    synth::AIChatComponent chatComponent(service, props);
+
+    juce::ComboBox* modelPicker = nullptr;
+    for (auto* child : chatComponent.getChildren()) {
+        if (auto* combo = dynamic_cast<juce::ComboBox*>(child)) {
+            modelPicker = combo;
+            break;
+        }
+    }
+    ASSERT_NE(modelPicker, nullptr);
+
+    // Resolve the ctor's own refresh with two real models.
+    provider->resolvePending({"MockModel1", "MockModel2"}, true);
+    ASSERT_EQ(modelPicker->getNumItems(), 2);
+
+    // Trigger a second refresh (mirrors SettingsWindow re-fetching after a host/provider
+    // change) and inspect the picker BEFORE this one resolves. With the ComboBox correctly
+    // cleared up front, only the "Loading models..." placeholder should be present.
+    chatComponent.refreshModels();
+    EXPECT_EQ(modelPicker->getNumItems(), 1);
+    EXPECT_EQ(modelPicker->getItemText(0), "Loading models...");
+
+    provider->resolvePending({"MockModel1", "MockModel2", "MockModel3"}, true);
+    EXPECT_EQ(modelPicker->getNumItems(), 3);
 }

--- a/docs/AI_Engine.md
+++ b/docs/AI_Engine.md
@@ -251,6 +251,15 @@ with a comment incorrectly claiming the ctor-time call already covered discovery
 `MainComponentTest.AiProviderGetsModelSelectedOnStartup` and
 `AIChatComponentTest.RefreshModelsSelectsModelWhenProviderInstalledAfterConstruction`.
 
+Because `refreshModels()` runs more than once by design (ctor, post-`setProvider()`, and
+again whenever `SettingsWindow` triggers a re-fetch after a host/provider change), it must
+`modelPicker.clear()` before re-adding the `"Loading models..."` placeholder at item ID 1.
+Skipping the clear lets that `addItem(..., 1)` collide with an ID already in the box (a
+model from a prior successful fetch, or the placeholder itself) — `juce::ComboBox::addItem()`
+jasserts on duplicate IDs, and the picker is left showing stale and fresh entries together
+for the duration of the new fetch. Locked by
+`AIChatComponentTest.RefreshModelsClearsStaleItemsBeforeSecondFetchResolves`.
+
 ### AI Provider Registry
 
 Providers are registered once, in `synth::AIProviderRegistry::createDefault()`


### PR DESCRIPTION
## Summary
- `AIChatComponent::refreshModels()` is called repeatedly over the component's lifetime (construction, after `MainComponent` installs a provider, and again whenever `SettingsWindow` triggers a re-fetch after a host/provider change) — never just once.
- Each call re-added a `"Loading models..."` placeholder at ComboBox item ID 1 without clearing first. Once a prior fetch had already populated real models (also starting at ID 1), the next call's `addItem(..., 1)` collided with an existing ID — `juce::ComboBox::addItem()` jasserts on duplicate IDs, and the picker was left showing stale and fresh entries together for the duration of the new fetch.
- Reproduced live: a Debug run trips `JUCE Assertion failure in juce_ComboBox.cpp:102` on the second `refreshModels()` call. This is almost certainly the "error fetching models" behavior reported — most visible after changing the Ollama host/provider in Settings, which re-triggers discovery while the picker already holds a prior model list.
- Fix: `modelPicker.clear()` before re-adding the placeholder, so every refresh starts from an empty box.

## Test plan
- [x] New regression test `AIChatComponentTest.RefreshModelsClearsStaleItemsBeforeSecondFetchResolves` (uses a new `DeferredChatProvider` mock that holds its callback, so the test can inspect the picker mid-refresh). Verified it fails without the fix (3 stale items instead of 1) and passes with it.
- [x] Full suite: `./build/Tests/Tests` — 683/683 passed.
- [x] `clang-format --dry-run --Werror` clean on both changed files.
- [x] Live Debug run confirmed the assertion is gone after the fix (previously reproduced pre-fix).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
