### PR TITLE
feat(ai): implement RemoteProvider — libcurl provider against local synth-platform (P2-7)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,8 +79,10 @@ add_library(Core STATIC
     # AI
     Source/AI/AIProvider.h
     Source/AI/OllamaProvider.h
+    Source/AI/RemoteProvider.h
     Source/AI/AIIntegrationService.cpp
     Source/AI/OllamaProvider.cpp
+    Source/AI/RemoteProvider.cpp
     Source/AI/AIIntegrationService.h
     Source/AI/AIStateMapper.cpp
     Source/AI/AIStateMapper.h
@@ -132,11 +134,19 @@ if(UNIX AND NOT APPLE)
     find_package(PkgConfig REQUIRED)
     pkg_check_modules(GTK3 REQUIRED gtk+-3.0)
 
-    find_package(CURL REQUIRED)
-
     # Link to Core so JUCE modules compiled within it find the headers
-    target_link_libraries(Core PUBLIC ${GTK3_LIBRARIES} CURL::libcurl)
+    target_link_libraries(Core PUBLIC ${GTK3_LIBRARIES})
     target_include_directories(Core PUBLIC ${GTK3_INCLUDE_DIRS})
+endif()
+
+# RemoteProvider (Source/AI/RemoteProvider.cpp) needs libcurl. Required on macOS and Linux (the
+# macOS SDK ships a curl.tbd stub, so find_package(CURL) succeeds there with no Homebrew
+# dependency) but deliberately NOT on WIN32 — the windows-latest CI job
+# (.github/workflows/ci.yml) has no libcurl setup step, and RemoteProvider's Windows branch is a
+# stub that never calls into curl.
+if(NOT WIN32)
+    find_package(CURL REQUIRED)
+    target_link_libraries(Core PUBLIC CURL::libcurl)
 endif()
 
 target_include_directories(Core PUBLIC

--- a/Source/AI/AIProviderRegistry.cpp
+++ b/Source/AI/AIProviderRegistry.cpp
@@ -1,5 +1,6 @@
 #include "AIProviderRegistry.h"
 #include "OllamaProvider.h"
+#include "RemoteProvider.h"
 
 namespace synth {
 
@@ -31,6 +32,21 @@ AIProviderRegistry AIProviderRegistry::createDefault() {
         {"ollama", "Ollama (local)", true, false, [](const ProviderConfig& config) -> std::unique_ptr<AIProvider> {
              return std::make_unique<OllamaProvider>(config.host);
          }});
+
+    // Registered AFTER "ollama" — order matters: AIProviderRegistry::create() falls back to
+    // descriptors.front() for an unknown/empty id, and that fallback must stay "ollama".
+    // hidden=true: ships wired up (constructible, registered, testable) but not yet offered in
+    // AISettingsTab's provider combo. Phase 4 is expected to flip this to false.
+    registry.registerProvider({"remote", "Remote (hosted)", true, true,
+                               [](const ProviderConfig& config) -> std::unique_ptr<AIProvider> {
+                                   auto provider = std::make_unique<RemoteProvider>(
+                                       config.host.isNotEmpty() ? config.host : "http://localhost:8787");
+                                   if (config.authToken.isNotEmpty())
+                                       provider->setAuthToken(config.authToken);
+                                   return provider;
+                               },
+                               /*hidden=*/true});
+
     return registry;
 }
 

--- a/Source/AI/AIProviderRegistry.h
+++ b/Source/AI/AIProviderRegistry.h
@@ -23,6 +23,14 @@ struct ProviderDescriptor {
     bool needsHost = false;
     bool needsAuth = false;
     std::function<std::unique_ptr<AIProvider>(const ProviderConfig&)> create;
+
+    // Appended LAST: existing call sites and tests use positional aggregate initialization
+    // (e.g. {"ollama", "Ollama (local)", true, false, [](...){...}}), so inserting a field
+    // earlier than `create` would silently break every one of them. Hidden from the Settings
+    // UI (AISettingsTab's provider combo) while still fully registered and constructible — a
+    // runtime feature flag, not a build-time one, for a provider that ships wired up before its
+    // UI entry point is turned on.
+    bool hidden = false;
 };
 
 /** Registry of available AI providers, keyed by stable id.

--- a/Source/AI/RemoteProvider.cpp
+++ b/Source/AI/RemoteProvider.cpp
@@ -1,0 +1,579 @@
+#include "RemoteProvider.h"
+#include "../Branding.h"
+#include <algorithm>
+
+#ifndef _WIN32
+#include <curl/curl.h>
+#endif
+
+namespace synth {
+
+namespace {
+// How long run() parks when the queue is empty. See OllamaProvider's kIdleWaitMs for the
+// identical rationale: purely a lost-wakeup safety net, never a poll relied on.
+constexpr int kIdleWaitMs = 1000;
+
+// Upper bound on waiting for a retired worker's thread handle to be released so a replacement
+// can start. See OllamaProvider's kWorkerHandoverTimeoutMs.
+constexpr int kWorkerHandoverTimeoutMs = 2000;
+
+// Same class of model, same generation-time ceiling as OllamaProvider's kChatRequestTimeoutMs
+// (OllamaProvider.cpp): the service's patch.generate call is non-streaming, so this is the
+// effective bound on how long a model has to produce a full response, not just a connect
+// timeout. Kept identical rather than re-deriving a separate number for a request that is,
+// from the client's point of view, the same shape of wait.
+constexpr int kRequestTimeoutMs = 240000;
+
+const char* const kShuttingDownMessage = "Error: Request cancelled - the Remote provider is shutting down.";
+const char* const kCancelledMessage = "Request cancelled.";
+
+/** Extracts `error.message` from a JSON error body, if present and a string. Returns an empty
+    string otherwise — callers fall back to a generic message naming the HTTP status. */
+juce::String extractErrorDetail(const juce::String& body) {
+    auto parsed = juce::JSON::parse(body);
+    if (auto* obj = parsed.getDynamicObject()) {
+        if (obj->hasProperty("error")) {
+            auto errorVar = obj->getProperty("error");
+            if (auto* errorObj = errorVar.getDynamicObject()) {
+                auto message = errorObj->getProperty("message");
+                if (message.isString())
+                    return message.toString();
+            }
+        }
+    }
+    return {};
+}
+
+/** Appends ": <detail>" to `base` when the response body carries a parseable error.message,
+    mirroring this codebase's "name the specific failure" ethos (see
+    AIIntegrationService::buildCorrectionPrompt). Falls back to `base` alone otherwise. */
+juce::String withErrorDetail(const juce::String& base, const juce::String& body) {
+    const auto detail = extractErrorDetail(body);
+    return detail.isNotEmpty() ? (base + ": " + detail) : base;
+}
+
+#ifndef _WIN32
+size_t curlWriteCallback(char* ptr, size_t size, size_t nmemb, void* userdata) {
+    auto* out = static_cast<juce::String*>(userdata);
+    *out += juce::String::fromUTF8(ptr, static_cast<int>(size * nmemb));
+    return size * nmemb;
+}
+
+size_t curlHeaderCallback(char* buffer, size_t size, size_t nitems, void* userdata) {
+    auto* headers = static_cast<juce::StringPairArray*>(userdata);
+    const auto lineLength = size * nitems;
+    juce::String line = juce::String::fromUTF8(buffer, static_cast<int>(lineLength)).trim();
+
+    const int colon = line.indexOfChar(':');
+    if (colon > 0) {
+        const auto key = line.substring(0, colon).trim();
+        const auto value = line.substring(colon + 1).trim();
+        if (key.isNotEmpty())
+            headers->set(key, value);
+    }
+
+    return lineLength;
+}
+
+int curlProgressCallback(void* clientp, curl_off_t, curl_off_t, curl_off_t, curl_off_t) {
+    auto* cancelled = static_cast<const std::atomic<bool>*>(clientp);
+    return (cancelled != nullptr && cancelled->load()) ? 1 : 0; // non-zero aborts the transfer
+}
+
+/** Real libcurl-backed HttpPerformer. Never touches a CURL* from any thread other than the one
+    running curl_easy_perform() for it — this function IS that thread (whichever calls it). */
+RemoteProvider::HttpResult performHttpWithCurl(const juce::String& url, const juce::StringPairArray& requestHeaders,
+                                               const juce::String& jsonBody, int timeoutMs,
+                                               const std::atomic<bool>& cancelled) {
+    // curl_global_init() exactly once, process-wide — never per-request. An immediately-invoked
+    // lambda initializing a function-local static is the simplest thread-safe way to do that
+    // pre-C++11-magic-statics-notwithstanding (C++11 guarantees this init is itself thread-safe).
+    static const bool globalInitDone = [] {
+        curl_global_init(CURL_GLOBAL_DEFAULT);
+        return true;
+    }();
+    juce::ignoreUnused(globalInitDone);
+
+    RemoteProvider::HttpResult result;
+
+    CURL* curl = curl_easy_init();
+    if (curl == nullptr) {
+        result.transportFailed = true;
+        result.errorMessage = "Error: Could not initialize libcurl.";
+        return result;
+    }
+
+    juce::String responseBody;
+    juce::StringPairArray responseHeaders;
+
+    curl_slist* headerList = nullptr;
+    for (const auto& key : requestHeaders.getAllKeys()) {
+        const auto headerLine = key + ": " + requestHeaders[key];
+        headerList = curl_slist_append(headerList, headerLine.toRawUTF8());
+    }
+
+    curl_easy_setopt(curl, CURLOPT_URL, url.toRawUTF8());
+    curl_easy_setopt(curl, CURLOPT_POST, 1L);
+    curl_easy_setopt(curl, CURLOPT_POSTFIELDS, jsonBody.toRawUTF8());
+    curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, static_cast<long>(jsonBody.getNumBytesAsUTF8()));
+    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headerList);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, curlWriteCallback);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &responseBody);
+    curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, curlHeaderCallback);
+    curl_easy_setopt(curl, CURLOPT_HEADERDATA, &responseHeaders);
+    curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, static_cast<long>(timeoutMs));
+    curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
+    curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 0L);
+    curl_easy_setopt(curl, CURLOPT_XFERINFOFUNCTION, curlProgressCallback);
+    curl_easy_setopt(curl, CURLOPT_XFERINFODATA, &cancelled);
+
+    const CURLcode res = curl_easy_perform(curl);
+
+    long httpStatus = 0;
+    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &httpStatus);
+    result.httpStatus = static_cast<int>(httpStatus);
+    result.body = responseBody;
+    result.headers = responseHeaders;
+
+    if (res == CURLE_ABORTED_BY_CALLBACK) {
+        // Treated as cancellation by the caller (which already knows it cancelled and checks
+        // state->cancelled before looking at this result), so the message here is never surfaced.
+        result.transportFailed = true;
+        result.errorMessage = "Request aborted (cancelled).";
+    } else if (res == CURLE_OPERATION_TIMEDOUT) {
+        result.timedOut = true;
+        result.errorMessage = "Error: Request to " + url + " timed out.";
+    } else if (res != CURLE_OK) {
+        result.transportFailed = true;
+        result.errorMessage = juce::String("Error: ") + curl_easy_strerror(res);
+    }
+
+    if (headerList != nullptr)
+        curl_slist_free_all(headerList);
+    curl_easy_cleanup(curl);
+
+    return result;
+}
+#else
+RemoteProvider::HttpResult performHttpUnavailable(const juce::String&, const juce::StringPairArray&,
+                                                  const juce::String&, int, const std::atomic<bool>&) {
+    RemoteProvider::HttpResult result;
+    result.transportFailed = true;
+    result.errorMessage = "Error: RemoteProvider is not available on Windows yet (no libcurl backend).";
+    return result;
+}
+#endif
+
+} // namespace
+
+RemoteProvider::RemoteProvider(const juce::String& host)
+    : Thread("RemoteProviderThread")
+    , remoteHost(host)
+#ifndef _WIN32
+    , performHttp(performHttpWithCurl)
+#else
+    , performHttp(performHttpUnavailable)
+#endif
+{
+}
+
+RemoteProvider::RemoteProvider(const juce::String& host, HttpPerformer performer)
+    : Thread("RemoteProviderThread")
+    , remoteHost(host)
+    , performHttp(std::move(performer)) {}
+
+RemoteProvider::~RemoteProvider() {
+    {
+        const juce::ScopedLock sl(queueLock);
+        isShuttingDown = true;
+    }
+
+    // Wakes run() (stopThread signals the exit flag and notify()s the thread's event), then
+    // blocks until run() has returned. run() retires through failAllPending(), which delivers
+    // the shutdown error for every still-queued request INLINE — see failAllPending() for why
+    // that delivery must not be deferred here.
+    stopThread(2000);
+
+    // Belt and braces: covers the case where no worker ever ran (so nothing retired) and
+    // anything that slipped into the queue during teardown.
+    failAllPending(AIErrorKind::Cancelled, kShuttingDownMessage);
+}
+
+void RemoteProvider::setAuthToken(const juce::String& token) { authToken = token; }
+
+RemoteProvider::RequestId RemoteProvider::sendPrompt(const std::vector<Message>& conversation,
+                                                     CompletionCallback callback, const juce::var& responseSchema,
+                                                     std::function<void(const juce::String&)> onDelta) {
+    // Streaming is not implemented: onDelta is accepted for interface compatibility but
+    // intentionally never invoked.
+    juce::ignoreUnused(onDelta);
+
+    Request request{RequestId{}, conversation, std::move(callback), responseSchema, nullptr};
+    bool rejected = false;
+    bool mustStartWorker = false;
+    AIErrorKind rejectionKind = AIErrorKind::Cancelled;
+    juce::String rejectionMessage = kShuttingDownMessage;
+
+    {
+        const juce::ScopedLock sl(queueLock);
+
+        request.id.value = nextRequestId++;
+        request.state = std::make_shared<RequestState>(request.id);
+
+        if (isShuttingDown) {
+            rejected = true;
+        } else if (responseSchema.isVoid()) {
+            // The remote service currently exposes only patch.generate (structured output); there
+            // is no plain-chat capability to call. Fail fast, no network hit — mirrors
+            // OllamaProvider's "no model selected" precedent.
+            rejected = true;
+            rejectionKind = AIErrorKind::Schema;
+            rejectionMessage =
+                "RemoteProvider only supports structured patch generation; the service has no conversational "
+                "capability yet.";
+        } else if (conversation.empty() || conversation.back().content.trim().isEmpty()) {
+            rejected = true;
+            rejectionKind = AIErrorKind::Schema;
+            rejectionMessage = "Error: Cannot send an empty prompt to the Remote provider.";
+        } else {
+            // Registered under the same lock as the queue push, so a cancel() racing this call
+            // either does not see the request at all or sees it in both places.
+            inFlight.emplace(request.id.value, request.state);
+            pendingRequests.push_back(request);
+
+            const bool ownerVanished = (workerState == WorkerState::running && !isThreadRunning());
+            mustStartWorker = (workerState == WorkerState::idle) || ownerVanished;
+
+            if (mustStartWorker)
+                workerState = WorkerState::starting;
+        }
+    }
+
+    const RequestId requestId = request.id;
+
+    if (rejected) {
+        deliverError(request, rejectionKind, rejectionMessage, /*retryAfterSeconds=*/0, /*forceSynchronous=*/true);
+        return requestId;
+    }
+
+    if (mustStartWorker && !ensureWorkerRunning()) {
+        failAllPending(AIErrorKind::Server, "Error: Could not start the Remote provider request worker thread.");
+        return requestId;
+    }
+
+    notify();
+
+    return requestId;
+}
+
+void RemoteProvider::cancel(RequestId requestId) {
+    if (requestId.value == 0)
+        return;
+
+    std::shared_ptr<RequestState> state;
+    Request abandoned;
+    bool tookFromQueue = false;
+
+    {
+        const juce::ScopedLock sl(queueLock);
+
+        const auto entry = inFlight.find(requestId.value);
+        if (entry == inFlight.end())
+            return; // Unknown id, or the request already completed and was delivered: nothing to do.
+
+        state = entry->second;
+        state->cancelled.store(true);
+
+        const auto queued = std::find_if(pendingRequests.begin(), pendingRequests.end(),
+                                         [&state](const Request& r) { return r.state == state; });
+
+        if (queued != pendingRequests.end()) {
+            abandoned = *queued;
+            pendingRequests.erase(queued);
+            tookFromQueue = true;
+        }
+    }
+
+    if (tookFromQueue) {
+        deliverError(abandoned, AIErrorKind::Cancelled, kCancelledMessage, /*retryAfterSeconds=*/0,
+                     /*forceSynchronous=*/false);
+        return;
+    }
+
+    // Already in flight: nothing more to do here. The cancelled flag is polled by the HTTP
+    // performer's own progress callback during curl_easy_perform(), on the worker thread, which
+    // notices it and unwinds on its own; the worker delivers the Cancelled callback itself.
+}
+
+bool RemoteProvider::claimDelivery(const Request& req) {
+    if (req.state == nullptr)
+        return true;
+
+    if (req.state->delivered.exchange(true))
+        return false;
+
+    const juce::ScopedLock sl(queueLock);
+    inFlight.erase(req.state->id.value);
+    return true;
+}
+
+bool RemoteProvider::ensureWorkerRunning() {
+    if (startThread())
+        return true;
+
+    if (juce::Thread::getCurrentThreadId() == getThreadId())
+        return false;
+
+    if (!waitForThreadToExit(kWorkerHandoverTimeoutMs))
+        return false;
+
+    return startThread();
+}
+
+void RemoteProvider::failAllPending(AIErrorKind kind, const juce::String& message) {
+    std::vector<Request> stranded;
+    bool deliverSynchronously = false;
+
+    {
+        const juce::ScopedLock sl(queueLock);
+        stranded.swap(pendingRequests);
+        workerState = WorkerState::idle;
+        deliverSynchronously = isShuttingDown;
+    }
+
+    for (const auto& req : stranded)
+        deliverError(req, kind, message, /*retryAfterSeconds=*/0, deliverSynchronously);
+}
+
+void RemoteProvider::deliverResult(const Request& req, const juce::String& responseText, bool forceSynchronous) {
+    if (!claimDelivery(req))
+        return;
+
+    if (!req.callback)
+        return;
+
+    AIResponse response;
+    response.success = true;
+    response.content = responseText;
+    response.requestId = juce::String(req.id.value);
+
+    if (isTestMode || forceSynchronous) {
+        req.callback(response);
+        return;
+    }
+
+    auto callback = req.callback;
+    juce::MessageManager::callAsync([callback, response]() { callback(response); });
+}
+
+void RemoteProvider::deliverError(const Request& req, AIErrorKind kind, const juce::String& message,
+                                  int retryAfterSeconds, bool forceSynchronous) {
+    if (!claimDelivery(req))
+        return;
+
+    if (!req.callback)
+        return;
+
+    AIResponse response;
+    response.success = false;
+    response.requestId = juce::String(req.id.value);
+    response.error.kind = kind;
+    response.error.message = message;
+    response.error.retryAfterSeconds = retryAfterSeconds;
+    response.error.requestId = response.requestId;
+
+    if (isTestMode || forceSynchronous) {
+        req.callback(response);
+        return;
+    }
+
+    auto callback = req.callback;
+    juce::MessageManager::callAsync([callback, response]() { callback(response); });
+}
+
+void RemoteProvider::setModel(const juce::String& name) {
+    // Cosmetic only: patch.generate's input schema has no model field, and there is no
+    // models-list endpoint (only GET /health and POST /v1/capability/:name exist) — the service
+    // picks its own model server-side. Stored so getCurrentModel() round-trips, never sent.
+    currentModel = name;
+}
+
+juce::String RemoteProvider::getCurrentModel() const { return currentModel; }
+
+void RemoteProvider::fetchAvailableModels(std::function<void(const juce::StringArray& models, bool success)> callback) {
+    // Nothing to enumerate — see setModel()'s comment — so this is a synchronous "success, empty
+    // list" rather than a failure. Delivered the same test-mode/async-aware way as every other
+    // callback in this class.
+    if (!callback)
+        return;
+
+    if (isTestMode) {
+        callback(juce::StringArray{}, true);
+    } else {
+        juce::MessageManager::callAsync([callback]() { callback(juce::StringArray{}, true); });
+    }
+}
+
+void RemoteProvider::run() {
+    {
+        const juce::ScopedLock sl(queueLock);
+        workerState = WorkerState::running;
+    }
+
+    for (;;) {
+        Request currentRequest;
+        bool haveRequest = false;
+
+        {
+            const juce::ScopedLock sl(queueLock);
+
+            if (threadShouldExit())
+                break; // leave the queue intact; failAllPending() below reports it
+
+            if (!pendingRequests.empty()) {
+                currentRequest = pendingRequests.front();
+                pendingRequests.erase(pendingRequests.begin());
+                haveRequest = true;
+            }
+        }
+
+        if (haveRequest) {
+            processRequest(currentRequest);
+            continue;
+        }
+
+        wait(kIdleWaitMs);
+    }
+
+    failAllPending(AIErrorKind::Cancelled, kShuttingDownMessage);
+}
+
+void RemoteProvider::processRequest(const Request& req) {
+    auto deliverSuccess = [this, &req](const juce::String& responseText) {
+        deliverResult(req, responseText, /*forceSynchronous=*/false);
+    };
+    auto deliverErr = [this, &req](AIErrorKind kind, const juce::String& message, int retryAfterSeconds = 0) {
+        deliverError(req, kind, message, retryAfterSeconds, /*forceSynchronous=*/false);
+    };
+
+    auto wasCancelled = [&req] { return req.state != nullptr && req.state->cancelled.load(); };
+
+    // Cancelled while it sat in the queue, or during the handoff to this thread. Bail before
+    // opening a connection.
+    if (wasCancelled()) {
+        deliverErr(AIErrorKind::Cancelled, kCancelledMessage);
+        return;
+    }
+
+    // Build the request body: {"productName": ..., "userPrompt": ...}. currentPatch and
+    // promptVersion are deliberately OMITTED entirely (not sent as null).
+    //
+    // Why this is safe: AIIntegrationService::buildPatchAugmentedContent() already renders the
+    // current graph state into the LAST conversation message as
+    // "Current patch state:\n```json\n<JSON>\n```\n\nUser request: <text>" whenever the graph is
+    // non-empty, or leaves it as plain text otherwise. The service's own buildUserMessage()
+    // (synth-platform/packages/capabilities/src/patch-generate/capability.ts) performs the EXACT
+    // SAME wrapping server-side, from a separate currentPatch + userPrompt pair, and only wraps
+    // when currentPatch is present. Sending the client's already-wrapped text as userPrompt alone,
+    // with currentPatch omitted, therefore produces byte-identical model input to the "proper"
+    // structured split — without any fragile re-parsing of the wrapper on this side. Do not
+    // "fix" this into a parser that splits userPrompt back into currentPatch/userPrompt.
+    const juce::String userPrompt = req.conversation.back().content;
+
+    juce::DynamicObject::Ptr body = new juce::DynamicObject();
+    body->setProperty("productName", juce::String(synth::branding::kProductName));
+    body->setProperty("userPrompt", userPrompt);
+
+    const juce::String jsonBody = juce::JSON::toString(juce::var(body.get()));
+
+    juce::StringPairArray requestHeaders;
+    requestHeaders.set("Content-Type", "application/json");
+    if (authToken.isNotEmpty())
+        requestHeaders.set("Authorization", "Bearer " + authToken);
+
+    const juce::String url = remoteHost + "/v1/capability/patch.generate";
+
+    // req.state is only ever null for a default-constructed Request, which is never what the
+    // worker pulls off pendingRequests (every enqueued Request gets a freshly made RequestState).
+    jassert(req.state != nullptr);
+    const HttpResult result = performHttp(url, requestHeaders, jsonBody, kRequestTimeoutMs, req.state->cancelled);
+
+    // Checked BEFORE inspecting the HTTP result — same as OllamaProvider checks wasCancelled()
+    // right after the network call returns: an aborted transfer looks exactly like a network
+    // failure from here, and reporting a cancellation the user asked for as an error they might
+    // try to debug would be actively misleading.
+    if (wasCancelled()) {
+        deliverErr(AIErrorKind::Cancelled, kCancelledMessage);
+        return;
+    }
+
+    if (result.transportFailed) {
+        deliverErr(AIErrorKind::Network,
+                   withErrorDetail("Error: Could not reach the Remote provider at " + remoteHost, result.body));
+        return;
+    }
+
+    if (result.timedOut) {
+        deliverErr(AIErrorKind::Timeout, "Error: Request to " + remoteHost + " timed out.");
+        return;
+    }
+
+    const int httpStatus = result.httpStatus;
+
+    if (httpStatus == 401 || httpStatus == 403) {
+        deliverErr(AIErrorKind::Auth, withErrorDetail("Error: Remote provider at " + remoteHost +
+                                                          " rejected the request as "
+                                                          "unauthorized (HTTP " +
+                                                          juce::String(httpStatus) + ")",
+                                                      result.body));
+        return;
+    }
+
+    if (httpStatus == 429) {
+        const int retryAfterSeconds = result.headers.getValue("Retry-After", "").getIntValue();
+        deliverErr(AIErrorKind::RateLimit,
+                   withErrorDetail("Error: Remote provider at " + remoteHost + " rate-limited the request (HTTP 429)",
+                                   result.body),
+                   retryAfterSeconds);
+        return;
+    }
+
+    if (httpStatus == 402) {
+        deliverErr(AIErrorKind::Quota, withErrorDetail("Error: Remote provider at " + remoteHost +
+                                                           " reported insufficient quota (HTTP 402)",
+                                                       result.body));
+        return;
+    }
+
+    if (httpStatus == 400 || httpStatus == 404) {
+        // Client/request-shape problem — bad JSON, or the client and service disagree about what
+        // capability exists. Not worth retrying with the same input.
+        deliverErr(AIErrorKind::Schema,
+                   withErrorDetail("Error: Remote provider at " + remoteHost + " rejected the request (HTTP " +
+                                       juce::String(httpStatus) + ")",
+                                   result.body));
+        return;
+    }
+
+    if (httpStatus < 200 || httpStatus >= 300) {
+        // 500, 502, or any other unexpected non-2xx.
+        deliverErr(AIErrorKind::Server,
+                   withErrorDetail("Error: Remote provider at " + remoteHost + " failed the request (HTTP " +
+                                       juce::String(httpStatus) + ")",
+                                   result.body));
+        return;
+    }
+
+    juce::var jsonResponse = juce::JSON::parse(result.body);
+    if (auto* obj = jsonResponse.getDynamicObject()) {
+        if (obj->hasProperty("data")) {
+            deliverSuccess(juce::JSON::toString(obj->getProperty("data")));
+            return;
+        }
+    }
+
+    deliverErr(AIErrorKind::Schema,
+               "Error: Remote provider at " + remoteHost + " returned a 2xx response with no usable \"data\".");
+}
+
+} // namespace synth

