### PR TITLE
feat(ai): add AIEvalHarness for AI patch quality (P2-8)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ coverage/
 *.log
 *.zip
 *.txt
+!CMakeLists.txt
 .claudignore
 .gemini/
 .claude/settings.local.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ FetchContent_MakeAvailable(juce)
 # Coverage Option
 option(ENABLE_COVERAGE "Enable code coverage testing" OFF)
 option(ENABLE_TESTS "Enable building test suite" OFF)
-option(ENABLE_AI_HARNESS "Build the AI patch validity measurement harness (needs a live Ollama)" OFF)
+option(ENABLE_AI_HARNESS "Build the AI patch validity/quality measurement harnesses (needs a live Ollama)" OFF)
 
 # Product identity — the single place to override branding at configure time
 # (e.g. `cmake -S . -B build -DSYNTH_PRODUCT_NAME=MySynth`). Mirrored in C++ at
@@ -86,6 +86,8 @@ add_library(Core STATIC
     Source/AI/AIStateMapper.h
     Source/AI/AIProviderRegistry.h
     Source/AI/AIProviderRegistry.cpp
+    Source/AI/PatchEval.h
+    Source/AI/PatchEval.cpp
     # UI utilities
     Source/UI/LayoutUtil.h
     Source/UI/LayoutUtil.cpp
@@ -291,9 +293,10 @@ if(ENABLE_TESTS)
     add_subdirectory(Tests)
 endif()
 
-# Measurement harness for AI patch validity. Needs a live Ollama, so it is never part of
-# the default build or CI — see Tools/AIPatchHarness/README.md.
+# Measurement harnesses for AI patch validity and quality. Both need a live Ollama, so neither
+# is ever part of the default build or CI — see their READMEs under Tools/.
 if(ENABLE_AI_HARNESS)
     add_subdirectory(Tools/AIPatchHarness)
+    add_subdirectory(Tools/AIEvalHarness)
 endif()
 

--- a/Source/AI/PatchEval.cpp
+++ b/Source/AI/PatchEval.cpp
@@ -1,0 +1,95 @@
+#include "PatchEval.h"
+
+#include <cmath>
+#include <set>
+#include <vector>
+
+namespace synth {
+
+namespace {
+
+const juce::AudioProcessorGraph::Node* findNodeByType(const juce::AudioProcessorGraph& graph,
+                                                      const juce::String& type) {
+    for (auto* node : graph.getNodes())
+        if (node->getProcessor() != nullptr && node->getProcessor()->getName() == type)
+            return node;
+    return nullptr;
+}
+
+// Backward reachability over audio-only connections (MIDI edges don't carry sound) starting at
+// `startId`. Answers "is anything actually plugged into this node's audio input, all the way
+// back to something that makes sound" rather than just "does it have one wire".
+std::set<juce::AudioProcessorGraph::NodeID> reachableBackward(const juce::AudioProcessorGraph& graph,
+                                                              juce::AudioProcessorGraph::NodeID startId) {
+    std::set<juce::AudioProcessorGraph::NodeID> visited;
+    std::vector<juce::AudioProcessorGraph::NodeID> stack{startId};
+    const auto connections = graph.getConnections();
+    while (!stack.empty()) {
+        const auto current = stack.back();
+        stack.pop_back();
+        for (const auto& conn : connections) {
+            if (conn.destination.nodeID == current && !conn.destination.isMIDI() &&
+                visited.find(conn.source.nodeID) == visited.end()) {
+                visited.insert(conn.source.nodeID);
+                stack.push_back(conn.source.nodeID);
+            }
+        }
+    }
+    return visited;
+}
+
+// Whether one parameter's current denormalised value sits within the range (or choice count) it
+// declares. Always true today — JUCE clamps on every write path via
+// NormalisableRange::convertFrom0to1 — but the eval harness exercises the real production path
+// with real model output rather than the values a unit test thinks to try, so it is worth
+// checking rather than assuming.
+bool paramInRange(juce::RangedAudioParameter* p) {
+    const auto range = p->getNormalisableRange();
+    const float value = range.convertFrom0to1(p->getValue());
+    if (!std::isfinite(value) || value < range.start || value > range.end)
+        return false;
+    if (auto* choice = dynamic_cast<juce::AudioParameterChoice*>(p))
+        return choice->getIndex() >= 0 && choice->getIndex() < choice->choices.size();
+    return true;
+}
+
+} // namespace
+
+PatchEvalResult evaluatePatch(const juce::AudioProcessorGraph& graph) {
+    PatchEvalResult result;
+    juce::StringArray reasons;
+
+    const auto* output = findNodeByType(graph, "Audio Output");
+    result.hasAudioOutput = output != nullptr;
+    if (!result.hasAudioOutput)
+        reasons.add("no Audio Output node in the patch");
+
+    if (result.hasAudioOutput) {
+        for (auto id : reachableBackward(graph, output->nodeID)) {
+            const auto* node = graph.getNodeForId(id);
+            if (node != nullptr && node->getProcessor() != nullptr && node->getProcessor()->getName() == "Oscillator") {
+                result.sourceReachesOutput = true;
+                break;
+            }
+        }
+        if (!result.sourceReachesOutput)
+            reasons.add("Audio Output is not reachable from any Oscillator");
+    }
+
+    for (auto* node : graph.getNodes()) {
+        if (node->getProcessor() == nullptr)
+            continue;
+        for (auto* param : node->getProcessor()->getParameters()) {
+            if (auto* ranged = dynamic_cast<juce::RangedAudioParameter*>(param);
+                ranged != nullptr && !paramInRange(ranged)) {
+                result.allParamsInRange = false;
+                reasons.add(node->getProcessor()->getName() + "." + ranged->paramID + " out of declared range");
+            }
+        }
+    }
+
+    result.detail = reasons.joinIntoString("; ");
+    return result;
+}
+
+} // namespace synth

--- a/Source/AI/PatchEval.h
+++ b/Source/AI/PatchEval.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <juce_audio_processors/juce_audio_processors.h>
+
+namespace synth {
+
+/**
+ * @brief Structural, model-independent checks run against a graph an AI patch was applied to.
+ *
+ * These answer a different question than AIStateMapper::validatePatch(): validatePatch only
+ * checks that the JSON is well-formed and every value is legal, which a patch can satisfy while
+ * still being useless (e.g. an "Audio Output" node nobody wired anything into). Used by
+ * Tools/AIEvalHarness to score candidate models against golden prompts.
+ */
+struct PatchEvalResult {
+    bool hasAudioOutput = false;      ///< an "Audio Output" node exists in the graph
+    bool sourceReachesOutput = false; ///< an "Oscillator" is connected, transitively, to it
+    bool allParamsInRange = true;     ///< every parameter's current value lies within its own declared range
+    juce::String detail;              ///< semicolon-joined reasons for any false field above
+
+    bool passed() const { return hasAudioOutput && sourceReachesOutput && allParamsInRange; }
+};
+
+/**
+ * @brief Evaluates the current state of `graph` against the checks in PatchEvalResult.
+ */
+PatchEvalResult evaluatePatch(const juce::AudioProcessorGraph& graph);
+
+} // namespace synth

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -25,6 +25,7 @@ add_executable(Tests
     AIStateMapperTests.cpp
     AIPatchValidationTests.cpp
     AIPatchRetryTests.cpp
+    PatchEvalTests.cpp
     AIProviderRegistryTests.cpp
     OllamaProviderTests.cpp
     MainComponentTests.cpp

--- a/Tests/PatchEvalTests.cpp
+++ b/Tests/PatchEvalTests.cpp
@@ -1,0 +1,177 @@
+// Unit coverage for the structural checks Tools/AIEvalHarness scores golden-prompt patches
+// against. These are pure graph-analysis functions (Source/AI/PatchEval.h) with no dependency on
+// a live model, so — unlike the harness itself — they belong in the regular test suite and CI.
+//
+// Every graph here is built via AIStateMapper::applyJSONToGraph(..., trusted=true), the same
+// entry point AIEvalHarness and preset loading use, rather than hand-assembling
+// juce::AudioProcessorGraph nodes/connections directly.
+
+#include "AI/AIStateMapper.h"
+#include "AI/PatchEval.h"
+#include <gtest/gtest.h>
+#include <juce_audio_processors/juce_audio_processors.h>
+
+namespace synth {
+namespace {
+
+// juce::AudioProcessorGraph has no copy/move constructor, so callers build into an out-param
+// rather than returning by value.
+//
+// A bare AudioProcessorGraph's "Audio Output" IO node mirrors the graph's OWN bus channel
+// count (AudioGraphIOProcessor::setParentGraph), which defaults to zero — a connection into it
+// would silently no-op, exactly like an unconnected node, without this. AudioEngine configures
+// this for real via setPlayConfigDetails()+prepareToPlay() before device audio starts; do the
+// same here so "Audio Output" behaves like it does in the running app.
+void buildGraph(const char* patchJson, juce::AudioProcessorGraph& graph) {
+    graph.setPlayConfigDetails(0, 2, 44100.0, 512);
+    graph.prepareToPlay(44100.0, 512);
+
+    juce::var json = juce::JSON::parse(juce::String(patchJson));
+    EXPECT_TRUE(AIStateMapper::applyJSONToGraph(json, graph, /*clearExisting=*/true, /*trusted=*/true));
+}
+
+TEST(PatchEvalTest, FullyConnectedChainPasses) {
+    juce::AudioProcessorGraph graph;
+    buildGraph(R"({
+        "nodes": [
+            {"id": 1, "type": "Poly MIDI"},
+            {"id": 2, "type": "Oscillator"},
+            {"id": 3, "type": "Filter"},
+            {"id": 4, "type": "Audio Output"}
+        ],
+        "connections": [
+            {"src": 1, "srcPort": -1, "dst": 2, "dstPort": -1},
+            {"src": 2, "srcPort": 0, "dst": 3, "dstPort": 0},
+            {"src": 3, "srcPort": 0, "dst": 4, "dstPort": 0}
+        ]
+    })",
+               graph);
+
+    const auto result = evaluatePatch(graph);
+    EXPECT_TRUE(result.hasAudioOutput);
+    EXPECT_TRUE(result.sourceReachesOutput);
+    EXPECT_TRUE(result.allParamsInRange);
+    EXPECT_TRUE(result.passed()) << result.detail.toStdString();
+}
+
+TEST(PatchEvalTest, MissingAudioOutputFails) {
+    juce::AudioProcessorGraph graph;
+    buildGraph(R"({
+        "nodes": [{"id": 1, "type": "Oscillator"}],
+        "connections": []
+    })",
+               graph);
+
+    const auto result = evaluatePatch(graph);
+    EXPECT_FALSE(result.hasAudioOutput);
+    EXPECT_FALSE(result.sourceReachesOutput);
+    EXPECT_FALSE(result.passed());
+    EXPECT_TRUE(result.detail.contains("Audio Output"));
+}
+
+TEST(PatchEvalTest, UnconnectedOscillatorDoesNotReachOutput) {
+    // Both nodes exist, but nothing wires the oscillator to the output — a model that emits
+    // node soup without connections must not pass.
+    juce::AudioProcessorGraph graph;
+    buildGraph(R"({
+        "nodes": [
+            {"id": 1, "type": "Oscillator"},
+            {"id": 2, "type": "Audio Output"}
+        ],
+        "connections": []
+    })",
+               graph);
+
+    const auto result = evaluatePatch(graph);
+    EXPECT_TRUE(result.hasAudioOutput);
+    EXPECT_FALSE(result.sourceReachesOutput);
+    EXPECT_FALSE(result.passed());
+}
+
+TEST(PatchEvalTest, DanglingChainNeverReachesOutputFails) {
+    // Oscillator -> Filter is wired, but the Filter is never connected onward to Audio Output.
+    juce::AudioProcessorGraph graph;
+    buildGraph(R"({
+        "nodes": [
+            {"id": 1, "type": "Oscillator"},
+            {"id": 2, "type": "Filter"},
+            {"id": 3, "type": "Audio Output"}
+        ],
+        "connections": [
+            {"src": 1, "srcPort": 0, "dst": 2, "dstPort": 0}
+        ]
+    })",
+               graph);
+
+    const auto result = evaluatePatch(graph);
+    EXPECT_TRUE(result.hasAudioOutput);
+    EXPECT_FALSE(result.sourceReachesOutput);
+}
+
+TEST(PatchEvalTest, NonOscillatorFeedIntoOutputDoesNotCountAsSource) {
+    // A Filter fed straight into Audio Output with nothing upstream of it: Audio Output IS
+    // connected to something, but that something is not a sound source.
+    juce::AudioProcessorGraph graph;
+    buildGraph(R"({
+        "nodes": [
+            {"id": 1, "type": "Filter"},
+            {"id": 2, "type": "Audio Output"}
+        ],
+        "connections": [
+            {"src": 1, "srcPort": 0, "dst": 2, "dstPort": 0}
+        ]
+    })",
+               graph);
+
+    const auto result = evaluatePatch(graph);
+    EXPECT_TRUE(result.hasAudioOutput);
+    EXPECT_FALSE(result.sourceReachesOutput);
+}
+
+TEST(PatchEvalTest, MidiOnlyConnectionDoesNotCountAsAudioPath) {
+    // Poly MIDI feeds the Oscillator's MIDI input only; Audio Output is never wired to anything
+    // (contrived, but exercises that a MIDI edge must not be mistaken for an audio path).
+    juce::AudioProcessorGraph graph;
+    buildGraph(R"({
+        "nodes": [
+            {"id": 1, "type": "Poly MIDI"},
+            {"id": 2, "type": "Oscillator"},
+            {"id": 3, "type": "Audio Output"}
+        ],
+        "connections": [
+            {"src": 1, "srcPort": -1, "dst": 2, "dstPort": -1}
+        ]
+    })",
+               graph);
+
+    const auto result = evaluatePatch(graph);
+    EXPECT_TRUE(result.hasAudioOutput);
+    EXPECT_FALSE(result.sourceReachesOutput);
+}
+
+TEST(PatchEvalTest, OutOfRangeRequestIsClampedIntoRangeOnApply) {
+    // Filter cutoff's declared range is [20, 20000] (FilterModule.h); a wildly out-of-range
+    // request is silently clamped by applyParamsToProcessor's snapToLegalValue, not rejected.
+    // This asserts PatchEval sees the resulting (clamped) value as in-range, not the requested
+    // one — the check is exercising the real applied state, not the JSON request.
+    juce::AudioProcessorGraph graph;
+    buildGraph(R"({
+        "nodes": [
+            {"id": 1, "type": "Oscillator"},
+            {"id": 2, "type": "Filter", "params": {"cutoff": 999999.0}},
+            {"id": 3, "type": "Audio Output"}
+        ],
+        "connections": [
+            {"src": 1, "srcPort": 0, "dst": 2, "dstPort": 0},
+            {"src": 2, "srcPort": 0, "dst": 3, "dstPort": 0}
+        ]
+    })",
+               graph);
+
+    const auto result = evaluatePatch(graph);
+    EXPECT_TRUE(result.allParamsInRange);
+    EXPECT_TRUE(result.passed()) << result.detail.toStdString();
+}
+
+} // namespace
+} // namespace synth

