### PR TITLE
fix(ai): raise OllamaProvider's chat request timeout from 120s to 240s

### DIFF
--- a/Source/AI/OllamaProvider.cpp
+++ b/Source/AI/OllamaProvider.cpp
@@ -14,6 +14,17 @@ constexpr int kIdleWaitMs = 1000;
 // practice this costs JUCE's ~2 ms teardown poll.
 constexpr int kWorkerHandoverTimeoutMs = 2000;
 
+// Ollama's chat endpoint is non-streaming: it sends nothing back at all, not even headers,
+// until generation is completely finished (see the StreamPublisher comment below). That makes
+// this the effective ceiling on how long a model has to produce a full response, not just a
+// connect timeout — a model slower than this is indistinguishable from Ollama being down. Was
+// 120s; raised after Tools/AIEvalHarness measured gemma4:12b-it-qat averaging ~180s/request on
+// real hardware, meaning most of its requests were failing on this timeout alone, not on
+// quality. The UI has a real cancel button (AIChatComponent's thinking spinner + Escape), so a
+// longer bound doesn't trap a user who doesn't want to wait — it just stops auto-failing a model
+// that's still working.
+constexpr int kChatRequestTimeoutMs = 240000;
+
 const char* const kShuttingDownMessage = "Error: Request cancelled - the Ollama provider is shutting down.";
 
 // Delivered with AIErrorKind::Cancelled. Callers are expected to branch on the kind rather than
@@ -587,7 +598,7 @@ void OllamaProvider::processRequest(const Request& req) {
 
     stream = createStream(url.withPOSTData(jsonString),
                           juce::URL::InputStreamOptions(juce::URL::ParameterHandling::inPostData)
-                              .withConnectionTimeoutMs(120000)
+                              .withConnectionTimeoutMs(kChatRequestTimeoutMs)
                               .withStatusCode(&httpStatus)
                               .withResponseHeaders(&responseHeaders),
                           publish);

--- a/Tools/AIEvalHarness/Main.cpp
+++ b/Tools/AIEvalHarness/Main.cpp
@@ -178,7 +178,10 @@ Outcome runScenario(const Scenario& scenario, const juce::String& host, const ju
         },
         /*useStructuredOutput=*/true);
 
-    if (!done.wait(180000)) {
+    // Must exceed OllamaProvider's own kChatRequestTimeoutMs (currently 240s) with margin, or this
+    // outer wait fires first and reports a vague "timed out" instead of OllamaProvider's real
+    // provider-error message.
+    if (!done.wait(270000)) {
         outcome.applyError = "timed out waiting for model";
         return outcome;
     }

--- a/Tools/AIEvalHarness/README.md
+++ b/Tools/AIEvalHarness/README.md
@@ -73,5 +73,11 @@ before switching the default model to it.
 ## Caveats
 
 Same as `Tools/AIPatchHarness`: not every backend enforces the JSON schema as a grammar (MLX
-models fall back to prompt compliance), `OllamaProvider` gives up after 120s per request, and
-results are model- and machine-dependent — quote the model tag alongside any number.
+models fall back to prompt compliance), `OllamaProvider` gives up after 240s per request (see
+`kChatRequestTimeoutMs` in `OllamaProvider.cpp` — Ollama's chat endpoint is non-streaming, so this
+doubles as the model's real time-to-finish budget, not just a connect timeout), and results are
+model- and machine-dependent — quote the model tag alongside any number. A model that times out
+scores as `NOT-APPLIED`, indistinguishable from Ollama being unreachable — the first six-model
+sweep run against this harness caught exactly this with `gemma4:12b-it-qat` (~180s/request
+average, close enough to the old 120s bound that most of its attempts failed on timing, not
+quality).

--- a/Tools/AIPatchHarness/Main.cpp
+++ b/Tools/AIPatchHarness/Main.cpp
@@ -153,7 +153,10 @@ Outcome runScenario(const Scenario& scenario, const juce::String& host, const ju
         },
         /*useStructuredOutput=*/true);
 