--- a/Source/AI/RemoteProvider.h
+++ b/Source/AI/RemoteProvider.h
@@ -1,0 +1,179 @@
+#pragma once
+
+#include "AIProvider.h"
+#include <atomic>
+#include <functional>
+#include <juce_core/juce_core.h>
+#include <juce_events/juce_events.h>
+#include <map>
+#include <memory>
+#include <vector>
+
+namespace synth {
+
+/**
+ * @class RemoteProvider
+ * @brief AIProvider implementation talking to a local instance of the synth-platform inference
+ *        service (`POST {host}/v1/capability/patch.generate`) over libcurl.
+ *
+ * Mirrors OllamaProvider's worker-thread/queue/cancellation architecture (see that class for the
+ * full rationale — the machinery here is deliberately the same shape, just simplified where
+ * libcurl makes cancellation easier than juce::WebInputStream does): a queueLock-guarded
+ * pendingRequests vector, a per-request RequestState shared between the queue and cancel(), an
+ * idle/starting/running worker-state machine, and an exactly-once claimDelivery()/deliverResult()/
+ * deliverError() pair with the same forceSynchronous-during-shutdown contract.
+ *
+ * Non-streaming: onDelta is accepted for interface compatibility but never invoked, because the
+ * service's patch.generate endpoint is not streaming-capable (a single `c.json({data})`).
+ *
+ * Ships registered in AIProviderRegistry but hidden from the Settings UI
+ * (ProviderDescriptor::hidden) until a later phase turns it on.
+ */
+class RemoteProvider
+    : public AIProvider
+    , protected juce::Thread {
+public:
+    /** Result of one HTTP transaction, transport-layer only — no interpretation of the body. */
+    struct HttpResult {
+        int httpStatus = 0;
+        juce::String body;
+        juce::StringPairArray headers;
+        bool transportFailed = false; // curl couldn't complete the transfer at all (DNS/connect/etc.)
+        bool timedOut = false;
+        juce::String errorMessage; // human-readable, meaningful when transportFailed or timedOut
+    };
+
+    /** Performs one HTTP POST. `cancelled` is polled by the implementation (real or fake) so a
+        request can be aborted mid-transfer; see cancel()'s doc comment for the full contract. */
+    using HttpPerformer =
+        std::function<HttpResult(const juce::String& url, const juce::StringPairArray& requestHeaders,
+                                 const juce::String& jsonBody, int timeoutMs, const std::atomic<bool>& cancelled)>;
+
+    RemoteProvider(const juce::String& host = "http://localhost:8787");
+
+    // Test-specific constructor to inject a fake HTTP transport (no real sockets).
+    RemoteProvider(const juce::String& host, HttpPerformer performer);
+
+    ~RemoteProvider() override;
+
+    /** Queues a structured patch-generation request for the worker thread.
+
+        Contract: every accepted request eventually gets its callback invoked — either with the
+        service's answer, or with a typed error. It is never silently dropped, including when it
+        lands while the worker is shutting down or already gone.
+
+        RemoteProvider only supports structured patch generation (see AIErrorKind::Schema fail-fast
+        below): the service currently exposes no conversational capability. Streaming is not
+        implemented: onDelta is accepted for interface compatibility but never invoked.
+    */
+    RequestId sendPrompt(const std::vector<Message>& conversation, CompletionCallback callback,
+                         const juce::var& responseSchema = juce::var(),
+                         std::function<void(const juce::String& delta)> onDelta = {}) override;
+
+    /** Abandons a queued or in-flight request. See OllamaProvider::cancel() for the full contract
+        this mirrors: exactly-once callback, no-op on an unknown/completed id, and a queued request
+        is pulled out and delivered Cancelled immediately rather than left to the worker. */
+    void cancel(RequestId requestId) override;
+
+    juce::String getProviderName() const override { return "Remote"; }
+
+    using juce::Thread::stopThread; // Make stopThread public for testing purposes
+
+    void setModel(const juce::String& name) override;
+    juce::String getCurrentModel() const override;
+    void fetchAvailableModels(std::function<void(const juce::StringArray& models, bool success)> callback) override;
+
+    /** Stores the token; when non-empty, every request carries `Authorization: Bearer <token>`. */
+    void setAuthToken(const juce::String& token) override;
+
+    void setTestMode(bool testMode) { isTestMode = testMode; }
+
+private:
+    juce::String remoteHost;
+    juce::String currentModel; // cosmetic only: the service picks its own model server-side
+    juce::String authToken;
+    HttpPerformer performHttp;
+    bool isTestMode = false;
+
+    /** Per-request cancellation state, shared between the queue entry, the registry and the
+        worker so cancel() can reach a request wherever it currently is.
+
+        Simpler than OllamaProvider::RequestState: libcurl's CURLOPT_XFERINFOFUNCTION progress
+        callback polls `cancelled` directly from inside curl_easy_perform() on the worker thread,
+        so there is no separate stream pointer/lock to publish — the atomic alone is the whole
+        cancellation channel. */
+    struct RequestState {
+        explicit RequestState(RequestId requestId)
+            : id(requestId) {}
+
+        const RequestId id;
+
+        // Set by cancel(). Polled by the HTTP performer's progress callback during the transfer,
+        // and checked by the worker before and after the call, so a request cancelled at any
+        // point is abandoned.
+        std::atomic<bool> cancelled{false};
+
+        // Exactly-once gate on the callback. cancel(), the worker and the shutdown path can all
+        // race to finish the same request; whoever flips this first owns delivery.
+        std::atomic<bool> delivered{false};
+    };
+
+    struct Request {
+        RequestId id;
+        std::vector<Message> conversation;
+        AIProvider::CompletionCallback callback;
+        juce::var responseSchema;
+        std::shared_ptr<RequestState> state; // null only for a default-constructed Request
+    };
+
+    // Monotonically increasing; only ever accessed from sendPrompt() callers, so a plain
+    // counter guarded by queueLock (taken for every sendPrompt() anyway) is sufficient.
+    uint64_t nextRequestId = 1; // guarded by queueLock
+
+    juce::CriticalSection queueLock;
+    std::vector<Request> pendingRequests;
+
+    // Every request that has been accepted and not yet delivered, so cancel() can find one the
+    // worker has already popped off pendingRequests. Guarded by queueLock; entries are removed by
+    // the delivery path, which is what makes cancel() of a completed id a no-op.
+    std::map<uint64_t, std::shared_ptr<RequestState>> inFlight;
+
+    // Who owns the queue — see OllamaProvider::WorkerState for the full rationale (identical
+    // here): NOT isThreadRunning(), because juce::Thread only clears its handle after run() has
+    // already returned.
+    enum class WorkerState { idle, starting, running };
+    WorkerState workerState = WorkerState::idle; // guarded by queueLock
+
+    // Set by the destructor before it stops the worker, so a late sendPrompt() fails its caller
+    // immediately instead of resurrecting a thread on a dying object.
+    bool isShuttingDown = false; // guarded by queueLock
+
+    void run() override;
+    void processRequest(const Request& req);
+
+    /** Starts a worker for a queue that currently has none. Returns false if no worker could be
+        started, in which case the caller MUST fail the queue. */
+    bool ensureWorkerRunning();
+
+    /** Releases queue ownership (workerState = idle) and fails everything left in it with the
+        given typed error, both in one locked section so nothing can slip in unnoticed behind it. */
+    void failAllPending(AIErrorKind kind, const juce::String& message);
+
+    /** Single delivery channel for every successful result. `forceSynchronous` bypasses
+        MessageManager::callAsync for shutdown paths, where the message loop cannot be relied on to
+        run the callback before this object is gone. */
+    void deliverResult(const Request& req, const juce::String& responseText, bool forceSynchronous);
+
+    /** Single delivery channel for every error. Same `forceSynchronous` contract as
+        deliverResult(). */
+    void deliverError(const Request& req, AIErrorKind kind, const juce::String& message, int retryAfterSeconds,
+                      bool forceSynchronous);
+
+    /** Claims the sole right to deliver `req`, and deregisters it. Returns false if someone else
+        got there first, in which case the caller must not invoke the callback. */
+    bool claimDelivery(const Request& req);
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(RemoteProvider)
+};
+
+} // namespace synth