--- a/Tools/AIEvalHarness/CMakeLists.txt
+++ b/Tools/AIEvalHarness/CMakeLists.txt
@@ -1,0 +1,22 @@
+add_executable(AIEvalHarness
+    Main.cpp
+    # AppUndoManager.cpp (compiled into Core) references GraphEditor via SafePointer for its
+    # UI-refresh callbacks; Core doesn't compile GraphEditor itself (only AgentSynth/Tests do),
+    # so any executable linking Core must supply it too or the link fails on GraphEditor's vtable
+    # and typeinfo.
+    ${CMAKE_SOURCE_DIR}/Source/UI/GraphEditor.cpp
+    ${CMAKE_SOURCE_DIR}/Source/UI/ModuleComponent.cpp
+    ${CMAKE_SOURCE_DIR}/Source/UI/ModMatrixComponent.cpp
+)
+
+target_link_libraries(AIEvalHarness PRIVATE
+    Core
+    juce::juce_core
+    juce::juce_events
+    juce::juce_audio_basics
+    juce::juce_audio_processors
+)
+
+target_include_directories(AIEvalHarness PRIVATE
+    ${CMAKE_SOURCE_DIR}/Source
+)

--- a/Tools/AIEvalHarness/Main.cpp
+++ b/Tools/AIEvalHarness/Main.cpp
@@ -1,0 +1,316 @@
+/*
+    AIEvalHarness — offline quality evaluation of AI-generated patches against golden prompts.
+
+    AIPatchHarness (Tools/AIPatchHarness) answers "did the model's answer pass validatePatch and
+    survive the retry path" — a syntactic question. This tool answers a different one: of the
+    patches that DID make it into the graph, are they actually usable synthesizer patches? A
+    patch can be perfectly schema-valid and still be silent (nothing wired to Audio Output) or
+    dangling (an oscillator nobody connected to anything).
+
+    It replays a fixed set of 30-50 realistic prompts through the exact production path an
+    Apply/Merge click takes, then runs synth::evaluatePatch() (Source/AI/PatchEval.h) against the
+    resulting graph for every prompt that actually applied:
+
+        AIIntegrationService::sendMessage(useStructuredOutput=true)
+          -> applyPatchWithRetry(...)             # what the user actually ends up with
+          -> evaluatePatch(graph)                 # has an output? connects? params in range?
+
+    This is what lets a cheaper/local candidate model be compared against the current default
+    without guessing — see Tools/AIEvalHarness/README.md for how to use the numbers to decide.
+    Because it needs a live model it is excluded from the test target and from CI; build it
+    explicitly with -DENABLE_AI_HARNESS=ON.
+
+        ./build/Tools/AIEvalHarness/AIEvalHarness [--model M] [--runs N] [--host URL] [--json OUT]
+
+    Exit code is 0 whenever the run completed, whatever the pass rate — the scorecard is the
+    output, not a pass/fail verdict.
+*/
+
+#include "AI/AIIntegrationService.h"
+#include "AI/AIStateMapper.h"
+#include "AI/OllamaProvider.h"
+#include "AI/PatchEval.h"
+
+#include <juce_audio_processors/juce_audio_processors.h>
+#include <juce_core/juce_core.h>
+#include <juce_events/juce_events.h>
+
+#include <cstdio>
+#include <vector>
+
+namespace {
+
+// One replayed scenario: what the user types, and what patch (if any) is already on the
+// canvas when they type it. `seedPatch` is applied trusted, exactly as loading a preset
+// would, so merge-mode prompts see realistic pre-existing node ids.
+struct Scenario {
+    const char* name;
+    const char* prompt;
+    bool mergeMode;
+    const char* seedPatch; // nullptr for a from-scratch (replace-mode) request
+};
+
+// A small but real starting patch: MIDI -> Oscillator -> Filter -> VCA -> Output.
+constexpr const char* kBasicPatch = R"({
+  "nodes": [
+    {"id": 1, "type": "Poly MIDI"},
+    {"id": 2, "type": "Oscillator", "params": {"waveform": "Saw"}},
+    {"id": 3, "type": "Filter", "params": {"cutoff": 2000.0}},
+    {"id": 4, "type": "VCA"},
+    {"id": 5, "type": "Audio Output"}
+  ],
+  "connections": [
+    {"src": 1, "srcPort": -1, "dst": 2, "dstPort": -1},
+    {"src": 2, "srcPort": 0, "dst": 3, "dstPort": 0},
+    {"src": 3, "srcPort": 0, "dst": 4, "dstPort": 0},
+    {"src": 4, "srcPort": 0, "dst": 5, "dstPort": 0}
+  ]
+})";
+
+// 40 prompts a real user would plausibly type, spanning both modes and every module family
+// (oscillators, filters, envelopes, every FX module, poly/sequencing, external MIDI, and
+// parameter-only tweaks). Kept as one flat golden set rather than per-prompt bespoke
+// assertions: every scenario is scored on the same three structural checks in PatchEval.h, so
+// what varies across scenarios is coverage of the module surface, not the pass criteria.
+const std::vector<Scenario>& scenarios() {
+    static const std::vector<Scenario> s = {
+        // --- from scratch (replace mode) ---
+        {"basic-bass", "Create a fat analog bass patch", false, nullptr},
+        {"pluck", "Make a short plucky lead sound", false, nullptr},
+        {"pad", "Build a warm evolving pad with a slow filter sweep", false, nullptr},
+        {"acid", "Create an acid bassline with a resonant filter and a sequencer", false, nullptr},
+        {"bell", "Design a bell-like FM tone", false, nullptr},
+        {"drone", "Make a dark drone with reverb", false, nullptr},
+        {"stab", "Create a bright synth stab with a fast envelope", false, nullptr},
+        {"organ", "Build a simple organ patch with multiple oscillators", false, nullptr},
+        {"noise-sweep", "Make a white noise sweep riser", false, nullptr},
+        {"poly-keys", "Create a polyphonic keys patch with chorus", false, nullptr},
+        {"mastering-chain", "Build a patch with compression and limiting on the output", false, nullptr},
+        {"flanger-sweep", "Create a swirling flanger effect on a saw wave", false, nullptr},
+        {"poly-pad", "Build a polyphonic pad using Poly MIDI and a voice mixer", false, nullptr},
+        {"sequenced-arp", "Make a sequenced arpeggio with a poly sequencer", false, nullptr},
+        {"sidechain-pump", "Create a pumping bass sound with heavy compression", false, nullptr},
+        {"ext-midi-lead", "Build a lead patch driven by external MIDI input", false, nullptr},
+        {"double-osc-unison", "Create a thick unison lead with two oscillators", false, nullptr},
+        {"ambient-wash", "Design an ambient wash with chorus, phaser, and reverb", false, nullptr},
+        {"percussive-pluck", "Make a percussive pluck with a fast filter envelope", false, nullptr},
+        {"vintage-organ", "Build a vintage organ patch with a slow chorus and a flanger", false, nullptr},
+
+        // --- modify an existing patch (merge mode) ---
+        {"add-reverb", "Add reverb to the end of the chain", true, kBasicPatch},
+        {"add-lfo-cutoff", "Add an LFO modulating the filter cutoff", true, kBasicPatch},
+        {"brighter", "Make it brighter", true, kBasicPatch},
+        {"add-delay", "Add a delay after the filter", true, kBasicPatch},
+        {"change-wave", "Change the oscillator to a square wave", true, kBasicPatch},
+        {"add-env", "Add an amp envelope controlling the VCA", true, kBasicPatch},
+        {"remove-filter", "Remove the filter from the patch", true, kBasicPatch},
+        {"add-distortion", "Add some distortion for grit", true, kBasicPatch},
+        {"detune", "Detune the oscillator slightly for width", true, kBasicPatch},
+        {"add-chorus-delay", "Add chorus and then a delay at the end", true, kBasicPatch},
+        {"slower-attack", "Make the attack slower", true, kBasicPatch},
+        {"more-resonance", "Increase the filter resonance", true, kBasicPatch},
+        {"add-compressor", "Add a compressor for punch", true, kBasicPatch},
+        {"add-limiter", "Add a limiter at the very end", true, kBasicPatch},
+        {"add-flanger", "Add a flanger for movement", true, kBasicPatch},
+        {"add-lfo-pitch", "Add an LFO for subtle pitch vibrato", true, kBasicPatch},
+        {"add-filter-env", "Add a filter envelope controlling the cutoff", true, kBasicPatch},
+        {"quieter", "Make it quieter", true, kBasicPatch},
+        {"remove-vca", "Remove the VCA", true, kBasicPatch},
+        {"attenuverted-lfo", "Add an LFO modulating the cutoff at reduced depth", true, kBasicPatch},
+    };
+    return s;
+}
+
+juce::String argValue(const juce::StringArray& args, const juce::String& flag, const juce::String& fallback) {
+    int i = args.indexOf(flag);
+    if (i >= 0 && i + 1 < args.size())
+        return args[i + 1];
+    return fallback;
+}
+
+// Result of replaying one scenario once.
+struct Outcome {
+    bool responded = false;         // the provider returned a successful completion at all
+    bool appliedAfterRetry = false; // what the user actually ends up with
+    juce::String applyError;
+
+    // Only meaningful when appliedAfterRetry is true — there is no graph worth scoring otherwise.
+    bool evaluated = false;
+    synth::PatchEvalResult eval;
+};
+
+Outcome runScenario(const Scenario& scenario, const juce::String& host, const juce::String& model) {
+    Outcome outcome;
+
+    juce::AudioProcessorGraph graph;
+    // "Audio Output" mirrors the graph's own bus channel count (AudioGraphIOProcessor); without
+    // configuring it the way AudioEngine does before device audio starts, it reports zero
+    // channels and every connection into it silently no-ops, making every scenario look
+    // unconnected regardless of what the model actually produced.
+    graph.setPlayConfigDetails(0, 2, 44100.0, 512);
+    graph.prepareToPlay(44100.0, 512);
+
+    if (scenario.seedPatch != nullptr) {
+        juce::var seed = juce::JSON::parse(juce::String(scenario.seedPatch));
+        // trusted=true: this is our own fixture, not model output.
+        if (!synth::AIStateMapper::applyJSONToGraph(seed, graph, /*clearExisting=*/true, /*trusted=*/true)) {
+            outcome.applyError = "harness error: seed patch failed to apply";
+            return outcome;
+        }
+    }
+
+    synth::AIIntegrationService service(graph);
+    auto provider = std::make_unique<synth::OllamaProvider>(host);
+    provider->setTestMode(true); // deliver callbacks synchronously; no message loop here
+    provider->setModel(model);
+    service.setProvider(std::move(provider));
+
+    juce::WaitableEvent done;
+    juce::String responseText;
+    bool success = false;
+
+    service.sendMessage(
+        scenario.prompt,
+        [&](const synth::AIProvider::AIResponse& response) {
+            responseText = response.success ? response.content : response.error.message;
+            success = response.success;
+            done.signal();
+        },
+        /*useStructuredOutput=*/true);
+
+    if (!done.wait(180000)) {
+        outcome.applyError = "timed out waiting for model";
+        return outcome;
+    }
+    if (!success) {
+        outcome.applyError = "provider error: " + responseText;
+        return outcome;
+    }
+    outcome.responded = true;
+
+    juce::WaitableEvent applied;
+    service.applyPatchWithRetry(responseText, scenario.mergeMode, [&](bool ok, const juce::String& error) {
+        outcome.appliedAfterRetry = ok;
+        outcome.applyError = error;
+        applied.signal();
+    });
+
+    if (!applied.wait(600000)) {
+        outcome.applyError = "timed out during retry";
+        return outcome;
+    }
+
+    if (outcome.appliedAfterRetry) {
+        outcome.eval = synth::evaluatePatch(graph);
+        outcome.evaluated = true;
+    }
+
+    return outcome;
+}
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+    juce::ScopedJuceInitialiser_GUI juceInit;
+
+    juce::StringArray args;
+    for (int i = 1; i < argc; ++i)
+        args.add(juce::String(argv[i]));
+
+    const juce::String host = argValue(args, "--host", "http://localhost:11434");
+    const juce::String model = argValue(args, "--model", "gemma4:12b-it-qat");
+    const int runs = juce::jmax(1, argValue(args, "--runs", "1").getIntValue());
+    const juce::String jsonOut = argValue(args, "--json", "");
+
+    std::printf("AIEvalHarness  host=%s  model=%s  runs=%d  scenarios=%d\n", host.toRawUTF8(), model.toRawUTF8(), runs,
+                (int)scenarios().size());
+    std::printf("%-20s %-6s %s\n", "scenario", "run", "outcome");
+    std::printf("--------------------------------------------------------------------\n");
+
+    int total = 0, providerErrors = 0, notApplied = 0, applied = 0;
+    int passOutput = 0, passConnects = 0, passParams = 0, passAll = 0;
+    juce::Array<juce::var> records;
+
+    for (int run = 1; run <= runs; ++run) {
+        for (const auto& scenario : scenarios()) {
+            const auto outcome = runScenario(scenario, host, model);
+            ++total;
+
+            juce::String label;
+            if (!outcome.responded) {
+                ++providerErrors;
+                label = "PROVIDER-ERROR " + outcome.applyError;
+            } else if (!outcome.appliedAfterRetry) {
+                ++notApplied;
+                label = "NOT-APPLIED " + outcome.applyError;
+            } else {
+                ++applied;
+                const auto& e = outcome.eval;
+                if (e.hasAudioOutput)
+                    ++passOutput;
+                if (e.sourceReachesOutput)
+                    ++passConnects;
+                if (e.allParamsInRange)
+                    ++passParams;
+                if (e.passed())
+                    ++passAll;
+                label = e.passed() ? "PASS" : ("FAIL " + e.detail);
+            }
+
+            std::printf("%-20s %-6d %s\n", scenario.name, run, label.toRawUTF8());
+            std::fflush(stdout);
+
+            juce::DynamicObject::Ptr rec = new juce::DynamicObject();
+            rec->setProperty("scenario", scenario.name);
+            rec->setProperty("run", run);
+            rec->setProperty("merge", scenario.mergeMode);
+            rec->setProperty("responded", outcome.responded);
+            rec->setProperty("appliedAfterRetry", outcome.appliedAfterRetry);
+            rec->setProperty("applyError", outcome.applyError);
+            if (outcome.evaluated) {
+                rec->setProperty("hasAudioOutput", outcome.eval.hasAudioOutput);
+                rec->setProperty("sourceReachesOutput", outcome.eval.sourceReachesOutput);
+                rec->setProperty("allParamsInRange", outcome.eval.allParamsInRange);
+                rec->setProperty("detail", outcome.eval.detail);
+            }
+            records.add(juce::var(rec.get()));
+        }
+    }
+
+    // Quality is only meaningful for patches that actually applied — a provider error or a
+    // rejected patch can't be scored against PatchEval, so `applied` (not `total`) is the
+    // denominator for every rate below.
+    const double rate = applied > 0 ? (100.0 * passAll / applied) : 0.0;
+
+    std::printf("\n=================== SUMMARY ===================\n");
+    std::printf("attempts (model responded): %d / %d\n", total - providerErrors, total);
+    std::printf("applied (what the user gets): %d\n", applied);
+    if (providerErrors > 0)
+        std::printf("provider errors (excluded): %d\n", providerErrors);
+    if (notApplied > 0)
+        std::printf("never applied (excluded from quality rate): %d\n", notApplied);
+    std::printf("\nof the %d applied patches:\n", applied);
+    std::printf("  has Audio Output:            %3d  (%.1f%%)\n", passOutput,
+                applied > 0 ? 100.0 * passOutput / applied : 0.0);
+    std::printf("  source reaches Audio Output: %3d  (%.1f%%)\n", passConnects,
+                applied > 0 ? 100.0 * passConnects / applied : 0.0);
+    std::printf("  all params in range:         %3d  (%.1f%%)\n", passParams,
+                applied > 0 ? 100.0 * passParams / applied : 0.0);
+    std::printf("  ALL THREE (overall pass):    %3d  (%.1f%%)\n", passAll, rate);
+    std::printf("===============================================\n");
+
+    if (jsonOut.isNotEmpty()) {
+        juce::DynamicObject::Ptr root = new juce::DynamicObject();
+        root->setProperty("model", model);
+        root->setProperty("runs", runs);
+        root->setProperty("applied", applied);
+        root->setProperty("passAll", passAll);
+        root->setProperty("providerErrors", providerErrors);
+        root->setProperty("notApplied", notApplied);
+        root->setProperty("records", records);
+        juce::File(jsonOut).replaceWithText(juce::JSON::toString(juce::var(root.get()), true));
+        std::printf("wrote %s\n", jsonOut.toRawUTF8());
+    }
+
+    return 0;
+}