-    if (!done.wait(180000)) {
+    // Must exceed OllamaProvider's own kChatRequestTimeoutMs (currently 240s) with margin, or this
+    // outer wait fires first and reports a vague "timed out" instead of OllamaProvider's real
+    // provider-error message.
+    if (!done.wait(270000)) {
         outcome.message = "timed out waiting for model";
         return outcome;
     }

--- a/Tools/AIPatchHarness/README.md
+++ b/Tools/AIPatchHarness/README.md
@@ -62,7 +62,9 @@ flatter the result.
   llama.cpp models, but MLX-backed models (e.g. `gemma4:e4b-mlx`) ignore it and fall back to
   prompt compliance — they will happily emit fenced Markdown. Schema-side fixes therefore show up
   on llama.cpp models and not on MLX ones; retries cover both.
-- **`OllamaProvider` gives up after 120 s.** A model slower than that per request (on this machine,
-  `gemma4:12b-it-qat` averaged ~180 s) reports as a provider error rather than a rejection. Pick a
+- **`OllamaProvider` gives up after 240 s** (`kChatRequestTimeoutMs` in `OllamaProvider.cpp`; was
+  120 s until this was measured with `gemma4:12b-it-qat` averaging ~180 s per request on real
+  hardware — most of its requests were failing on the timeout alone, not on quality). A model
+  slower than the current bound still reports as a provider error rather than a rejection. Pick a
   model that answers within the timeout, or the run measures the timeout instead of the model.
 - Results are model- and machine-dependent. Quote the model tag alongside any number.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -204,8 +204,8 @@ cmake --build build --target AIPatchHarness
 ```
 
 See `Tools/AIPatchHarness/README.md` — in particular that `format` enforcement is backend-dependent
-and that `OllamaProvider` times out at 120 s, which shows up as a provider error rather than a
-rejection.
+and that `OllamaProvider` times out at 240 s (`kChatRequestTimeoutMs`), which shows up as a
+provider error rather than a rejection.
 
 `Tools/AIEvalHarness` scores a different thing: of the patches that pass validation and apply, are
 they actually usable — has an output, that output is reachable from a real sound source, every


### PR DESCRIPTION
## Summary
- `OllamaProvider.cpp:590` hardcoded a 120s connection timeout on every chat request. Because Ollama's chat endpoint is non-streaming (nothing comes back — not even headers — until generation is fully done), that timeout is the actual ceiling on how long a model has to finish, not just a connect timeout.
- The first `Tools/AIEvalHarness` multi-model sweep measured `gemma4:12b-it-qat` (the app's current default) averaging ~180s/request on real hardware — close enough to the old 120s bound that most of its requests failed on timing alone, indistinguishable from Ollama being down. This is a real production reliability gap for anyone running the default model on comparable hardware, not just an eval-harness artifact.
- Raised to 240s via a new named constant (`kChatRequestTimeoutMs`), with a comment explaining why and citing the measurement. The AI panel already has a real cancel path (thinking-spinner + Escape), so a longer bound doesn't trap a user who doesn't want to wait — it just stops auto-failing a model that's still working.
- Bumped both harness tools' own outer `WaitableEvent::wait()` (180s → 270s) so they don't fire before `OllamaProvider`'s own timeout and mask its real provider-error message with a generic "timed out waiting for model".
- Updated `Tools/AIPatchHarness/README.md`, `Tools/AIEvalHarness/README.md`, and `docs/testing.md`, which all documented the old 120s figure.

## Test plan
- [x] `./build/Tests/Tests` — 690/690 pass, no regressions (existing `OllamaProviderTest.SendPromptTimeoutFails` mocks the stream and doesn't depend on the literal timeout value, so it needed no changes)
- [x] `clang-format --dry-run --Werror` clean on all changed files
- [ ] Re-run `AIEvalHarness --model gemma4:12b-it-qat` to confirm it no longer times out on the majority of requests (follow-up, not blocking this fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)