--- a/Source/UI/SettingsWindow.cpp
+++ b/Source/UI/SettingsWindow.cpp
@@ -19,13 +19,22 @@ public:
         providerLabel.setText("AI Provider:", juce::dontSendNotification);
 
         addAndMakeVisible(providerCombo);
+
+        // Built once and reused by selectedDescriptor() below: populating the combo from a
+        // filtered view but then indexing selectedDescriptor() into the UNFILTERED
+        // providerRegistry.listAll() would desync the moment a hidden provider sits between two
+        // visible ones (combo index N would no longer be listAll()[N]). visibleProviders is the
+        // single source of truth for both.
+        for (const auto& descriptor : providerRegistry.listAll())
+            if (!descriptor.hidden)
+                visibleProviders.push_back(&descriptor);
+
         juce::String savedProviderId = appProperties.getUserSettings()->getValue("aiProvider", "ollama");
         int selectedItemId = 1;
-        const auto& allProviders = providerRegistry.listAll();
-        for (size_t i = 0; i < allProviders.size(); ++i) {
+        for (size_t i = 0; i < visibleProviders.size(); ++i) {
             int itemId = (int)i + 1;
-            providerCombo.addItem(allProviders[i].displayName, itemId);
-            if (allProviders[i].id == savedProviderId)
+            providerCombo.addItem(visibleProviders[i]->displayName, itemId);
+            if (visibleProviders[i]->id == savedProviderId)
                 selectedItemId = itemId;
         }
         providerCombo.setSelectedId(selectedItemId, juce::dontSendNotification);
@@ -73,9 +82,8 @@ public:
 private:
     const synth::ProviderDescriptor* selectedDescriptor() const {
         int selectedIndex = providerCombo.getSelectedItemIndex();
-        const auto& all = providerRegistry.listAll();
-        if (selectedIndex >= 0 && (size_t)selectedIndex < all.size())
-            return &all[(size_t)selectedIndex];
+        if (selectedIndex >= 0 && (size_t)selectedIndex < visibleProviders.size())
+            return visibleProviders[(size_t)selectedIndex];
         return nullptr;
     }
 
@@ -92,6 +100,11 @@ private:
     synth::AIIntegrationService& aiService;
     synth::AIChatComponent& aiChatComponent;
     synth::AIProviderRegistry providerRegistry;
+    // Non-owning pointers into providerRegistry's storage — valid for the AISettingsTab's
+    // lifetime because providerRegistry is a fellow member and outlives this vector. See the
+    // constructor for why this must be the ONLY thing the combo population and
+    // selectedDescriptor() index into.
+    std::vector<const synth::ProviderDescriptor*> visibleProviders;
 
     juce::Label providerLabel;
     juce::ComboBox providerCombo;

--- a/Tests/AIProviderRegistryTests.cpp
+++ b/Tests/AIProviderRegistryTests.cpp
@@ -93,3 +93,19 @@ TEST(AIProviderRegistryTest, PersistedIdIsIndependentOfDisplayName) {
     auto provider = newRegistry.create("ollama", {});
     ASSERT_NE(provider, nullptr);
 }
+
+TEST(AIProviderRegistryTest, CreateDefaultRegistersOllamaFirstAndRemoteHidden) {
+    auto registry = synth::AIProviderRegistry::createDefault();
+
+    const auto& all = registry.listAll();
+    ASSERT_EQ(all.size(), 2u);
+
+    // "ollama" must stay first: AIProviderRegistry::create() falls back to descriptors.front()
+    // for an unknown/empty id, and that fallback must be unaffected by adding "remote".
+    EXPECT_EQ(all[0].id, "ollama");
+    EXPECT_FALSE(all[0].hidden);
+
+    const auto* remote = registry.find("remote");
+    ASSERT_NE(remote, nullptr);
+    EXPECT_TRUE(remote->hidden);
+}

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -28,6 +28,7 @@ add_executable(Tests
     PatchEvalTests.cpp
     AIProviderRegistryTests.cpp
     OllamaProviderTests.cpp
+    RemoteProviderTests.cpp
     MainComponentTests.cpp
     GraphEditorTests.cpp
     ModuleComponentTests.cpp

--- a/Tests/RemoteProviderTests.cpp
+++ b/Tests/RemoteProviderTests.cpp
@@ -1,0 +1,620 @@
+#include "../Source/AI/RemoteProvider.h"
+#include "../Source/Branding.h"
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <future>
+#include <gtest/gtest.h>
+#include <juce_core/juce_core.h>
+#include <memory>
+#include <mutex>
+
+namespace {
+
+struct MockCompletionCallback {
+    std::promise<std::pair<juce::String, bool>> promise;
+
+    void operator()(const juce::StringArray& models, bool success) {
+        promise.set_value({models.joinIntoString("|"), success});
+    }
+
+    std::pair<juce::String, bool> getResult() { return promise.get_future().get(); }
+};
+
+struct MockPromptCallback {
+    std::promise<synth::AIProvider::AIResponse> promise;
+
+    void operator()(const synth::AIProvider::AIResponse& response) { promise.set_value(response); }
+
+    synth::AIProvider::AIResponse getResult() { return promise.get_future().get(); }
+};
+
+// Bounded-wait latch for "did the callback fire?" assertions. See OllamaProviderTests.cpp for the
+// identical rationale: every wait has a timeout so a lost request fails the test instead of
+// hanging it.
+class CallbackLatch {
+public:
+    void fire() {
+        {
+            const std::lock_guard<std::mutex> lock(mutex);
+            fired = true;
+        }
+        cv.notify_all();
+    }
+
+    bool waitFor(std::chrono::milliseconds timeout) {
+        std::unique_lock<std::mutex> lock(mutex);
+        return cv.wait_for(lock, timeout, [this] { return fired; });
+    }
+
+    bool hasFired() const {
+        const std::lock_guard<std::mutex> lock(mutex);
+        return fired;
+    }
+
+private:
+    mutable std::mutex mutex;
+    std::condition_variable cv;
+    bool fired = false;
+};
+
+constexpr std::chrono::milliseconds kCallbackTimeout{10000};
+
+const juce::String kMockHost = "http://mock-host:8787";
+
+// A non-void response schema, matching what AIIntegrationService::sendMessage() passes for a
+// structured patch request (AIStateMapper::getPatchSchema()). Content is irrelevant to
+// RemoteProvider — it never sends "format" the way OllamaProvider does — only isVoid() matters.
+juce::var makeSchema() { return juce::var(new juce::DynamicObject()); }
+
+synth::RemoteProvider::HttpResult makeSuccess(const juce::String& body) {
+    synth::RemoteProvider::HttpResult result;
+    result.httpStatus = 200;
+    result.body = body;
+    return result;
+}
+
+synth::RemoteProvider::HttpResult makeStatus(int status, const juce::String& body = "{}",
+                                             const juce::StringPairArray& headers = {}) {
+    synth::RemoteProvider::HttpResult result;
+    result.httpStatus = status;
+    result.body = body;
+    result.headers = headers;
+    return result;
+}
+
+} // namespace
+
+class RemoteProviderTest : public ::testing::Test {
+protected:
+    void TearDown() override {
+        // Nothing persistent between tests: each test constructs its own provider.
+    }
+};
+
+// ============================================================================
+// Request shape
+// ============================================================================
+
+TEST_F(RemoteProviderTest, RequestShapePlainTextConversation) {
+    juce::String capturedUrl;
+    juce::StringPairArray capturedHeaders;
+    juce::String capturedBody;
+
+    auto performer = [&](const juce::String& url, const juce::StringPairArray& headers, const juce::String& jsonBody,
+                         int, const std::atomic<bool>&) -> synth::RemoteProvider::HttpResult {
+        capturedUrl = url;
+        capturedHeaders = headers;
+        capturedBody = jsonBody;
+        return makeSuccess(R"({"data":{"nodes":[]}})");
+    };
+
+    synth::RemoteProvider provider{kMockHost, performer};
+    provider.setTestMode(true);
+
+    std::vector<synth::AIProvider::Message> conversation = {{"user", "Make a bass patch"}};
+    MockPromptCallback callback;
+    provider.sendPrompt(
+        conversation, [&callback](const synth::AIProvider::AIResponse& r) { callback(r); }, makeSchema());
+
+    auto result = callback.getResult();
+    provider.stopThread(5000);
+
+    ASSERT_TRUE(result.success);
+    EXPECT_EQ(capturedUrl, kMockHost + "/v1/capability/patch.generate");
+    EXPECT_TRUE(capturedHeaders.containsKey("Content-Type"));
+    EXPECT_EQ(capturedHeaders.getValue("Content-Type", ""), juce::String("application/json"));
+    EXPECT_FALSE(capturedHeaders.containsKey("Authorization"));
+
+    juce::var parsedBody = juce::JSON::parse(capturedBody);
+    ASSERT_TRUE(parsedBody.isObject());
+    auto* obj = parsedBody.getDynamicObject();
+    ASSERT_NE(obj, nullptr);
+    EXPECT_EQ(obj->getProperty("productName").toString(), juce::String(synth::branding::kProductName));
+    EXPECT_EQ(obj->getProperty("userPrompt").toString(), juce::String("Make a bass patch"));
+    EXPECT_FALSE(obj->hasProperty("currentPatch"));
+    EXPECT_FALSE(obj->hasProperty("promptVersion"));
+}
+
+// The design hinges on this: AIIntegrationService::buildPatchAugmentedContent() wraps the current
+// graph into the last message as "Current patch state:...User request: ...", and that wrapper
+// must pass through into userPrompt completely unchanged, never re-parsed or re-split.
+TEST_F(RemoteProviderTest, RequestShapePassesAugmentedContentThroughUnchanged) {
+    const juce::String wrapped =
+        "Current patch state:\n```json\n{\"nodes\":[{\"id\":1}]}\n```\n\nUser request: add a filter";
+
+    juce::String capturedBody;
+    auto performer = [&](const juce::String&, const juce::StringPairArray&, const juce::String& jsonBody, int,
+                         const std::atomic<bool>&) -> synth::RemoteProvider::HttpResult {
+        capturedBody = jsonBody;
+        return makeSuccess(R"({"data":{}})");
+    };
+
+    synth::RemoteProvider provider{kMockHost, performer};
+    provider.setTestMode(true);
+
+    std::vector<synth::AIProvider::Message> conversation = {{"user", wrapped}};
+    MockPromptCallback callback;
+    provider.sendPrompt(
+        conversation, [&callback](const synth::AIProvider::AIResponse& r) { callback(r); }, makeSchema());
+
+    auto result = callback.getResult();
+    provider.stopThread(5000);
+
+    ASSERT_TRUE(result.success);
+    juce::var parsedBody = juce::JSON::parse(capturedBody);
+    auto* obj = parsedBody.getDynamicObject();
+    ASSERT_NE(obj, nullptr);
+    EXPECT_EQ(obj->getProperty("userPrompt").toString(), wrapped);
+    EXPECT_FALSE(obj->hasProperty("currentPatch"));
+}
+
+TEST_F(RemoteProviderTest, AuthorizationHeaderOnlySentWhenTokenSet) {
+    juce::StringPairArray capturedHeaders;
+    auto performer = [&](const juce::String&, const juce::StringPairArray& headers, const juce::String&, int,
+                         const std::atomic<bool>&) -> synth::RemoteProvider::HttpResult {
+        capturedHeaders = headers;
+        return makeSuccess(R"({"data":{}})");
+    };
+
+    synth::RemoteProvider provider{kMockHost, performer};
+    provider.setTestMode(true);
+    provider.setAuthToken("secret-token-123");
+
+    MockPromptCallback callback;
+    provider.sendPrompt(
+        {{"user", "hi"}}, [&callback](const synth::AIProvider::AIResponse& r) { callback(r); }, makeSchema());
+    callback.getResult();
+    provider.stopThread(5000);
+
+    EXPECT_TRUE(capturedHeaders.containsKey("Authorization"));
+    EXPECT_EQ(capturedHeaders.getValue("Authorization", ""), juce::String("Bearer secret-token-123"));
+}
+
+// ============================================================================
+// Fail-fast: no network call
+// ============================================================================
+
+TEST_F(RemoteProviderTest, VoidResponseSchemaFailsFastWithoutHittingNetwork) {
+    bool performerInvoked = false;
+    auto performer = [&](const juce::String&, const juce::StringPairArray&, const juce::String&, int,
+                         const std::atomic<bool>&) -> synth::RemoteProvider::HttpResult {
+        performerInvoked = true;
+        return makeSuccess(R"({"data":{}})");
+    };
+
+    synth::RemoteProvider provider{kMockHost, performer};
+    provider.setTestMode(true);
+
+    MockPromptCallback callback;
+    // No schema argument: defaults to juce::var() (void), exactly what AIIntegrationService::
+    // sendMessage() passes for a plain conversational turn.
+    provider.sendPrompt({{"user", "hello"}}, [&callback](const synth::AIProvider::AIResponse& r) { callback(r); });
+
+    auto result = callback.getResult();
+    provider.stopThread(5000);
+
+    EXPECT_FALSE(result.success);
+    EXPECT_EQ(result.error.kind, synth::AIProvider::AIErrorKind::Schema);
+    EXPECT_FALSE(performerInvoked);
+}
+
+TEST_F(RemoteProviderTest, EmptyConversationFailsFastWithoutHittingNetwork) {
+    bool performerInvoked = false;
+    auto performer = [&](const juce::String&, const juce::StringPairArray&, const juce::String&, int,
+                         const std::atomic<bool>&) -> synth::RemoteProvider::HttpResult {
+        performerInvoked = true;
+        return makeSuccess(R"({"data":{}})");
+    };
+
+    synth::RemoteProvider provider{kMockHost, performer};
+    provider.setTestMode(true);
+
+    MockPromptCallback callback;
+    provider.sendPrompt({}, [&callback](const synth::AIProvider::AIResponse& r) { callback(r); }, makeSchema());
+
+    auto result = callback.getResult();
+    provider.stopThread(5000);
+
+    EXPECT_FALSE(result.success);
+    EXPECT_EQ(result.error.kind, synth::AIProvider::AIErrorKind::Schema);
+    EXPECT_FALSE(performerInvoked);
+}
+
+TEST_F(RemoteProviderTest, BlankLastMessageFailsFastWithoutHittingNetwork) {
+    bool performerInvoked = false;
+    auto performer = [&](const juce::String&, const juce::StringPairArray&, const juce::String&, int,
+                         const std::atomic<bool>&) -> synth::RemoteProvider::HttpResult {
+        performerInvoked = true;
+        return makeSuccess(R"({"data":{}})");
+    };
+
+    synth::RemoteProvider provider{kMockHost, performer};
+    provider.setTestMode(true);
+
+    MockPromptCallback callback;
+    provider.sendPrompt(
+        {{"user", "   "}}, [&callback](const synth::AIProvider::AIResponse& r) { callback(r); }, makeSchema());
+
+    auto result = callback.getResult();
+    provider.stopThread(5000);
+
+    EXPECT_FALSE(result.success);
+    EXPECT_EQ(result.error.kind, synth::AIProvider::AIErrorKind::Schema);
+    EXPECT_FALSE(performerInvoked);
+}
+
+// ============================================================================
+// HTTP status -> AIErrorKind mapping
+// ============================================================================
+
+struct StatusMappingCase {
+    int httpStatus;
+    synth::AIProvider::AIErrorKind expectedKind;
+};
+
+class RemoteProviderStatusMappingTest : public ::testing::TestWithParam<StatusMappingCase> {};
+
+TEST_P(RemoteProviderStatusMappingTest, MapsStatusToExpectedErrorKind) {
+    const auto testCase = GetParam();
+
+    auto performer = [&](const juce::String&, const juce::StringPairArray&, const juce::String&, int,
+                         const std::atomic<bool>&) -> synth::RemoteProvider::HttpResult {
+        return makeStatus(testCase.httpStatus, "{}");
+    };
+
+    synth::RemoteProvider provider{kMockHost, performer};
+    provider.setTestMode(true);
+
+    MockPromptCallback callback;
+    provider.sendPrompt(
+        {{"user", "hi"}}, [&callback](const synth::AIProvider::AIResponse& r) { callback(r); }, makeSchema());
+
+    auto result = callback.getResult();
+    provider.stopThread(5000);
+
+    EXPECT_FALSE(result.success);
+    EXPECT_EQ(result.error.kind, testCase.expectedKind) << "for HTTP " << testCase.httpStatus;
+}
+
+INSTANTIATE_TEST_SUITE_P(HttpStatuses, RemoteProviderStatusMappingTest,
+                         ::testing::Values(StatusMappingCase{401, synth::AIProvider::AIErrorKind::Auth},
+                                           StatusMappingCase{403, synth::AIProvider::AIErrorKind::Auth},
+                                           StatusMappingCase{402, synth::AIProvider::AIErrorKind::Quota},
+                                           StatusMappingCase{400, synth::AIProvider::AIErrorKind::Schema},
+                                           StatusMappingCase{404, synth::AIProvider::AIErrorKind::Schema},
+                                           StatusMappingCase{500, synth::AIProvider::AIErrorKind::Server},
+                                           StatusMappingCase{502, synth::AIProvider::AIErrorKind::Server},
+                                           StatusMappingCase{418, synth::AIProvider::AIErrorKind::Server}));
+
+TEST_F(RemoteProviderTest, MapsTooManyRequestsToRateLimitAndReadsRetryAfter) {
+    juce::StringPairArray headers;
+    headers.set("Retry-After", "45");
+
+    auto performer = [&](const juce::String&, const juce::StringPairArray&, const juce::String&, int,
+                         const std::atomic<bool>&) -> synth::RemoteProvider::HttpResult {
+        return makeStatus(429, "{}", headers);
+    };
+
+    synth::RemoteProvider provider{kMockHost, performer};
+    provider.setTestMode(true);
+
+    MockPromptCallback callback;
+    provider.sendPrompt(
+        {{"user", "hi"}}, [&callback](const synth::AIProvider::AIResponse& r) { callback(r); }, makeSchema());
+
+    auto result = callback.getResult();
+    provider.stopThread(5000);
+
+    EXPECT_FALSE(result.success);
+    EXPECT_EQ(result.error.kind, synth::AIProvider::AIErrorKind::RateLimit);
+    EXPECT_EQ(result.error.retryAfterSeconds, 45);
+}
+
+// ============================================================================
+// Success / malformed bodies
+// ============================================================================
+
+TEST_F(RemoteProviderTest, SuccessReturnsDataReserializedAsJsonText) {
+    auto performer = [](const juce::String&, const juce::StringPairArray&, const juce::String&, int,
+                        const std::atomic<bool>&) -> synth::RemoteProvider::HttpResult {
+        return makeSuccess(R"({"data":{"nodes":[{"id":1,"type":"Oscillator"}]}})");
+    };
+
+    synth::RemoteProvider provider{kMockHost, performer};
+    provider.setTestMode(true);
+
+    MockPromptCallback callback;
+    provider.sendPrompt(
+        {{"user", "hi"}}, [&callback](const synth::AIProvider::AIResponse& r) { callback(r); }, makeSchema());
+
+    auto result = callback.getResult();
+    provider.stopThread(5000);
+
+    ASSERT_TRUE(result.success);
+    juce::var parsedContent = juce::JSON::parse(result.content);
+    ASSERT_TRUE(parsedContent.isObject());
+    auto* nodes = parsedContent.getProperty("nodes", juce::var()).getArray();
+    ASSERT_NE(nodes, nullptr);
+    ASSERT_EQ(nodes->size(), 1);
+    EXPECT_EQ((*nodes)[0].getProperty("type", juce::var()).toString(), juce::String("Oscillator"));
+}
+
+TEST_F(RemoteProviderTest, UnparseableSuccessBodyMapsToSchema) {
+    auto performer = [](const juce::String&, const juce::StringPairArray&, const juce::String&, int,
+                        const std::atomic<bool>&) -> synth::RemoteProvider::HttpResult {
+        return makeSuccess("not json at all");
+    };
+
+    synth::RemoteProvider provider{kMockHost, performer};
+    provider.setTestMode(true);
+
+    MockPromptCallback callback;
+    provider.sendPrompt(
+        {{"user", "hi"}}, [&callback](const synth::AIProvider::AIResponse& r) { callback(r); }, makeSchema());
+
+    auto result = callback.getResult();
+    provider.stopThread(5000);
+
+    EXPECT_FALSE(result.success);
+    EXPECT_EQ(result.error.kind, synth::AIProvider::AIErrorKind::Schema);
+}
+
+TEST_F(RemoteProviderTest, SuccessBodyWithNoDataKeyMapsToSchema) {
+    auto performer = [](const juce::String&, const juce::StringPairArray&, const juce::String&, int,
+                        const std::atomic<bool>&) -> synth::RemoteProvider::HttpResult {
+        return makeSuccess(R"({"foo":1})");
+    };
+
+    synth::RemoteProvider provider{kMockHost, performer};
+    provider.setTestMode(true);
+
+    MockPromptCallback callback;
+    provider.sendPrompt(
+        {{"user", "hi"}}, [&callback](const synth::AIProvider::AIResponse& r) { callback(r); }, makeSchema());
+
+    auto result = callback.getResult();
+    provider.stopThread(5000);
+
+    EXPECT_FALSE(result.success);
+    EXPECT_EQ(result.error.kind, synth::AIProvider::AIErrorKind::Schema);
+}
+
+TEST_F(RemoteProviderTest, ErrorBodyMessageIsAppendedToDeliveredError) {
+    auto performer = [](const juce::String&, const juce::StringPairArray&, const juce::String&, int,
+                        const std::atomic<bool>&) -> synth::RemoteProvider::HttpResult {
+        return makeStatus(502, R"({"error":{"code":"GENERATION_FAILED","message":"model timed out mid-generation"}})");
+    };
+
+    synth::RemoteProvider provider{kMockHost, performer};
+    provider.setTestMode(true);
+
+    MockPromptCallback callback;
+    provider.sendPrompt(
+        {{"user", "hi"}}, [&callback](const synth::AIProvider::AIResponse& r) { callback(r); }, makeSchema());
+
+    auto result = callback.getResult();
+    provider.stopThread(5000);
+
+    EXPECT_FALSE(result.success);
+    EXPECT_EQ(result.error.kind, synth::AIProvider::AIErrorKind::Server);
+    EXPECT_TRUE(result.error.message.contains("model timed out mid-generation"));
+}
+
+// ============================================================================
+// Transport-level failures
+// ============================================================================
+
+TEST_F(RemoteProviderTest, TransportFailureMapsToNetwork) {
+    auto performer = [](const juce::String&, const juce::StringPairArray&, const juce::String&, int,
+                        const std::atomic<bool>&) -> synth::RemoteProvider::HttpResult {
+        synth::RemoteProvider::HttpResult result;
+        result.transportFailed = true;
+        result.errorMessage = "Could not resolve host";
+        return result;
+    };
+
+    synth::RemoteProvider provider{kMockHost, performer};
+    provider.setTestMode(true);
+
+    MockPromptCallback callback;
+    provider.sendPrompt(
+        {{"user", "hi"}}, [&callback](const synth::AIProvider::AIResponse& r) { callback(r); }, makeSchema());
+
+    auto result = callback.getResult();
+    provider.stopThread(5000);
+
+    EXPECT_FALSE(result.success);
+    EXPECT_EQ(result.error.kind, synth::AIProvider::AIErrorKind::Network);
+}
+
+TEST_F(RemoteProviderTest, TimeoutMapsToTimeout) {
+    auto performer = [](const juce::String&, const juce::StringPairArray&, const juce::String&, int,
+                        const std::atomic<bool>&) -> synth::RemoteProvider::HttpResult {
+        synth::RemoteProvider::HttpResult result;
+        result.timedOut = true;
+        result.errorMessage = "timed out";
+        return result;
+    };
+
+    synth::RemoteProvider provider{kMockHost, performer};
+    provider.setTestMode(true);
+
+    MockPromptCallback callback;
+    provider.sendPrompt(
+        {{"user", "hi"}}, [&callback](const synth::AIProvider::AIResponse& r) { callback(r); }, makeSchema());
+
+    auto result = callback.getResult();
+    provider.stopThread(5000);
+
+    EXPECT_FALSE(result.success);
+    EXPECT_EQ(result.error.kind, synth::AIProvider::AIErrorKind::Timeout);
+}
+
+// ============================================================================
+// Cancellation
+// ============================================================================
+
+// A request still sitting in pendingRequests (never dequeued) when cancel() is called must be
+// delivered Cancelled promptly, and the fake performer must never be invoked for it at all.
+TEST_F(RemoteProviderTest, CancellingQueuedRequestDeliversCancelledWithoutInvokingPerformer) {
+    auto firstEntered = std::make_shared<CallbackLatch>();
+    auto firstGate = std::make_shared<CallbackLatch>(); // released to let the first request finish
+    std::atomic<int> performerCallCount{0};
+
+    auto performer = [firstEntered, firstGate,
+                      &performerCallCount](const juce::String&, const juce::StringPairArray&, const juce::String&, int,
+                                           const std::atomic<bool>& cancelled) -> synth::RemoteProvider::HttpResult {
+        const int callIndex = performerCallCount.fetch_add(1);
+        if (callIndex == 0) {
+            firstEntered->fire();
+            // Poll like a real curl progress callback would, but this request is never cancelled
+            // in this test — it is released explicitly once the assertions below are done.
+            int elapsedMs = 0;
+            while (!firstGate->hasFired() && !cancelled.load() && elapsedMs < 15000) {
+                juce::Thread::sleep(5);
+                elapsedMs += 5;
+            }
+            return makeSuccess(R"({"data":{}})");
+        }
+        // Must never be reached: request 2 is cancelled while still queued, before the worker
+        // ever pops it.
+        return makeSuccess(R"({"data":{}})");
+    };
+
+    synth::RemoteProvider provider{kMockHost, performer};
+    provider.setTestMode(true);
+
+    auto firstDone = std::make_shared<CallbackLatch>();
+    provider.sendPrompt(
+        {{"user", "first (long)"}}, [firstDone](const synth::AIProvider::AIResponse&) { firstDone->fire(); },
+        makeSchema());
+    ASSERT_TRUE(firstEntered->waitFor(kCallbackTimeout)) << "the worker never started the first request";
+
+    std::atomic<int> secondCallCount{0};
+    std::atomic<synth::AIProvider::AIErrorKind> secondKind{synth::AIProvider::AIErrorKind::None};
+    auto secondDone = std::make_shared<CallbackLatch>();
+    const auto secondId = provider.sendPrompt(
+        {{"user", "second (should be cancelled while queued)"}},
+        [&secondCallCount, &secondKind, secondDone](const synth::AIProvider::AIResponse& r) {
+            secondCallCount.fetch_add(1);
+            secondKind.store(r.error.kind);
+            secondDone->fire();
+        },
+        makeSchema());
+
+    provider.cancel(secondId);
+
+    ASSERT_TRUE(secondDone->waitFor(kCallbackTimeout)) << "cancelling a queued request left the caller hanging";
+    EXPECT_EQ(secondCallCount.load(), 1);
+    EXPECT_EQ(secondKind.load(), synth::AIProvider::AIErrorKind::Cancelled);
+    EXPECT_EQ(performerCallCount.load(), 1) << "the fake performer must not be invoked for a request cancelled "
+                                               "while it was still queued";
+
+    firstGate->fire();
+    ASSERT_TRUE(firstDone->waitFor(kCallbackTimeout)) << "the first request never completed";
+
+    provider.stopThread(5000);
+}
+
+// A request whose fake performer is currently "in flight" must notice cancellation via the
+// `cancelled` atomic it was handed — exactly what CURLOPT_XFERINFOFUNCTION does for real curl —
+// and the provider must deliver Cancelled once the performer returns.
+TEST_F(RemoteProviderTest, CancellingInFlightRequestDeliversCancelledOnceNoticed) {
+    auto entered = std::make_shared<CallbackLatch>();
+
+    auto performer = [entered](const juce::String&, const juce::StringPairArray&, const juce::String&, int,
+                               const std::atomic<bool>& cancelled) -> synth::RemoteProvider::HttpResult {
+        entered->fire();
+        int elapsedMs = 0;
+        while (!cancelled.load() && elapsedMs < 15000) {
+            juce::Thread::sleep(5);
+            elapsedMs += 5;
+        }
+        synth::RemoteProvider::HttpResult result;
+        result.transportFailed = true; // simulates CURLE_ABORTED_BY_CALLBACK; irrelevant to the
+                                       // caller, which checks `cancelled` before looking at this.
+        result.errorMessage = "aborted";
+        return result;
+    };
+
+    synth::RemoteProvider provider{kMockHost, performer};
+    provider.setTestMode(true);
+
+    std::atomic<int> callCount{0};
+    std::atomic<synth::AIProvider::AIErrorKind> kind{synth::AIProvider::AIErrorKind::None};
+    auto done = std::make_shared<CallbackLatch>();
+
+    const auto id = provider.sendPrompt(
+        {{"user", "long generation"}},
+        [&callCount, &kind, done](const synth::AIProvider::AIResponse& r) {
+            callCount.fetch_add(1);
+            kind.store(r.error.kind);
+            done->fire();
+        },
+        makeSchema());
+
+    ASSERT_TRUE(entered->waitFor(kCallbackTimeout)) << "the worker never reached the fake in-flight performer";
+
+    provider.cancel(id);
+
+    ASSERT_TRUE(done->waitFor(kCallbackTimeout)) << "cancel() left the caller hanging with no callback";
+    EXPECT_EQ(callCount.load(), 1);
+    EXPECT_EQ(kind.load(), synth::AIProvider::AIErrorKind::Cancelled);
+
+    provider.stopThread(5000);
+}
+
+// ============================================================================
+// Misc interface conformance
+// ============================================================================
+
+TEST_F(RemoteProviderTest, ProviderNameIsRemote) {
+    synth::RemoteProvider provider{kMockHost};
+    EXPECT_EQ(provider.getProviderName(), juce::String("Remote"));
+}
+
+TEST_F(RemoteProviderTest, FetchAvailableModelsReturnsEmptyListWithSuccess) {
+    auto performer = [](const juce::String&, const juce::StringPairArray&, const juce::String&, int,
+                        const std::atomic<bool>&) -> synth::RemoteProvider::HttpResult {
+        ADD_FAILURE() << "fetchAvailableModels must not hit the network";
+        return {};
+    };
+
+    synth::RemoteProvider provider{kMockHost, performer};
+    provider.setTestMode(true);
+
+    MockCompletionCallback callback;
+    provider.fetchAvailableModels(
+        [&callback](const juce::StringArray& models, bool success) { callback(models, success); });
+
+    auto result = callback.getResult();
+    EXPECT_TRUE(std::get<1>(result));
+    EXPECT_TRUE(std::get<0>(result).isEmpty());
+}
+
+TEST_F(RemoteProviderTest, SetAndGetCurrentModelRoundTripsCosmetically) {
+    synth::RemoteProvider provider{kMockHost};
+    provider.setModel("whatever-label");
+    EXPECT_EQ(provider.getCurrentModel(), juce::String("whatever-label"));
+}

--- a/docs/AI_Engine.md
+++ b/docs/AI_Engine.md
@@ -480,6 +480,100 @@ Locked by `OllamaProviderTest.CancelledRequestInvokesCallbackWithCancelledKind`,
 > hit Cancel, and confirm the input frees immediately and the next message is answered without delay.
 > A regression here is invisible to the suite — the mock path would still pass.
 
+### RemoteProvider: synth-platform Inference Service (libcurl, hidden pending Phase 4)
+
+`Source/AI/RemoteProvider.{h,cpp}` is the first non-Ollama `AIProvider`: it talks to a local
+instance of the `synth-platform` inference service over libcurl instead of `juce::WebInputStream`.
+It reuses `OllamaProvider`'s worker-thread/queue/cancellation architecture almost exactly
+(`queueLock`-guarded `pendingRequests`, `inFlight` map, `idle`/`starting`/`running` worker state,
+`claimDelivery()`/`deliverResult()`/`deliverError()` with the same exactly-once and
+`forceSynchronous`-during-shutdown contract) — see "OllamaProvider: Worker-Thread Contract" above
+for the rules this inherits unchanged.
+
+**Wire contract:**
+
+- `POST {host}/v1/capability/patch.generate`
+- Request: `{"productName": string, "userPrompt": string}` — `currentPatch` and `promptVersion`
+  are always omitted (not sent as `null`).
+- Success: HTTP 200, `{"data": <Patch JSON object>}`. `data` is re-serialized with
+  `juce::JSON::toString()` and delivered as `AIResponse::content` — the same raw-JSON-text shape
+  `AIIntegrationService::applyPatch()` already expects from any provider.
+- Error: non-2xx, `{"error": {"code": string, "message": string}}`.
+
+**Why `userPrompt` can carry the client's already-wrapped text unmodified.**
+`AIIntegrationService::buildPatchAugmentedContent()` renders the current graph into the *last*
+conversation message as `"Current patch state:\n\`\`\`json\n<JSON>\n\`\`\`\n\nUser request:
+<text>"` whenever the graph is non-empty, and leaves it as plain text otherwise. The service's own
+`buildUserMessage()` (`synth-platform/packages/capabilities/src/patch-generate/capability.ts`)
+performs the *exact same* wrapping server-side, from a separate `currentPatch` + `userPrompt`
+pair, and only wraps when `currentPatch` is present. Sending the client's already-wrapped text as
+`userPrompt` alone, with `currentPatch` omitted, therefore produces byte-identical model input to
+the "proper" structured split — without RemoteProvider ever having to parse the wrapper back
+apart. **Do not "fix" this into a parser** that splits `userPrompt` into `currentPatch` +
+`userPrompt` — it would just reimplement, and risk diverging from, wrapping the service already
+does.
+
+**Conversational mode is out of scope.** The service exposes only `patch.generate`; there is no
+plain-chat capability. `AIIntegrationService::sendMessage()` calls `sendPrompt()` with a void
+`responseSchema` for ordinary chat turns, so `RemoteProvider::sendPrompt()` fails fast — no
+network call — with `AIErrorKind::Schema` when `responseSchema.isVoid()`, mirroring
+`OllamaProvider`'s "no model selected" fail-fast precedent. It also fails fast the same way for an
+empty `conversation` or a blank/whitespace-only last message (mirrors the service's own
+`userPrompt: z.string().min(1)`).
+
+**Error-kind mapping** (checked in this order — `cancelled` is checked before any of the below,
+same as `OllamaProvider` checks `wasCancelled()` right after the network call returns):
+
+| Condition                                    | `AIErrorKind`                    |
+|-----------------------------------------------|-----------------------------------|
+| transport failure that wasn't a cancellation  | `Network`                        |
+| `timedOut`                                    | `Timeout`                        |
+| `cancelled`                                   | `Cancelled`                      |
+| HTTP 401 / 403                                | `Auth`                            |
+| HTTP 429 (reads `Retry-After`)                | `RateLimit`                      |
+| HTTP 402                                      | `Quota`                           |
+| HTTP 400 / 404                                | `Schema` (client/request-shape problem, not worth retrying as-is) |
+| HTTP 500 / 502 / any other unexpected non-2xx | `Server`                          |
+| 2xx with no parseable `data`                  | `Schema`                          |
+
+Whenever the response body parses as JSON with a string `error.message`, it is appended to the
+delivered error message (mirrors the "name the specific failure" ethos on
+`AIIntegrationService::buildCorrectionPrompt`); otherwise the message just names the HTTP status.
+
+**Cancellation, simplified vs `OllamaProvider`.** libcurl doesn't need the
+`StreamPublisher`/`activeStream`/`streamLock` machinery `OllamaProvider` uses to abort a
+`WebInputStream` mid-connect: `CURLOPT_XFERINFOFUNCTION` is invoked periodically by libcurl
+*during* the transfer, on the same thread running `curl_easy_perform()`, and returning non-zero
+aborts it with `CURLE_ABORTED_BY_CALLBACK`. `RequestState` therefore only needs `cancelled` and
+`delivered` atomics. `cancel()` on a still-queued request pulls it out of `pendingRequests` and
+delivers `Cancelled` immediately (identical to `OllamaProvider::cancel()`'s queued branch);
+`cancel()` on an in-flight request just sets the flag — the worker's own progress callback notices
+it inside `curl_easy_perform()` and unwinds on its own. A `CURL*` handle is never touched from any
+thread other than the one running `curl_easy_perform()` for it.
+
+**HTTP transport seam.** `RemoteProvider::HttpPerformer` (`RemoteProvider.h`) parallels
+`OllamaProvider::InputStreamFactory`: a constructor taking just a host installs the real
+libcurl-backed performer, and a second constructor injects a fake one for tests (no real sockets —
+see `Tests/RemoteProviderTests.cpp`).
+
+**Windows is not supported yet.** `RemoteProvider.cpp`'s libcurl implementation is compiled only
+under `#ifndef _WIN32`; the `#else` branch is a stub returning `transportFailed=true` with a clear
+message, touching no curl API. The `windows-latest` CI job has no libcurl setup step, and the P2-5
+spike already flagged Windows/WinINet as an unverified follow-up risk rather than a P2-7 blocker.
+Root `CMakeLists.txt` requires `CURL` (`find_package(CURL REQUIRED)`) under `if(NOT WIN32)` —
+covering both Linux and macOS (whose SDK ships a `curl.tbd` stub, so no Homebrew dependency is
+needed there) — and deliberately does not require it on `WIN32`.
+
+**Ships hidden.** `ProviderDescriptor::hidden` (`Source/AI/AIProviderRegistry.h`) is a runtime
+flag, not a build-time one: `RemoteProvider` is fully registered and constructible via
+`AIProviderRegistry::createDefault()` (id `"remote"`, registered after `"ollama"` so the
+unknown-id fallback to `descriptors.front()` is unaffected), but `AISettingsTab`
+(`Source/UI/SettingsWindow.cpp`) filters out any `hidden` descriptor before populating the
+provider combo box, via a `visibleProviders` member used consistently by both the population loop
+and `selectedDescriptor()` (indexing the combo's selected item against the *unfiltered* list would
+desync the moment a hidden entry sits between two visible ones). Phase 4 is expected to flip
+`"remote"`'s `hidden` to `false`.
+
 ## 6. Future Considerations
 
 -   **Direct Saving of AI Suggested Patches**: Implement functionality for users to directly save AI-generated patches as presets.


### PR DESCRIPTION
## Summary
- First non-Ollama `AIProvider`: `RemoteProvider` talks to a local `synth-platform` inference service instance (`POST {host}/v1/capability/patch.generate`) over libcurl, closing the client<->service loop against `http://localhost:8787` before anything gets deployed.
- Mirrors `OllamaProvider`'s worker-thread/queue/exactly-once-delivery architecture; cancellation is simpler since libcurl's `CURLOPT_XFERINFOFUNCTION` progress callback replaces the stream-publish machinery.
- Ships registered in `AIProviderRegistry` but hidden from the Settings UI (`ProviderDescriptor::hidden`, a runtime flag) until a later phase turns it on.
- Non-streaming (`onDelta` accepted, never invoked) — the service endpoint isn't streaming-capable.
- Fails fast (no network call) on conversational (non-patch) requests, since the service currently exposes only `patch.generate`.
- The client's existing prompt-augmentation text passes through to the service's `userPrompt` field unmodified — verified byte-identical to what the service's own `buildUserMessage()` would produce from a structured `currentPatch`+`userPrompt` split, so no fragile re-parsing is needed (see `docs/AI_Engine.md` for the full argument).
- CMake links `CURL::libcurl` on macOS + Linux only (`if(NOT WIN32)`); Windows gets a stub that never touches the curl API, since `windows-latest` CI has no libcurl setup.

## Test plan
- [x] `cmake -S . -B build -DENABLE_TESTS=ON && cmake --build build --target Tests` — clean configure and build
- [x] `./build/Tests/Tests` — 720/720 passed (92 suites)
- [x] New `Tests/RemoteProviderTests.cpp`: request shape/passthrough, auth header, fail-fast cases (void schema, empty conversation, blank prompt), full HTTP-status→`AIErrorKind` mapping table, success/malformed-body handling, error-message enrichment, transport failure/timeout, both cancellation paths (queued vs. in-flight)
- [x] `Tests/AIProviderRegistryTests.cpp` extended to assert `createDefault()` registers `"ollama"` (unhidden, first) and `"remote"` (hidden)
- [x] `SettingsWindowTest` suite still green after the `visibleProviders` filtering fix

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