--- a/Tools/AIEvalHarness/README.md
+++ b/Tools/AIEvalHarness/README.md
@@ -1,0 +1,77 @@
+# AIEvalHarness
+
+Scores how often AI-generated patches that actually apply are *usable* synthesizer patches, not
+just schema-valid JSON. This is what lets you safely move to a cheaper or local model later —
+without it, every cost optimization is a guess about quality.
+
+It is a measurement instrument, not a test. It needs a live Ollama instance, so it is excluded
+from `Tests` and from CI, and must be opted into at configure time.
+
+## Running
+
+```bash
+cmake -S . -B build -DENABLE_AI_HARNESS=ON
+cmake --build build --target AIEvalHarness
+./build/Tools/AIEvalHarness/AIEvalHarness \
+    --model artifish/llama3.2-uncensored:latest --runs 2 --json out.json
+```
+
+| Flag | Default | Meaning |
+| :--- | :--- | :--- |
+| `--model` | `gemma4:12b-it-qat` | Ollama model tag. Must be one `ollama list` reports. |
+| `--runs` | `1` | How many times to replay the whole scenario set. |
+| `--host` | `http://localhost:11434` | Ollama base URL. |
+| `--json` | *(none)* | Write per-attempt records to this file for later analysis. |
+
+## How this differs from AIPatchHarness
+
+`Tools/AIPatchHarness` asks "did the model's answer pass `validatePatch` and survive the retry
+path" — a syntactic question about the JSON. This tool asks a different one: of the patches that
+*did* make it into the graph, are they patches a user would actually want? A patch can be
+perfectly schema-valid and still be silent (nothing wired to Audio Output) or dangling (an
+oscillator nobody connected to anything) — `validatePatch` has no opinion on either, because
+both are structurally legal graphs.
+
+## What it replays
+
+40 realistic prompts, split between building a patch from scratch (replace mode) and modifying
+an existing one (merge mode), spanning every module family in the app: oscillators, filters,
+envelopes, every FX module, poly/sequencing, external MIDI, and parameter-only tweaks ("make it
+brighter", "increase the resonance"). Merge scenarios first apply a fixed seed patch — MIDI ->
+Oscillator -> Filter -> VCA -> Output — as *trusted* JSON, exactly like `AIPatchHarness`.
+
+Each attempt follows the exact production path an Apply/Merge click takes, then scores the
+result:
+
+```
+sendMessage(useStructuredOutput=true)
+  -> applyPatchWithRetry(...)      # what the user actually ends up with
+  -> evaluatePatch(graph)          # Source/AI/PatchEval.h
+```
+
+`evaluatePatch` runs three structural checks against the resulting `juce::AudioProcessorGraph`,
+unit-tested independently of any model in `Tests/PatchEvalTests.cpp`:
+
+- **has an output** — an `Audio Output` node exists in the graph.
+- **connects** — that `Audio Output` is reachable, following audio (not MIDI) connections
+  backward, from some `Oscillator` — i.e. there is an actual sound path from a source to the
+  speaker, not just isolated nodes sharing a canvas.
+- **params in range** — every parameter's current value lies within its own declared range (and,
+  for choice parameters, its index is a legal choice). This is guaranteed today by
+  `NormalisableRange::convertFrom0to1` clamping on every write path, so it is defense-in-depth
+  against a future regression rather than something expected to fail — but it exercises the
+  values *real model output* actually produces, not just the ones a unit test thinks to try.
+
+## Reading the output
+
+Quality is only meaningful for patches that actually applied — a provider error or a rejected
+patch can't be scored against `PatchEval`, so **applied** (not the number of scenarios) is the
+denominator for every percentage. A model that validates well in `AIPatchHarness` but scores
+poorly here is producing schema-legal patches that don't actually do anything — worth knowing
+before switching the default model to it.
+
+## Caveats
+
+Same as `Tools/AIPatchHarness`: not every backend enforces the JSON schema as a grammar (MLX
+models fall back to prompt compliance), `OllamaProvider` gives up after 120s per request, and
+results are model- and machine-dependent — quote the model tag alongside any number.

--- a/Tools/AIPatchHarness/CMakeLists.txt
+++ b/Tools/AIPatchHarness/CMakeLists.txt
@@ -1,0 +1,22 @@
+add_executable(AIPatchHarness
+    Main.cpp
+    # AppUndoManager.cpp (compiled into Core) references GraphEditor via SafePointer for its
+    # UI-refresh callbacks; Core doesn't compile GraphEditor itself (only AgentSynth/Tests do),
+    # so any executable linking Core must supply it too or the link fails on GraphEditor's vtable
+    # and typeinfo.
+    ${CMAKE_SOURCE_DIR}/Source/UI/GraphEditor.cpp
+    ${CMAKE_SOURCE_DIR}/Source/UI/ModuleComponent.cpp
+    ${CMAKE_SOURCE_DIR}/Source/UI/ModMatrixComponent.cpp
+)
+
+target_link_libraries(AIPatchHarness PRIVATE
+    Core
+    juce::juce_core
+    juce::juce_events
+    juce::juce_audio_basics
+    juce::juce_audio_processors
+)
+
+target_include_directories(AIPatchHarness PRIVATE
+    ${CMAKE_SOURCE_DIR}/Source
+)

--- a/Tools/AIPatchHarness/README.md
+++ b/Tools/AIPatchHarness/README.md
@@ -6,12 +6,16 @@ Measures how often AI-generated patches actually pass `AIStateMapper::validatePa
 It is a measurement instrument, not a test. It needs a live Ollama instance, so it is excluded
 from `Tests` and from CI, and must be opted into at configure time.
 
+This answers a syntactic question — did the JSON pass validation. For whether patches that *do*
+apply are actually usable (has an output, connects to a source, params in range), see
+`Tools/AIEvalHarness` instead.
+
 ## Running
 
 ```bash
 cmake -S . -B build -DENABLE_AI_HARNESS=ON
 cmake --build build --target AIPatchHarness
-./build/Tools/AIPatchHarness/AIPatchHarness_artefacts/AIPatchHarness \
+./build/Tools/AIPatchHarness/AIPatchHarness \
     --model artifish/llama3.2-uncensored:latest --runs 2 --json out.json
 ```
 

--- a/docs/AI_Engine.md
+++ b/docs/AI_Engine.md
@@ -120,6 +120,13 @@ security boundary and is never relaxed to raise the pass rate; everything below 
 and tallies rejections by `PatchValidationError`. It needs a live Ollama, so it is opt-in
 (`-DENABLE_AI_HARNESS=ON`) and excluded from CI. See its README for flags and caveats.
 
+`Tools/AIEvalHarness` answers a different question: of the patches that *do* pass validation and
+apply, are they usable — an output wired to a source, not just schema-legal JSON? It scores 40
+golden prompts against `Source/AI/PatchEval.h`'s structural checks (unit-tested in
+`Tests/PatchEvalTests.cpp`, model-independently) and is what makes switching to a cheaper or local
+model a measured decision instead of a guess. Same opt-in flag, same exclusion from CI — see its
+README.
+
 Two facts that measurement established, and that any future change here should be re-checked
 against:
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -200,12 +200,26 @@ live Ollama, so it is opt-in and never built by CI:
 ```bash
 cmake -S . -B build -DENABLE_AI_HARNESS=ON
 cmake --build build --target AIPatchHarness
-./build/Tools/AIPatchHarness/AIPatchHarness_artefacts/AIPatchHarness --model <tag> --runs 2
+./build/Tools/AIPatchHarness/AIPatchHarness --model <tag> --runs 2
 ```
 
 See `Tools/AIPatchHarness/README.md` — in particular that `format` enforcement is backend-dependent
 and that `OllamaProvider` times out at 120 s, which shows up as a provider error rather than a
 rejection.
+
+`Tools/AIEvalHarness` scores a different thing: of the patches that pass validation and apply, are
+they actually usable — has an output, that output is reachable from a real sound source, every
+parameter in range? It replays 40 golden prompts and runs `Source/AI/PatchEval.h`'s checks against
+the resulting graph. Same opt-in flag:
+
+```bash
+cmake -S . -B build -DENABLE_AI_HARNESS=ON
+cmake --build build --target AIEvalHarness
+./build/Tools/AIEvalHarness/AIEvalHarness --model <tag> --runs 2
+```
+
+The structural checks themselves (`evaluatePatch()`) have no model dependency and are covered by
+`Tests/PatchEvalTests.cpp` in the regular suite — only the golden-prompt replay needs Ollama.
 
 ## Adding Tests for New Modules
 


### PR DESCRIPTION
## Summary
- Adds `Tools/AIEvalHarness`, a 40-golden-prompt harness that scores whether AI-generated patches that pass validation and apply are actually *usable* — has an Audio Output, that output is reachable from a real source (Oscillator), and every parameter is within its declared range. Complements `Tools/AIPatchHarness` (which only measures schema validity), and is what lets a cheaper/local model be swapped in later as a measured decision instead of a guess (roadmap item P2-8).
- New `Source/AI/PatchEval.h`/`.cpp` holds the three structural checks as pure graph-analysis functions, unit-tested independently of any model in `Tests/PatchEvalTests.cpp` (7 new tests).
- Fixes two latent bugs uncovered while building this that made `Tools/AIPatchHarness` completely unbuildable since it was introduced:
  - Its `CMakeLists.txt` was silently discarded by a blanket `*.txt` `.gitignore` rule — `cmake -DENABLE_AI_HARNESS=ON` failed at configure time with "does not contain a CMakeLists.txt file". Scoped the rule with `!CMakeLists.txt`.
  - `Core`'s `AppUndoManager.cpp` references `GraphEditor` via `SafePointer` for UI-refresh callbacks, but `Core` doesn't compile `GraphEditor.cpp` itself (only `AgentSynth`/`Tests` do) — any other executable linking `Core` fails at link time on `GraphEditor`'s vtable/typeinfo. Added `GraphEditor.cpp`/`ModuleComponent.cpp`/`ModMatrixComponent.cpp` to both harness targets.

## Test plan
- [x] `cmake -S . -B build -DENABLE_TESTS=ON -DENABLE_AI_HARNESS=ON && cmake --build build --target Tests AIPatchHarness AIEvalHarness` — all three targets build clean
- [x] `./build/Tests/Tests` — 689/689 tests pass (including the 7 new `PatchEvalTest.*`)
- [x] Smoke-tested `AIEvalHarness` against a live local Ollama (`gemma4:12b-it-qat`, then `artifish/llama3.2-uncensored:latest`) — confirmed it reaches the model, applies patches, and scores them correctly (including catching a real weak-model failure mode: consistently omitting the Audio Output node)
- [ ] Full 40-scenario `--runs 1` pass against a candidate model, for anyone using this to make an actual model-switch decision

🤖 Generated with [Claude Code](https://claude.com/claude-code)