### PR TITLE
feat(module): add Pitch Shifter / Frequency Shifter FX module (#155)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,7 @@ Every implementation plan **must** include:
 
 - [`docs/architecture.md`](docs/architecture.md) — layers, core classes (ModuleBase, AudioEngine, GraphEditor, UndoManager, LookAndFeel), bypass/mute contract, signal flow
 - [`docs/modules.md`](docs/modules.md) — per-module specs + poly channel layouts (Oscillator, Filter, VCA, ADSR, LFO, Sequencer, Poly MIDI, Voice Mixer …)
-- [`docs/fx_modules.md`](docs/fx_modules.md) — FX specs (Distortion, Delay, Reverb, Chorus, Phaser, Compressor, Flanger, Limiter)
+- [`docs/fx_modules.md`](docs/fx_modules.md) — FX specs (Distortion, Delay, Reverb, Chorus, Phaser, Compressor, Flanger, Limiter, Pitch Shifter)
 - [`docs/modulation.md`](docs/modulation.md) — routing model, logical-port API, poly-bus wires, attenuverters, visual signal flow
 - [`docs/layout.md`](docs/layout.md) — grid/snap/auto-arrange, toolbar & status-bar chrome, width buckets, visualizer components, UI perf, animation system (UIAnimation.h, AnimationDriver, micro-interactions), alignment guides
 - [`docs/theming.md`](docs/theming.md) — theme tokens, SVG icons, JSON user themes, LookAndFeel, font limitation, Metrics fields (including code-only rendering constants)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ Every implementation plan **must** include:
 
 - [`docs/architecture.md`](docs/architecture.md) — layers, core classes (ModuleBase, AudioEngine, GraphEditor, UndoManager, LookAndFeel), bypass/mute contract, signal flow
 - [`docs/modules.md`](docs/modules.md) — per-module specs + poly channel layouts (Oscillator, Filter, VCA, ADSR, LFO, Sequencer, Poly MIDI, Voice Mixer …)
-- [`docs/fx_modules.md`](docs/fx_modules.md) — FX specs (Distortion, Delay, Reverb, Chorus, Phaser, Compressor, Flanger, Limiter)
+- [`docs/fx_modules.md`](docs/fx_modules.md) — FX specs (Distortion, Delay, Reverb, Chorus, Phaser, Compressor, Flanger, Limiter, Pitch Shifter)
 - [`docs/modulation.md`](docs/modulation.md) — routing model, logical-port API, poly-bus wires, attenuverters, visual signal flow
 - [`docs/layout.md`](docs/layout.md) — grid/snap/auto-arrange, toolbar & status-bar chrome, width buckets, visualizer components, UI perf, animation system (UIAnimation.h, AnimationDriver, micro-interactions)
 - [`docs/theming.md`](docs/theming.md) — theme tokens, SVG icons, JSON user themes, LookAndFeel, font limitation

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,7 @@ add_library(Core STATIC
     Source/Modules/FX/FlangerModule.h
     Source/Modules/FX/LimiterModule.h
     Source/Modules/FX/BitcrusherModule.h
+    Source/Modules/FX/PitchShifterModule.h
     Source/Modules/NoiseModule.h
     # AI
     Source/AI/AIProvider.h

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -37,7 +37,7 @@ The project follows a modular architecture with:
 - LFO: Low Frequency Oscillator for modulation
 - Sequencer: Step sequencer with per-step pitch control
 - MIDI Keyboard: Interactive on-screen keyboard for MIDI input
-- FX Modules: Delay, Distortion, Reverb, Chorus, Phaser, Compressor, Flanger, Limiter
+- FX Modules: Delay, Distortion, Reverb, Chorus, Phaser, Compressor, Flanger, Limiter, Pitch Shifter
 - Preset System: Factory presets with categorized organization
 - Poly MIDI: Polyphonic MIDI input handling (ch0-7=pitch Hz, ch8-15=gate); `voiceMaskAtomic_` (`std::atomic<uint8_t>`) written end-of-processBlock — read by `AudioEngine::getDisplayVoiceCount()` via `std::popcount` without locks
 - Poly Sequencer: Polyphonic step sequencer
@@ -156,6 +156,7 @@ Refer to [docs/shortcuts.md](docs/shortcuts.md) for the full list of configurabl
 - `Source/Modules/FX/CompressorModule.h`: Compressor with manual makeup gain
 - `Source/Modules/FX/FlangerModule.h`: Flanger via `juce::dsp::Chorus` with low-delay tuning
 - `Source/Modules/FX/LimiterModule.h`: Brickwall limiter with input gain drive
+- `Source/Modules/FX/PitchShifterModule.h`: Dual-mode pitch (delay-line transposition) / frequency (Hilbert SSB) shifter
 - `Source/UI/AIChatComponent.cpp/.h`: Chat interface for AI-assisted patching. **Logging gotcha:** this component registers itself as the global `juce::Logger` (`setCurrentLogger`) and pipes every `juce::Logger::writeToLog(...)` into a `TextEditor` debug console (Debug builds only). Appends are coalesced + the console is length-bounded, but DO NOT add high-frequency `writeToLog` calls (per-parameter, per-sample, per-frame, per-connection) — they run on the UI thread. Keep logging to errors/rare events. (A per-parameter log on preset load once caused a multi-second UI freeze; guarded by `AIStateMapperTest.PresetLoadDoesNotSpamLogger`.) Visibility persists via `ApplicationProperties` key `"aiPanelVisible"` (default false); read at top of `MainComponent::initialiseCommon()`
 - **UI rendering perf:** `ModuleComponent` uses `setBufferedToImage(true)` and gates its 15Hz `timerCallback` repaint (RMS-change / active-modulation / sequencer-step-change only) so the GraphEditor's 30Hz connection animation composites cached module images instead of re-running JUCE text layout every frame. Don't reintroduce unconditional per-tick `repaint()` on modules or their always-visible children. A theme switch triggers exactly ONE re-skin pass (`AppLookAndFeel::applyTheme` → `sendLookAndFeelChangeMessage` → single `repaint()`) — no timer or continuous repaint is added. `applyToolbarIcons()` (Drawable clone work) is gated to narrow-mode transitions in `MainComponent::resized()` — not called on every resize frame. Status bar polls at 5 Hz (every 2nd 10 Hz timer tick) and repaints only itself; ZERO `writeToLog` calls in any status-polling path.
 - `Source/UI/ScopeComponent.h`: Oscilloscope/waveform display component

--- a/Source/AI/AIStateMapper.cpp
+++ b/Source/AI/AIStateMapper.cpp
@@ -11,6 +11,7 @@
 #include "../Modules/FX/FlangerModule.h"
 #include "../Modules/FX/LimiterModule.h"
 #include "../Modules/FX/PhaserModule.h"
+#include "../Modules/FX/PitchShifterModule.h"
 #include "../Modules/FX/ReverbModule.h"
 #include "../Modules/FilterModule.h"
 #include "../Modules/LFOModule.h"
@@ -64,6 +65,7 @@ static const std::unordered_map<juce::String, ModuleFactoryFunc> moduleFactory =
     {"Limiter", []() { return std::make_unique<LimiterModule>(); }},
     {"Voice Mixer", []() { return std::make_unique<VoiceMixerModule>(); }},
     {"Bitcrusher", []() { return std::make_unique<BitcrusherModule>(); }},
+    {"Pitch Shifter", []() { return std::make_unique<PitchShifterModule>(); }},
     {"Noise", []() { return std::make_unique<NoiseModule>(); }},
     {"External MIDI", []() { return std::make_unique<ExternalMidiModule>(); }}};
 
@@ -513,6 +515,8 @@ static juce::String getFactoryTypeName(juce::AudioProcessor* processor) {
             return "Voice Mixer";
         case ModuleType::Bitcrusher:
             return "Bitcrusher";
+        case ModuleType::PitchShifter:
+            return "Pitch Shifter";
         case ModuleType::Noise:
             return "Noise";
         case ModuleType::ExternalMidi:
@@ -1061,8 +1065,8 @@ bool AIStateMapper::applyJSONToGraph(const juce::var& json, juce::AudioProcessor
         if (audioOutputNode != nullptr) {
             // Types that produce audio and should auto-connect to output
             static const std::set<juce::String> audioNodeTypes = {
-                "Oscillator", "Noise",  "Filter", "VCA",        "Distortion", "Delay",   "Reverb",    "Amp Env",
-                "Filter Env", "Chorus", "Phaser", "Compressor", "Flanger",    "Limiter", "Bitcrusher"};
+                "Oscillator", "Noise",  "Filter", "VCA",        "Distortion", "Delay",   "Reverb",     "Amp Env",
+                "Filter Env", "Chorus", "Phaser", "Compressor", "Flanger",    "Limiter", "Bitcrusher", "Pitch Shifter"};
 
             for (auto newNodeId : newlyCreatedNodes) {
                 auto* node = graph.getNodeForId(newNodeId);

--- a/Source/Modules/FX/PitchShifterModule.h
+++ b/Source/Modules/FX/PitchShifterModule.h
@@ -1,0 +1,370 @@
+#pragma once
+
+#include "../ModuleBase.h"
+#include <cmath>
+
+/**
+    Dual-mode pitch / frequency shifter.
+
+    Two independent algorithms share one module because they answer the same musical
+    question ("move this signal in frequency") with opposite characters:
+
+    - **Pitch** mode transposes by a *ratio* (semitones + cents), so harmonic
+      relationships are preserved — the classic detune / octaver sound. It uses a
+      two-tap crossfaded delay line: both taps read the same write head at delays that
+      sweep across one window, half a window apart, summed with an equal-power window
+      so the tap discontinuity always lands where that tap's gain is zero.
+
+    - **Frequency** mode adds a *constant* offset in Hz via single-sideband modulation
+      (a Hilbert transform pair driving a quadrature oscillator). Harmonics stop being
+      integer multiples of the fundamental, which is what produces ring-mod-adjacent
+      "alien voice" and metallic timbres.
+
+    Feedback routes the shifted output back into the input, so each pass is shifted
+    again — cascading octaves in Pitch mode, barber-pole / Shepard-tone illusions in
+    Frequency mode. It is soft-clipped so the loop stays bounded at high settings.
+*/
+class PitchShifterModule : public ModuleBase {
+public:
+    PitchShifterModule()
+        : ModuleBase("Pitch Shifter", 6, 2) // 2 audio + 4 CV (Pitch, Shift, Mix, Feedback)
+    {
+        addParameter(modeParam = new juce::AudioParameterChoice("shiftMode", "Mode", {"Pitch", "Frequency"}, 0));
+        addParameter(pitchParam = new juce::AudioParameterFloat("pitch", "Pitch (semi)", -24.0f, 24.0f, 0.0f));
+        addParameter(fineParam = new juce::AudioParameterFloat("fine", "Fine (cents)", -100.0f, 100.0f, 0.0f));
+        addParameter(shiftParam = new juce::AudioParameterFloat("shiftHz", "Shift (Hz)", -1000.0f, 1000.0f, 0.0f));
+        addParameter(windowParam =
+                         new juce::AudioParameterFloat("window", "Window (ms)", kMinWindowMs, kMaxWindowMs, 50.0f));
+        addParameter(feedbackParam = new juce::AudioParameterFloat("feedback", "Feedback", 0.0f, kMaxFeedback, 0.0f));
+        addParameter(mixParam = new juce::AudioParameterFloat("mix", "Mix", 0.0f, 1.0f, 1.0f));
+        addMuteParameter();
+        enableVisualBuffer(true);
+    }
+
+    void prepareToPlay(double sampleRate, int samplesPerBlock) override {
+        juce::ignoreUnused(samplesPerBlock);
+        currentSampleRate = (sampleRate > 0.0) ? sampleRate : 44100.0;
+
+        // Longest tap delay equals one window, so the line only needs the largest window
+        // plus a couple of samples of headroom for the interpolator.
+        delayLength = (int)std::ceil(currentSampleRate * (kMaxWindowMs / 1000.0)) + 8;
+        delayLine.setSize(2, delayLength);
+        delayLine.clear();
+        writePos = 0;
+
+        smoothedPitch.reset(currentSampleRate, 0.02);
+        smoothedShift.reset(currentSampleRate, 0.02);
+        smoothedWindow.reset(currentSampleRate, 0.05);
+        smoothedFeedback.reset(currentSampleRate, 0.02);
+        smoothedMix.reset(currentSampleRate, 0.005);
+
+        smoothedPitch.setCurrentAndTargetValue(*pitchParam + *fineParam * 0.01f);
+        smoothedShift.setCurrentAndTargetValue(*shiftParam);
+        smoothedWindow.setCurrentAndTargetValue(*windowParam);
+        smoothedFeedback.setCurrentAndTargetValue(*feedbackParam);
+        smoothedMix.setCurrentAndTargetValue(*mixParam);
+
+        phase = 0.0f;
+        oscPhase = 0.0f;
+        lastShifted[0] = lastShifted[1] = 0.0f;
+
+        for (int ch = 0; ch < 2; ++ch) {
+            hilbert[ch].reset();
+            hilbert[ch].setCoefficients();
+        }
+    }
+
+    void processBlock(juce::AudioBuffer<float>& buffer, juce::MidiBuffer& midiMessages) override {
+        juce::ignoreUnused(midiMessages);
+        juce::ScopedNoDenormals noDenormals;
+
+        const int numSamples = buffer.getNumSamples();
+        const int numChannels = buffer.getNumChannels();
+
+        if (numSamples == 0 || numChannels == 0)
+            return;
+
+        if (isMuted()) {
+            buffer.clear();
+            return;
+        }
+
+        if (isBypassed()) {
+            // Pass dry audio through; clear CV channels so mod signals don't leak downstream
+            for (int ch = 2; ch < numChannels; ++ch)
+                buffer.clear(ch, 0, numSamples);
+            return;
+        }
+
+        if (numChannels < 2 || delayLength <= 0) {
+            for (int ch = 2; ch < numChannels; ++ch)
+                buffer.clear(ch, 0, numSamples);
+            return;
+        }
+
+        const float* cvPitch = (numChannels > 2) ? buffer.getReadPointer(2) : nullptr;
+        const float* cvShift = (numChannels > 3) ? buffer.getReadPointer(3) : nullptr;
+        const float* cvMix = (numChannels > 4) ? buffer.getReadPointer(4) : nullptr;
+        const float* cvFeedback = (numChannels > 5) ? buffer.getReadPointer(5) : nullptr;
+
+        const bool cvPitchActive = isChannelActive(cvPitch, numSamples);
+        const bool cvShiftActive = isChannelActive(cvShift, numSamples);
+        const bool cvMixActive = isChannelActive(cvMix, numSamples);
+        const bool cvFeedbackActive = isChannelActive(cvFeedback, numSamples);
+
+        smoothedPitch.setTargetValue(*pitchParam + *fineParam * 0.01f);
+        smoothedShift.setTargetValue(*shiftParam);
+        smoothedWindow.setTargetValue(*windowParam);
+        smoothedFeedback.setTargetValue(*feedbackParam);
+        smoothedMix.setTargetValue(*mixParam);
+
+        const bool frequencyMode = (modeParam->getIndex() == 1);
+        const float twoPi = juce::MathConstants<float>::twoPi;
+
+        float* outL = buffer.getWritePointer(0);
+        float* outR = buffer.getWritePointer(1);
+
+        for (int i = 0; i < numSamples; ++i) {
+            // Raw CV is normalised [-1, 1]; each target maps it onto its full native range
+            // (depth is set by the attenuverter on the cable, never by an internal knob).
+            const float pitchMod = cvPitchActive ? cvPitch[i] * 24.0f : 0.0f;
+            const float shiftMod = cvShiftActive ? cvShift[i] * 1000.0f : 0.0f;
+            const float mixMod = cvMixActive ? cvMix[i] : 0.0f;
+            const float feedbackMod = cvFeedbackActive ? cvFeedback[i] * kMaxFeedback : 0.0f;
+
+            const float semitones = juce::jlimit(-48.0f, 48.0f, smoothedPitch.getNextValue() + pitchMod);
+            const float shiftHz = juce::jlimit(-2000.0f, 2000.0f, smoothedShift.getNextValue() + shiftMod);
+            const float windowMs = smoothedWindow.getNextValue();
+            const float feedback = juce::jlimit(0.0f, kMaxFeedback, smoothedFeedback.getNextValue() + feedbackMod);
+            const float mix = juce::jlimit(0.0f, 1.0f, smoothedMix.getNextValue() + mixMod);
+
+            const float dryL = outL[i];
+            const float dryR = outR[i];
+
+            // Soft-clip the feedback so a long shifted-and-refed chain cannot run away.
+            const float inL = dryL + (feedback > 0.0f ? std::tanh(feedback * lastShifted[0]) : 0.0f);
+            const float inR = dryR + (feedback > 0.0f ? std::tanh(feedback * lastShifted[1]) : 0.0f);
+
+            // Always keep the delay line warm so switching modes mid-signal doesn't
+            // replay a stale buffer.
+            delayLine.setSample(0, writePos, inL);
+            delayLine.setSample(1, writePos, inR);
+
+            float wetL, wetR;
+
+            if (frequencyMode) {
+                oscPhase += twoPi * shiftHz / (float)currentSampleRate;
+                while (oscPhase >= twoPi)
+                    oscPhase -= twoPi;
+                while (oscPhase < 0.0f)
+                    oscPhase += twoPi;
+
+                const float cosT = std::cos(oscPhase);
+                const float sinT = std::sin(oscPhase);
+
+                wetL = hilbert[0].shift(inL, cosT, sinT);
+                wetR = hilbert[1].shift(inR, cosT, sinT);
+            } else {
+                const float ratio = std::pow(2.0f, semitones / 12.0f);
+                const float windowSamples = juce::jmax(32.0f, windowMs * 0.001f * (float)currentSampleRate);
+
+                if (std::abs(ratio - 1.0f) < kUnityRatioEpsilon) {
+                    // At unity the two taps would sit at fixed, different delays and comb-filter
+                    // the input, so Pitch = 0 emits the signal untransposed instead.
+                    phase = 0.0f;
+                    wetL = inL;
+                    wetR = inR;
+                } else {
+                    // r(t) = w(t) - d(t) must advance at `ratio`, so d' = 1 - ratio; normalising
+                    // by the window turns that into a phase that sweeps one window per cycle.
+                    phase += (1.0f - ratio) / windowSamples;
+                    while (phase >= 1.0f)
+                        phase -= 1.0f;
+                    while (phase < 0.0f)
+                        phase += 1.0f;
+
+                    const float fracA = phase;
+                    const float fracB = (fracA < 0.5f) ? fracA + 0.5f : fracA - 0.5f;
+
+                    // Equal-power window: gainA^2 + gainB^2 == 1, and each gain is zero exactly
+                    // where its own tap wraps, so the wrap is inaudible.
+                    const float gainA = std::sin(juce::MathConstants<float>::pi * fracA);
+                    const float gainB = std::abs(std::cos(juce::MathConstants<float>::pi * fracA));
+
+                    const float delayA = juce::jlimit(kMinReadDelay, windowSamples, fracA * windowSamples);
+                    const float delayB = juce::jlimit(kMinReadDelay, windowSamples, fracB * windowSamples);
+
+                    wetL = gainA * readDelayed(0, delayA) + gainB * readDelayed(0, delayB);
+                    wetR = gainA * readDelayed(1, delayA) + gainB * readDelayed(1, delayB);
+                }
+            }
+
+            lastShifted[0] = wetL;
+            lastShifted[1] = wetR;
+
+            outL[i] = dryL * (1.0f - mix) + wetL * mix;
+            outR[i] = dryR * (1.0f - mix) + wetR * mix;
+
+            if (++writePos >= delayLength)
+                writePos = 0;
+        }
+
+        if (auto* vb = getVisualBuffer()) {
+            for (int i = 0; i < numSamples; ++i)
+                vb->pushSample(outL[i]);
+        }
+
+        // Clear CV channels to prevent leaking to downstream modules
+        for (int ch = 2; ch < numChannels; ++ch)
+            buffer.clear(ch, 0, numSamples);
+    }
+
+    juce::String getInputPortLabel(int i) const override {
+        const juce::String labels[] = {"Left", "Right", "Pitch", "Shift", "Mix", "Feedback"};
+        return (i >= 0 && i < 6) ? labels[i] : ModuleBase::getInputPortLabel(i);
+    }
+    juce::String getOutputPortLabel(int i) const override { return i == 0 ? "Left" : "Right"; }
+
+    std::vector<ModulationTarget> getModulationTargets() const override {
+        return {{"Pitch", 2}, {"Shift", 3}, {"Mix", 4}, {"Feedback", 5}};
+    }
+
+    ModulationCategory getModulationCategory() const override { return ModulationCategory::FX; }
+    ModuleType getModuleType() const override { return ModuleType::PitchShifter; }
+
+    double getTailLengthSeconds() const override { return kMaxWindowMs / 1000.0; }
+
+private:
+    static constexpr float kMinWindowMs = 10.0f;
+    static constexpr float kMaxWindowMs = 100.0f;
+    static constexpr float kMaxFeedback = 0.95f;
+    // ~0.0017 semitones — narrow enough that sweeping the knob passes straight through it.
+    static constexpr float kUnityRatioEpsilon = 1.0e-4f;
+    // The cubic interpolator looks one sample ahead of the read index, so never read closer
+    // than two samples behind the write head (both taps are windowed to ~0 gain there anyway).
+    static constexpr float kMinReadDelay = 2.0f;
+
+    static bool isChannelActive(const float* channel, int numSamples) {
+        if (!channel)
+            return false;
+        for (int i = 0; i < numSamples; ++i) {
+            if (channel[i] != 0.0f)
+                return true;
+        }
+        return false;
+    }
+
+    /** Reads the delay line `delaySamples` behind the write head with cubic Hermite
+        interpolation — linear interpolation would audibly dull a transposed signal. */
+    float readDelayed(int ch, float delaySamples) const {
+        const float pos = (float)writePos - delaySamples;
+        int index = (int)std::floor(pos);
+        const float t = pos - (float)index;
+
+        const float* data = delayLine.getReadPointer(ch);
+        const auto wrap = [this](int i) { return ((i % delayLength) + delayLength) % delayLength; };
+
+        const float x0 = data[wrap(index - 1)];
+        const float x1 = data[wrap(index)];
+        const float x2 = data[wrap(index + 1)];
+        const float x3 = data[wrap(index + 2)];
+
+        const float c0 = x1;
+        const float c1 = 0.5f * (x2 - x0);
+        const float c2 = x0 - 2.5f * x1 + 2.0f * x2 - 0.5f * x3;
+        const float c3 = 0.5f * (x3 - x0) + 1.5f * (x1 - x2);
+
+        return ((c3 * t + c2) * t + c1) * t + c0;
+    }
+
+    /** Hilbert transform pair (two cascaded 2nd-order allpass chains whose outputs stay
+        ~90 degrees apart across the audio band) feeding a single-sideband modulator. */
+    struct HilbertShifter {
+        struct Allpass {
+            float aSquared = 0.0f;
+            float x1 = 0.0f, x2 = 0.0f, y1 = 0.0f, y2 = 0.0f;
+
+            // H(z) = (a^2 - z^-2) / (1 - a^2 z^-2)
+            float process(float x) {
+                const float y = aSquared * (x + y2) - x2;
+                x2 = x1;
+                x1 = x;
+                y2 = y1;
+                y1 = y;
+                return y;
+            }
+
+            void reset() { x1 = x2 = y1 = y2 = 0.0f; }
+        };
+
+        // Olli Niemitalo's allpass coefficient pair — the standard wideband 90-degree
+        // approximation used for SSB modulation.
+        void setCoefficients() {
+            static constexpr float kInPhase[4] = {0.6923878f, 0.9360654322959f, 0.9882295226860f, 0.9987488452737f};
+            static constexpr float kQuadrature[4] = {0.4021921162426f, 0.8561710882420f, 0.9722909545651f,
+                                                     0.9952884791278f};
+            for (int i = 0; i < 4; ++i) {
+                inPhase[i].aSquared = kInPhase[i] * kInPhase[i];
+                quadrature[i].aSquared = kQuadrature[i] * kQuadrature[i];
+            }
+        }
+
+        void reset() {
+            for (int i = 0; i < 4; ++i) {
+                inPhase[i].reset();
+                quadrature[i].reset();
+            }
+            delayed = 0.0f;
+        }
+
+        /** Returns the input shifted up by the oscillator whose current cos/sin are given.
+            A negative oscillator frequency shifts down; no separate branch is needed. */
+        float shift(float x, float cosT, float sinT) {
+            float i = x;
+            for (auto& stage : inPhase)
+                i = stage.process(i);
+
+            float q = x;
+            for (auto& stage : quadrature)
+                q = stage.process(q);
+
+            // The in-phase chain is defined relative to a one-sample-delayed signal.
+            const float iDelayed = delayed;
+            delayed = i;
+
+            // The quadrature branch leads the in-phase branch by 90 degrees, so the upper
+            // sideband is the *sum* here; measured rejection of the lower one is ~55 dB.
+            return iDelayed * cosT + q * sinT;
+        }
+
+        Allpass inPhase[4];
+        Allpass quadrature[4];
+        float delayed = 0.0f;
+    };
+
+    double currentSampleRate = 44100.0;
+
+    juce::AudioBuffer<float> delayLine;
+    int delayLength = 0;
+    int writePos = 0;
+
+    float phase = 0.0f;    // pitch-mode crossfade position, [0, 1)
+    float oscPhase = 0.0f; // frequency-mode quadrature oscillator, [0, 2pi)
+    float lastShifted[2] = {0.0f, 0.0f};
+
+    HilbertShifter hilbert[2];
+
+    juce::SmoothedValue<float, juce::ValueSmoothingTypes::Linear> smoothedPitch;
+    juce::SmoothedValue<float, juce::ValueSmoothingTypes::Linear> smoothedShift;
+    juce::SmoothedValue<float, juce::ValueSmoothingTypes::Linear> smoothedWindow;
+    juce::SmoothedValue<float, juce::ValueSmoothingTypes::Linear> smoothedFeedback;
+    juce::SmoothedValue<float, juce::ValueSmoothingTypes::Linear> smoothedMix;
+
+    juce::AudioParameterChoice* modeParam = nullptr;
+    juce::AudioParameterFloat* pitchParam = nullptr;
+    juce::AudioParameterFloat* fineParam = nullptr;
+    juce::AudioParameterFloat* shiftParam = nullptr;
+    juce::AudioParameterFloat* windowParam = nullptr;
+    juce::AudioParameterFloat* feedbackParam = nullptr;
+    juce::AudioParameterFloat* mixParam = nullptr;
+};

--- a/Source/Modules/ModuleBase.h
+++ b/Source/Modules/ModuleBase.h
@@ -45,6 +45,7 @@ enum class ModuleType {
     Limiter,
     VoiceMixer,
     Bitcrusher,
+    PitchShifter,
     Noise
 };
 

--- a/Source/UI/LayoutUtil.cpp
+++ b/Source/UI/LayoutUtil.cpp
@@ -147,6 +147,7 @@ int roleRank(ModuleType t) {
     case ModuleType::Flanger:
     case ModuleType::Limiter:
     case ModuleType::Bitcrusher:
+    case ModuleType::PitchShifter:
         return 2;
     case ModuleType::ADSR:
     case ModuleType::LFO:

--- a/Source/UI/ModuleComponent.cpp
+++ b/Source/UI/ModuleComponent.cpp
@@ -1120,7 +1120,8 @@ void ModuleComponent::mouseDown(const juce::MouseEvent& e) {
                       {"Phaser", ModuleType::Phaser},
                       {"Flanger", ModuleType::Flanger},
                       {"Distortion", ModuleType::Distortion},
-                      {"Bitcrusher", ModuleType::Bitcrusher}}},
+                      {"Bitcrusher", ModuleType::Bitcrusher},
+                      {"Pitch Shifter", ModuleType::PitchShifter}}},
                     {"Time FX", {{"Delay", ModuleType::Delay}, {"Reverb", ModuleType::Reverb}}},
                     {"Dynamics", {{"Compressor", ModuleType::Compressor}, {"Limiter", ModuleType::Limiter}}},
                 };

--- a/Source/UI/ModuleLibraryComponent.h
+++ b/Source/UI/ModuleLibraryComponent.h
@@ -36,6 +36,7 @@ public:
             {"Flanger", false},
             {"Distortion", false},
             {"Bitcrusher", false},
+            {"Pitch Shifter", false},
             {"Time FX", true},
             {"Delay", false},
             {"Reverb", false},
@@ -87,6 +88,8 @@ public:
             return "Waveshaping distortion from soft saturation to hard clipping.";
         if (moduleName.equalsIgnoreCase("Bitcrusher"))
             return "For Lo-Fi, sample-rate reduction, and retro digital grit.";
+        if (moduleName.equalsIgnoreCase("Pitch Shifter"))
+            return "Transposes by semitones or shifts every partial by a fixed number of Hz.";
         if (moduleName.equalsIgnoreCase("Delay"))
             return "Tempo-syncable stereo echo / delay line.";
         if (moduleName.equalsIgnoreCase("Reverb"))

--- a/Tests/AIStateMapperTests.cpp
+++ b/Tests/AIStateMapperTests.cpp
@@ -263,7 +263,7 @@ TEST(AIStateMapperTest, FactorySupportsAllModuleTypes) {
                                        "VCA",         "ADSR",           "Sequencer",     "LFO",        "Distortion",
                                        "Delay",       "Reverb",         "MIDI Keyboard", "Amp Env",    "Filter Env",
                                        "Poly MIDI",   "Poly Sequencer", "Attenuverter",  "Chorus",     "Phaser",
-                                       "Compressor",  "Flanger",        "Limiter",       "Bitcrusher"};
+                                       "Compressor",  "Flanger",        "Limiter",       "Bitcrusher", "Pitch Shifter"};
     for (const auto& type : expectedTypes) {
         auto module = synth::AIStateMapper::createModule(type);
         EXPECT_NE(module, nullptr) << "Failed to create module: " << type.toStdString();

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -40,6 +40,7 @@ add_executable(Tests
     AIUndoTests.cpp
     ModMatrixTests.cpp
     FXModuleTests.cpp
+    PitchShifterModuleTests.cpp
     VoiceMixerModuleTests.cpp
     BitcrusherModuleTests.cpp
     NoiseModuleTests.cpp

--- a/Tests/E2EWorkflowTests.cpp
+++ b/Tests/E2EWorkflowTests.cpp
@@ -231,10 +231,10 @@ TEST_F(E2EWorkflowTest, DropModule_CreatesNode) {
 }
 
 TEST_F(E2EWorkflowTest, DropAllModuleTypes_NoCrash) {
-    const juce::StringArray moduleTypes = {"Oscillator", "Noise",          "Filter",    "ADSR",        "VCA",
-                                           "Sequencer",  "Poly Sequencer", "LFO",       "Distortion",  "Delay",
-                                           "Reverb",     "MidiKeyboard",   "Chorus",    "Phaser",      "Compressor",
-                                           "Flanger",    "Limiter",        "Poly MIDI", "Voice Mixer", "Bitcrusher"};
+    const juce::StringArray moduleTypes = {
+        "Oscillator", "Noise",      "Filter",  "ADSR",      "VCA",          "Sequencer",  "Poly Sequencer",
+        "LFO",        "Distortion", "Delay",   "Reverb",    "MidiKeyboard", "Chorus",     "Phaser",
+        "Compressor", "Flanger",    "Limiter", "Poly MIDI", "Voice Mixer",  "Bitcrusher", "Pitch Shifter"};
 
     for (const auto& type : moduleTypes) {
         auto nodeBefore = nodeCount();

--- a/Tests/FXModuleTests.cpp
+++ b/Tests/FXModuleTests.cpp
@@ -8,6 +8,7 @@
 #include "Modules/FX/FlangerModule.h"
 #include "Modules/FX/LimiterModule.h"
 #include "Modules/FX/PhaserModule.h"
+#include "Modules/FX/PitchShifterModule.h"
 #include "Modules/FX/ReverbModule.h"
 #include "Modules/FilterModule.h"
 #include "Modules/LFOModule.h"
@@ -1036,4 +1037,16 @@ TEST(PortLabelTests, LimiterPortLabels) {
     EXPECT_EQ(limiter.getInputPortLabel(1), "Right");
     EXPECT_EQ(limiter.getOutputPortLabel(0), "Left");
     EXPECT_EQ(limiter.getOutputPortLabel(1), "Right");
+}
+
+TEST(PortLabelTests, PitchShifterPortLabels) {
+    PitchShifterModule shifter;
+    EXPECT_EQ(shifter.getInputPortLabel(0), "Left");
+    EXPECT_EQ(shifter.getInputPortLabel(1), "Right");
+    EXPECT_EQ(shifter.getInputPortLabel(2), "Pitch");
+    EXPECT_EQ(shifter.getInputPortLabel(3), "Shift");
+    EXPECT_EQ(shifter.getInputPortLabel(4), "Mix");
+    EXPECT_EQ(shifter.getInputPortLabel(5), "Feedback");
+    EXPECT_EQ(shifter.getOutputPortLabel(0), "Left");
+    EXPECT_EQ(shifter.getOutputPortLabel(1), "Right");
 }

--- a/Tests/ModuleBypassTests.cpp
+++ b/Tests/ModuleBypassTests.cpp
@@ -5,6 +5,7 @@
 #include "../Source/Modules/FX/FlangerModule.h"
 #include "../Source/Modules/FX/LimiterModule.h"
 #include "../Source/Modules/FX/PhaserModule.h"
+#include "../Source/Modules/FX/PitchShifterModule.h"
 #include "../Source/Modules/FX/ReverbModule.h"
 #include "../Source/Modules/FilterModule.h"
 #include "../Source/Modules/OscillatorModule.h"
@@ -618,6 +619,67 @@ TEST(FXBypassTest, BitcrusherMuteSilencesOutput) {
     module.processBlock(buffer, midi);
 
     for (int ch = 0; ch < 5; ++ch)
+        for (int i = 0; i < 512; ++i)
+            EXPECT_FLOAT_EQ(buffer.getSample(ch, i), 0.0f) << "Ch" << ch << " sample " << i;
+}
+
+// --- Pitch Shifter --- (6 channels: audio on 0+1, CV on 2-5)
+
+TEST(FXBypassTest, PitchShifterBypassPassesDryAudio) {
+    PitchShifterModule module;
+    module.prepareToPlay(44100.0, 512);
+
+    juce::AudioBuffer<float> buffer(6, 512);
+    buffer.clear();
+    for (int i = 0; i < 512; ++i) {
+        buffer.setSample(0, i, 0.65f);
+        buffer.setSample(1, i, 0.65f);
+    }
+
+    module.setBypassed(true);
+    juce::MidiBuffer midi;
+    module.processBlock(buffer, midi);
+
+    for (int i = 0; i < 512; ++i) {
+        EXPECT_FLOAT_EQ(buffer.getSample(0, i), 0.65f) << "Ch0 sample " << i;
+        EXPECT_FLOAT_EQ(buffer.getSample(1, i), 0.65f) << "Ch1 sample " << i;
+    }
+}
+
+TEST(FXBypassTest, PitchShifterBypassClearsCVChannels) {
+    PitchShifterModule module;
+    module.prepareToPlay(44100.0, 512);
+
+    juce::AudioBuffer<float> buffer(6, 512);
+    buffer.clear();
+    for (int ch = 2; ch < 6; ++ch)
+        for (int i = 0; i < 512; ++i)
+            buffer.setSample(ch, i, 0.5f);
+
+    module.setBypassed(true);
+    juce::MidiBuffer midi;
+    module.processBlock(buffer, midi);
+
+    for (int ch = 2; ch < 6; ++ch)
+        for (int i = 0; i < 512; ++i)
+            EXPECT_FLOAT_EQ(buffer.getSample(ch, i), 0.0f) << "CV ch" << ch << " sample " << i;
+}
+
+TEST(FXBypassTest, PitchShifterMuteSilencesOutput) {
+    PitchShifterModule module;
+    module.prepareToPlay(44100.0, 512);
+
+    juce::AudioBuffer<float> buffer(6, 512);
+    buffer.clear();
+    for (int ch = 0; ch < 6; ++ch)
+        for (int i = 0; i < 512; ++i)
+            buffer.setSample(ch, i, 0.65f);
+
+    module.setMuted(true);
+    juce::MidiBuffer midi;
+    module.processBlock(buffer, midi);
+
+    for (int ch = 0; ch < 6; ++ch)
         for (int i = 0; i < 512; ++i)
             EXPECT_FLOAT_EQ(buffer.getSample(ch, i), 0.0f) << "Ch" << ch << " sample " << i;
 }

--- a/Tests/ModuleLibraryComponentTests.cpp
+++ b/Tests/ModuleLibraryComponentTests.cpp
@@ -13,10 +13,10 @@
 // ============================================================================
 
 TEST(ModuleLibraryDescriptionFor, KnownModulesReturnNonEmpty) {
-    const char* known[] = {"Oscillator",   "Noise",     "LFO",           "Sequencer", "Poly Sequencer",
-                           "MidiKeyboard", "Poly MIDI", "External MIDI", "ADSR",      "VCA",
-                           "Filter",       "Chorus",    "Phaser",        "Flanger",   "Distortion",
-                           "Delay",        "Reverb",    "Compressor",    "Limiter",   "Voice Mixer"};
+    const char* known[] = {"Oscillator", "Noise",         "LFO",          "Sequencer", "Poly Sequencer", "MidiKeyboard",
+                           "Poly MIDI",  "External MIDI", "ADSR",         "VCA",       "Filter",         "Chorus",
+                           "Phaser",     "Flanger",       "Distortion",   "Delay",     "Reverb",         "Compressor",
+                           "Limiter",    "Voice Mixer",   "Pitch Shifter"};
     for (const char* name : known) {
         juce::String desc = ModuleLibraryComponent::descriptionFor(name);
         EXPECT_FALSE(desc.isEmpty()) << "descriptionFor(\"" << name << "\") must not be empty";
@@ -24,10 +24,10 @@ TEST(ModuleLibraryDescriptionFor, KnownModulesReturnNonEmpty) {
 }
 
 TEST(ModuleLibraryDescriptionFor, KnownModulesReturnDistinctStrings) {
-    const char* known[] = {"Oscillator",   "Noise",     "LFO",           "Sequencer", "Poly Sequencer",
-                           "MidiKeyboard", "Poly MIDI", "External MIDI", "ADSR",      "VCA",
-                           "Filter",       "Chorus",    "Phaser",        "Flanger",   "Distortion",
-                           "Delay",        "Reverb",    "Compressor",    "Limiter",   "Voice Mixer"};
+    const char* known[] = {"Oscillator", "Noise",         "LFO",          "Sequencer", "Poly Sequencer", "MidiKeyboard",
+                           "Poly MIDI",  "External MIDI", "ADSR",         "VCA",       "Filter",         "Chorus",
+                           "Phaser",     "Flanger",       "Distortion",   "Delay",     "Reverb",         "Compressor",
+                           "Limiter",    "Voice Mixer",   "Pitch Shifter"};
     std::vector<juce::String> descs;
     for (const char* name : known)
         descs.push_back(ModuleLibraryComponent::descriptionFor(name));

--- a/Tests/PitchShifterModuleTests.cpp
+++ b/Tests/PitchShifterModuleTests.cpp
@@ -1,0 +1,496 @@
+// PitchShifterModuleTests.cpp
+// DSP-level tests for PitchShifterModule. The two engines are verified spectrally:
+//   • Pitch mode must move the fundamental by a *ratio* (440 -> 880 for +12 semitones)
+//   • Frequency mode must move it by a constant *offset* (1000 -> 1200 for +200 Hz),
+//     with the opposite sideband suppressed — that is what distinguishes a real SSB
+//     shifter from a ring modulator.
+// Port labels live with the other FX modules in FXModuleTests.cpp.
+
+#include "Modules/FX/PitchShifterModule.h"
+#include <gtest/gtest.h>
+#include <juce_audio_basics/juce_audio_basics.h>
+
+namespace {
+
+constexpr double kSampleRate = 44100.0;
+constexpr int kBlockSize = 512;
+constexpr int kNumChannels = 6; // 2 audio + 4 CV
+
+void setFloatParam(juce::AudioProcessor& proc, const juce::String& id, float value) {
+    for (auto* p : proc.getParameters()) {
+        if (auto* f = dynamic_cast<juce::AudioParameterFloat*>(p)) {
+            if (f->paramID == id) {
+                f->setValueNotifyingHost(f->convertTo0to1(value));
+                return;
+            }
+        }
+    }
+    ADD_FAILURE() << "No float parameter with id \"" << id << "\"";
+}
+
+void setChoiceParam(juce::AudioProcessor& proc, const juce::String& id, int index) {
+    for (auto* p : proc.getParameters()) {
+        if (auto* c = dynamic_cast<juce::AudioParameterChoice*>(p)) {
+            if (c->paramID == id) {
+                c->setValueNotifyingHost(c->convertTo0to1((float)index));
+                return;
+            }
+        }
+    }
+    ADD_FAILURE() << "No choice parameter with id \"" << id << "\"";
+}
+
+float getFloatParam(juce::AudioProcessor& proc, const juce::String& id) {
+    for (auto* p : proc.getParameters())
+        if (auto* f = dynamic_cast<juce::AudioParameterFloat*>(p))
+            if (f->paramID == id)
+                return f->get();
+    ADD_FAILURE() << "No float parameter with id \"" << id << "\"";
+    return 0.0f;
+}
+
+/** Magnitude of one frequency bin, via the Goertzel algorithm. */
+double binMagnitude(const std::vector<float>& x, double freq) {
+    if (x.empty())
+        return 0.0;
+
+    const double w = juce::MathConstants<double>::twoPi * freq / kSampleRate;
+    const double coeff = 2.0 * std::cos(w);
+    double s1 = 0.0, s2 = 0.0;
+    for (float v : x) {
+        const double s0 = (double)v + coeff * s1 - s2;
+        s2 = s1;
+        s1 = s0;
+    }
+    const double re = s1 - s2 * std::cos(w);
+    const double im = s2 * std::sin(w);
+    return std::sqrt(re * re + im * im) / (double)x.size();
+}
+
+/** Strongest integer frequency in [loHz, hiHz]. */
+double peakFrequency(const std::vector<float>& x, int loHz, int hiHz) {
+    double bestFreq = (double)loHz;
+    double bestMag = -1.0;
+    for (int f = loHz; f <= hiHz; ++f) {
+        const double mag = binMagnitude(x, (double)f);
+        if (mag > bestMag) {
+            bestMag = mag;
+            bestFreq = (double)f;
+        }
+    }
+    return bestFreq;
+}
+
+struct RenderOptions {
+    double inputFreq = 440.0;
+    int totalSamples = 49152; // ~1.1 s: long enough to settle, cheap enough for CI
+    int skipSamples = 16384;  // discard the fill-up transient of the delay line
+    int numChannels = kNumChannels;
+    int cvChannel = -1;
+    float cvValue = 0.0f;
+};
+
+/** Renders a sine through the module and returns the left-channel output after the
+    transient. `module` must already be prepared. */
+std::vector<float> renderSine(PitchShifterModule& module, const RenderOptions& opts = {}) {
+    std::vector<float> out;
+    out.reserve((size_t)juce::jmax(0, opts.totalSamples - opts.skipSamples));
+
+    juce::AudioBuffer<float> buffer(opts.numChannels, kBlockSize);
+    juce::MidiBuffer midi;
+
+    double phase = 0.0;
+    const double inc = juce::MathConstants<double>::twoPi * opts.inputFreq / kSampleRate;
+
+    for (int start = 0; start < opts.totalSamples; start += kBlockSize) {
+        buffer.clear();
+        for (int i = 0; i < kBlockSize; ++i) {
+            const float s = (float)std::sin(phase);
+            phase += inc;
+            for (int ch = 0; ch < juce::jmin(2, opts.numChannels); ++ch)
+                buffer.setSample(ch, i, s);
+        }
+        if (opts.cvChannel >= 0 && opts.cvChannel < opts.numChannels)
+            for (int i = 0; i < kBlockSize; ++i)
+                buffer.setSample(opts.cvChannel, i, opts.cvValue);
+
+        module.processBlock(buffer, midi);
+
+        for (int i = 0; i < kBlockSize; ++i) {
+            const int absoluteIndex = start + i;
+            if (absoluteIndex >= opts.skipSamples && absoluteIndex < opts.totalSamples)
+                out.push_back(buffer.getSample(0, i));
+        }
+    }
+    return out;
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// Identity / registration
+// ---------------------------------------------------------------------------
+
+TEST(PitchShifterModuleTest, ModuleTypeAndCategoryAreCorrect) {
+    PitchShifterModule module;
+    EXPECT_EQ(module.getModuleType(), ModuleType::PitchShifter);
+    EXPECT_EQ(module.getModulationCategory(), ModulationCategory::FX);
+    EXPECT_EQ(module.getName(), "Pitch Shifter");
+}
+
+TEST(PitchShifterModuleTest, ChannelLayoutMatchesPortLabels) {
+    PitchShifterModule module;
+    EXPECT_EQ(module.getTotalNumInputChannels(), 6);
+    EXPECT_EQ(module.getTotalNumOutputChannels(), 2);
+}
+
+TEST(PitchShifterModuleTest, ModulationTargetsMatchCVChannels) {
+    PitchShifterModule module;
+    const auto targets = module.getModulationTargets();
+    ASSERT_EQ(targets.size(), 4u);
+    EXPECT_EQ(targets[0].name, "Pitch");
+    EXPECT_EQ(targets[0].channelIndex, 2);
+    EXPECT_EQ(targets[1].name, "Shift");
+    EXPECT_EQ(targets[1].channelIndex, 3);
+    EXPECT_EQ(targets[2].name, "Mix");
+    EXPECT_EQ(targets[2].channelIndex, 4);
+    EXPECT_EQ(targets[3].name, "Feedback");
+    EXPECT_EQ(targets[3].channelIndex, 5);
+}
+
+// ---------------------------------------------------------------------------
+// Pitch mode
+// ---------------------------------------------------------------------------
+
+TEST(PitchShifterModuleTest, DefaultsArePassThrough) {
+    // Pitch = 0 with Mix = 1 must be transparent, not a two-tap comb filter.
+    PitchShifterModule module;
+    module.prepareToPlay(kSampleRate, kBlockSize);
+
+    juce::AudioBuffer<float> buffer(kNumChannels, kBlockSize);
+    buffer.clear();
+    for (int i = 0; i < kBlockSize; ++i) {
+        const float s = (float)std::sin(juce::MathConstants<double>::twoPi * 440.0 * i / kSampleRate);
+        buffer.setSample(0, i, s);
+        buffer.setSample(1, i, s);
+    }
+    juce::AudioBuffer<float> expected(buffer);
+
+    juce::MidiBuffer midi;
+    module.processBlock(buffer, midi);
+
+    for (int ch = 0; ch < 2; ++ch)
+        for (int i = 0; i < kBlockSize; ++i)
+            EXPECT_FLOAT_EQ(buffer.getSample(ch, i), expected.getSample(ch, i)) << "Ch" << ch << " sample " << i;
+}
+
+TEST(PitchShifterModuleTest, PitchUpOneOctaveDoublesFundamental) {
+    PitchShifterModule module;
+    setFloatParam(module, "pitch", 12.0f);
+    module.prepareToPlay(kSampleRate, kBlockSize);
+
+    const auto out = renderSine(module);
+    const double peak = peakFrequency(out, 600, 1100);
+
+    EXPECT_NEAR(peak, 880.0, 6.0) << "+12 semitones should transpose 440 Hz to 880 Hz";
+    EXPECT_GT(binMagnitude(out, 880.0), 3.0 * binMagnitude(out, 440.0))
+        << "The original fundamental should be largely gone at Mix = 1";
+}
+
+TEST(PitchShifterModuleTest, PitchDownOneOctaveHalvesFundamental) {
+    PitchShifterModule module;
+    setFloatParam(module, "pitch", -12.0f);
+    module.prepareToPlay(kSampleRate, kBlockSize);
+
+    const auto out = renderSine(module);
+    const double peak = peakFrequency(out, 120, 600);
+
+    EXPECT_NEAR(peak, 220.0, 6.0) << "-12 semitones should transpose 440 Hz to 220 Hz";
+    EXPECT_GT(binMagnitude(out, 220.0), 3.0 * binMagnitude(out, 440.0));
+}
+
+TEST(PitchShifterModuleTest, FineTuneDetunesInCents) {
+    // +100 cents == +1 semitone: 1000 Hz -> 1000 * 2^(1/12) ~= 1059.5 Hz.
+    PitchShifterModule module;
+    setFloatParam(module, "fine", 100.0f);
+    module.prepareToPlay(kSampleRate, kBlockSize);
+
+    RenderOptions opts;
+    opts.inputFreq = 1000.0;
+    const auto out = renderSine(module, opts);
+
+    EXPECT_NEAR(peakFrequency(out, 950, 1150), 1059.5, 6.0) << "Fine tune must apply as cents on top of Pitch";
+}
+
+TEST(PitchShifterModuleTest, MixZeroPassesDryOnly) {
+    PitchShifterModule module;
+    setFloatParam(module, "pitch", 12.0f);
+    setFloatParam(module, "mix", 0.0f);
+    module.prepareToPlay(kSampleRate, kBlockSize);
+
+    juce::AudioBuffer<float> buffer(kNumChannels, kBlockSize);
+    buffer.clear();
+    for (int i = 0; i < kBlockSize; ++i) {
+        buffer.setSample(0, i, 0.6f);
+        buffer.setSample(1, i, -0.4f);
+    }
+
+    juce::MidiBuffer midi;
+    module.processBlock(buffer, midi);
+
+    for (int i = 0; i < kBlockSize; ++i) {
+        EXPECT_FLOAT_EQ(buffer.getSample(0, i), 0.6f) << "Ch0 sample " << i;
+        EXPECT_FLOAT_EQ(buffer.getSample(1, i), -0.4f) << "Ch1 sample " << i;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Frequency (single-sideband) mode
+// ---------------------------------------------------------------------------
+
+TEST(PitchShifterModuleTest, FrequencyModeShiftsByConstantOffset) {
+    PitchShifterModule module;
+    setChoiceParam(module, "shiftMode", 1); // Frequency
+    setFloatParam(module, "shiftHz", 200.0f);
+    module.prepareToPlay(kSampleRate, kBlockSize);
+
+    RenderOptions opts;
+    opts.inputFreq = 1000.0;
+    const auto out = renderSine(module, opts);
+
+    EXPECT_NEAR(peakFrequency(out, 1050, 1350), 1200.0, 3.0) << "+200 Hz must land at 1200 Hz, not at a pitch ratio";
+    EXPECT_LT(binMagnitude(out, 800.0), 0.25 * binMagnitude(out, 1200.0))
+        << "The lower sideband must be suppressed — otherwise this is ring modulation, not a frequency shift";
+}
+
+TEST(PitchShifterModuleTest, FrequencyModeShiftsDownwards) {
+    PitchShifterModule module;
+    setChoiceParam(module, "shiftMode", 1);
+    setFloatParam(module, "shiftHz", -200.0f);
+    module.prepareToPlay(kSampleRate, kBlockSize);
+
+    RenderOptions opts;
+    opts.inputFreq = 1000.0;
+    const auto out = renderSine(module, opts);
+
+    EXPECT_NEAR(peakFrequency(out, 650, 950), 800.0, 3.0);
+    EXPECT_LT(binMagnitude(out, 1200.0), 0.25 * binMagnitude(out, 800.0));
+}
+
+TEST(PitchShifterModuleTest, FrequencyModeIsInharmonic) {
+    // The signature of a frequency shifter: a harmonic pair does NOT stay harmonic.
+    // 1000 Hz shifted by +150 lands at 1150, while its 2nd harmonic lands at 2150 —
+    // a pitch shifter would have put it at 2300.
+    PitchShifterModule module;
+    setChoiceParam(module, "shiftMode", 1);
+    setFloatParam(module, "shiftHz", 150.0f);
+    module.prepareToPlay(kSampleRate, kBlockSize);
+
+    RenderOptions opts;
+    opts.inputFreq = 1000.0;
+    const auto out = renderSine(module, opts);
+
+    EXPECT_NEAR(peakFrequency(out, 1000, 1400), 1150.0, 3.0);
+    EXPECT_LT(binMagnitude(out, 2300.0), 0.25 * binMagnitude(out, 1150.0));
+}
+
+// ---------------------------------------------------------------------------
+// CV modulation
+// ---------------------------------------------------------------------------
+
+TEST(PitchShifterModuleTest, PitchCVTransposesWithoutTouchingTheParameter) {
+    PitchShifterModule module;
+    module.prepareToPlay(kSampleRate, kBlockSize); // Pitch parameter stays at 0
+
+    RenderOptions opts;
+    opts.cvChannel = 2;
+    opts.cvValue = 0.5f; // 0.5 * 24 semitones = +12
+    const auto out = renderSine(module, opts);
+
+    EXPECT_NEAR(peakFrequency(out, 600, 1100), 880.0, 6.0)
+        << "Full-scale CV must map onto the full +/-24 semitone range";
+    EXPECT_FLOAT_EQ(getFloatParam(module, "pitch"), 0.0f) << "CV must not write back into the parameter";
+}
+
+TEST(PitchShifterModuleTest, ShiftCVMovesTheFrequencyOffset) {
+    PitchShifterModule module;
+    setChoiceParam(module, "shiftMode", 1);
+    module.prepareToPlay(kSampleRate, kBlockSize); // Shift parameter stays at 0 Hz
+
+    RenderOptions opts;
+    opts.inputFreq = 1000.0;
+    opts.cvChannel = 3;
+    opts.cvValue = 0.2f; // 0.2 * 1000 Hz = +200 Hz
+    const auto out = renderSine(module, opts);
+
+    EXPECT_NEAR(peakFrequency(out, 1050, 1350), 1200.0, 3.0);
+}
+
+TEST(PitchShifterModuleTest, MixCVBlendsTowardsDry) {
+    // Mix parameter at 0 with full negative-to-positive CV should reach the wet signal.
+    PitchShifterModule module;
+    setFloatParam(module, "pitch", 12.0f);
+    setFloatParam(module, "mix", 0.0f);
+    module.prepareToPlay(kSampleRate, kBlockSize);
+
+    RenderOptions opts;
+    opts.cvChannel = 4;
+    opts.cvValue = 1.0f;
+    const auto out = renderSine(module, opts);
+
+    EXPECT_NEAR(peakFrequency(out, 600, 1100), 880.0, 6.0) << "Mix CV must be able to open the wet path fully";
+}
+
+TEST(PitchShifterModuleTest, CVChannelsAreClearedAfterProcessing) {
+    PitchShifterModule module;
+    module.prepareToPlay(kSampleRate, kBlockSize);
+
+    juce::AudioBuffer<float> buffer(kNumChannels, kBlockSize);
+    buffer.clear();
+    for (int ch = 2; ch < kNumChannels; ++ch)
+        for (int i = 0; i < kBlockSize; ++i)
+            buffer.setSample(ch, i, 0.5f);
+
+    juce::MidiBuffer midi;
+    module.processBlock(buffer, midi);
+
+    for (int ch = 2; ch < kNumChannels; ++ch)
+        for (int i = 0; i < kBlockSize; ++i)
+            EXPECT_FLOAT_EQ(buffer.getSample(ch, i), 0.0f) << "CV ch" << ch << " sample " << i;
+}
+
+// ---------------------------------------------------------------------------
+// Feedback / robustness
+// ---------------------------------------------------------------------------
+
+TEST(PitchShifterModuleTest, MaximumFeedbackStaysBounded) {
+    // Shepard-tone patches run the shifter into itself; the loop must not blow up.
+    PitchShifterModule module;
+    setFloatParam(module, "pitch", 7.0f);
+    setFloatParam(module, "feedback", 0.95f);
+    module.prepareToPlay(kSampleRate, kBlockSize);
+
+    RenderOptions opts;
+    opts.totalSamples = (int)(kSampleRate * 3.0);
+    opts.skipSamples = 0;
+    const auto out = renderSine(module, opts);
+
+    for (size_t i = 0; i < out.size(); ++i) {
+        ASSERT_TRUE(std::isfinite(out[i])) << "Non-finite output at sample " << i;
+        ASSERT_LT(std::abs(out[i]), 8.0f) << "Feedback loop diverged at sample " << i;
+    }
+}
+
+TEST(PitchShifterModuleTest, FrequencyModeMaximumFeedbackStaysBounded) {
+    PitchShifterModule module;
+    setChoiceParam(module, "shiftMode", 1);
+    setFloatParam(module, "shiftHz", 120.0f);
+    setFloatParam(module, "feedback", 0.95f);
+    module.prepareToPlay(kSampleRate, kBlockSize);
+
+    RenderOptions opts;
+    opts.totalSamples = (int)(kSampleRate * 3.0);
+    opts.skipSamples = 0;
+    const auto out = renderSine(module, opts);
+
+    for (size_t i = 0; i < out.size(); ++i) {
+        ASSERT_TRUE(std::isfinite(out[i])) << "Non-finite output at sample " << i;
+        ASSERT_LT(std::abs(out[i]), 8.0f) << "Feedback loop diverged at sample " << i;
+    }
+}
+
+TEST(PitchShifterModuleTest, ExtremeParametersProduceFiniteOutput) {
+    for (float semitones : {-24.0f, 24.0f}) {
+        for (float windowMs : {10.0f, 100.0f}) {
+            PitchShifterModule module;
+            setFloatParam(module, "pitch", semitones);
+            setFloatParam(module, "fine", semitones < 0.0f ? -100.0f : 100.0f);
+            setFloatParam(module, "window", windowMs);
+            module.prepareToPlay(kSampleRate, kBlockSize);
+
+            RenderOptions opts;
+            opts.totalSamples = 8192;
+            opts.skipSamples = 0;
+            const auto out = renderSine(module, opts);
+
+            for (float v : out)
+                ASSERT_TRUE(std::isfinite(v)) << "pitch=" << semitones << " window=" << windowMs;
+        }
+    }
+}
+
+TEST(PitchShifterModuleTest, ZeroLengthAndSingleSampleBuffersAreSafe) {
+    PitchShifterModule module;
+    setFloatParam(module, "pitch", 5.0f);
+    module.prepareToPlay(kSampleRate, kBlockSize);
+
+    juce::MidiBuffer midi;
+
+    juce::AudioBuffer<float> empty(kNumChannels, 0);
+    EXPECT_NO_THROW(module.processBlock(empty, midi));
+
+    juce::AudioBuffer<float> single(kNumChannels, 1);
+    single.clear();
+    single.setSample(0, 0, 0.5f);
+    single.setSample(1, 0, 0.5f);
+    EXPECT_NO_THROW(module.processBlock(single, midi));
+    EXPECT_TRUE(std::isfinite(single.getSample(0, 0)));
+}
+
+TEST(PitchShifterModuleTest, MonoBufferIsSafe) {
+    // The graph can hand a module fewer channels than it declares; that must not read
+    // past the buffer.
+    PitchShifterModule module;
+    module.prepareToPlay(kSampleRate, kBlockSize);
+
+    juce::AudioBuffer<float> mono(1, kBlockSize);
+    mono.clear();
+    for (int i = 0; i < kBlockSize; ++i)
+        mono.setSample(0, i, 0.3f);
+
+    juce::MidiBuffer midi;
+    EXPECT_NO_THROW(module.processBlock(mono, midi));
+    for (int i = 0; i < kBlockSize; ++i)
+        EXPECT_FLOAT_EQ(mono.getSample(0, i), 0.3f) << "Mono input should pass through untouched";
+}
+
+TEST(PitchShifterModuleTest, ProcessBeforePrepareDoesNotCrash) {
+    PitchShifterModule module;
+    juce::AudioBuffer<float> buffer(kNumChannels, kBlockSize);
+    buffer.clear();
+    juce::MidiBuffer midi;
+    EXPECT_NO_THROW(module.processBlock(buffer, midi));
+}
+
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+
+TEST(PitchShifterModuleTest, StateRoundTripPreservesParameters) {
+    PitchShifterModule source;
+    setChoiceParam(source, "shiftMode", 1);
+    setFloatParam(source, "pitch", -7.0f);
+    setFloatParam(source, "fine", 25.0f);
+    setFloatParam(source, "shiftHz", 333.0f);
+    setFloatParam(source, "window", 80.0f);
+    setFloatParam(source, "feedback", 0.5f);
+    setFloatParam(source, "mix", 0.35f);
+
+    juce::MemoryBlock state;
+    source.getStateInformation(state);
+
+    PitchShifterModule restored;
+    restored.setStateInformation(state.getData(), (int)state.getSize());
+
+    EXPECT_NEAR(getFloatParam(restored, "pitch"), -7.0f, 0.01f);
+    EXPECT_NEAR(getFloatParam(restored, "fine"), 25.0f, 0.05f);
+    EXPECT_NEAR(getFloatParam(restored, "shiftHz"), 333.0f, 0.5f);
+    EXPECT_NEAR(getFloatParam(restored, "window"), 80.0f, 0.05f);
+    EXPECT_NEAR(getFloatParam(restored, "feedback"), 0.5f, 0.01f);
+    EXPECT_NEAR(getFloatParam(restored, "mix"), 0.35f, 0.01f);
+
+    for (auto* p : restored.getParameters())
+        if (auto* c = dynamic_cast<juce::AudioParameterChoice*>(p))
+            if (c->paramID == "shiftMode")
+                EXPECT_EQ(c->getIndex(), 1);
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -45,7 +45,8 @@ Every concrete module implements `virtual ModuleType getModuleType() const = 0`.
 ```
 Oscillator, Filter, VCA, ADSR, LFO, Sequencer, PolySequencer,
 MidiKeyboard, PolyMidi, ExternalMidi, Attenuverter,
-Delay, Distortion, Reverb, Chorus, Phaser, Compressor, Flanger, Limiter, VoiceMixer, Bitcrusher, Noise
+Delay, Distortion, Reverb, Chorus, Phaser, Compressor, Flanger, Limiter, VoiceMixer,
+Bitcrusher, PitchShifter, Noise
 ```
 
 `ModuleType` is consumed by `LayoutUtil::getModuleWidthBucket` to classify modules into width buckets (Narrow / Single / Double) and by `ModuleComponent` for type-safe UI layout switching.

--- a/docs/fx_modules.md
+++ b/docs/fx_modules.md
@@ -57,3 +57,13 @@ Technical documentation for the Agent Synth effects suite.
 - **CV Modulation**: Rate (ch2), Depth (ch3), Mix (ch4). CV presence is detected via non-zero sample checking.
 - **Parameters**: Rate (1–50), Depth (1–24 bits), Mix (0–1), Dither (0–1).
 
+## Pitch Shifter Module
+Two engines behind one Mode switch, because they answer the same question with opposite characters: Pitch mode multiplies frequencies (harmonic), Frequency mode adds to them (inharmonic).
+
+- **Pitch mode**: Two-tap crossfaded delay line. The read heads sweep across one window half a window apart; the phase advances at `(1 - ratio) / windowSamples` per sample, which is the condition for the read position to advance at `ratio`. Taps are summed with an equal-power window (`sin`/`|cos|` of the phase) so each tap's wrap-around lands exactly where its own gain is zero. Reads use cubic Hermite interpolation — linear interpolation audibly dulls a transposed signal.
+  - **Unity dead zone**: when `|ratio - 1| < 1e-4` (about 0.0017 semitones) the two taps would sit at fixed, different delays and comb-filter the input, so the module emits the signal untransposed instead. This makes the default (Pitch 0, Mix 1) bit-transparent.
+  - **Window**: trades artifacts against latency. Short windows chop the signal at a higher rate (audible as AM sidebands at `|1 - ratio| / window` Hz); long windows smear transients. 50 ms default.
+- **Frequency mode**: Single-sideband modulation. A Hilbert transform pair (two cascaded 4-section 2nd-order allpass chains, `H(z) = (a² - z⁻²)/(1 - a²z⁻²)`, using Olli Niemitalo's wideband 90° coefficients) feeds a quadrature oscillator: `out = I·cos(ωt) + Q·sin(ωt)`. Measured rejection of the unwanted sideband is ~55 dB. A negative Shift runs the oscillator backwards — no separate code path. Harmonics stop being integer multiples of the fundamental, which is what produces the "alien voice" / metallic timbre.
+- **Feedback**: routes the shifted output back into the input, so each pass is shifted again — cascading octaves in Pitch mode, barber-pole / Shepard-tone illusions in Frequency mode. Soft-clipped with `tanh` so the loop stays bounded at the 0.95 maximum.
+- **CV Modulation**: Pitch (ch2, ±24 semitones), Shift (ch3, ±1000 Hz), Mix (ch4, ±1), Feedback (ch5, ±0.95). CV is added per-sample to the smoothed parameter value and clamped; Window and Fine have no CV input.
+- **Parameters**: Mode (Pitch/Frequency), Pitch (-24–+24 semitones), Fine (-100–+100 cents), Shift (-1000–+1000 Hz), Window (10–100 ms), Feedback (0–0.95), Mix (0–1, default 1).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -31,7 +31,8 @@ Headless DSP tests that render audio through individual modules and verify outpu
 | LFOModuleTest | 11 | LFO waveform output, rate modulation, sync behavior |
 | VCAModuleTest | 5 | Gain application, envelope following, silence detection |
 | AttenuverterModuleTest | 4 | CV signal attenuation, bipolar control, CV modulation |
-| FX module tests | 52 | Delay (passthrough, feedback), Distortion (clipping, drive), Reverb (room size), Chorus, Phaser, Compressor, Flanger, Limiter, Bitcrusher (downsampling, quantization, CV) |
+| FX module tests | 53 | Delay (passthrough, feedback), Distortion (clipping, drive), Reverb (room size), Chorus, Phaser, Compressor, Flanger, Limiter, Bitcrusher (downsampling, quantization, CV) |
+| PitchShifterModuleTest | 22 | Pitch mode transposition ratios (spectral peak), Frequency mode SSB offset + sideband suppression, CV routing, feedback stability, state round-trip |
 | AntiClickTest | 4 | ADSR minimum release, smooth parameter transitions |
 | EdgeCaseTests | 21 | Zero-length buffers, extreme parameters, single-sample buffers, rapid parameter changes, large buffers |
 | AudioRenderingTests | 26 | Snapshot-based tests comparing bit-perfect output against reference files; covers full chains (Osc->Filter->VCA), modulation accuracy, and External MIDI input |
@@ -61,6 +62,7 @@ Test UI component interactions using in-process construction (no window, no disp
 | VisualBufferTest | 3 | Scope visualization buffer management, read/write, ringbuffer behavior |
 | ModuleBaseTest | 4 | Parameter getters, port labels, bypass functionality |
 | ModuleBypassTest | 5 | Default state, toggle, signal passing when bypassed |
+| FXBypassTest | 23 | Per-FX bypass dry pass-through, CV-channel clearing, mute silencing |
 | VisualSignalFlowTests | 8 | AttenuverterModule peak/mod value tracking, VisualBuffer RMS computation, AudioEngine::getModulationDisplayInfo() population |
 | SettingsWindowTest | 8 | Tab structure, tab persistence, audio device selector, AI settings persistence, resize safety, shortcuts reference |
 | ShortcutManagerTest | 8 | Default bindings, reverse lookup, conflict detection, persistence round-trip, reset to defaults, display strings |


### PR DESCRIPTION
## Summary

Adds a dual-mode Pitch Shifter / Frequency Shifter FX module, closing #155. One module with a `Mode` switch, because the two engines answer the same question with opposite characters: **Pitch** multiplies frequencies (harmonic), **Frequency** adds to them (inharmonic). Together with Feedback they cover all three use cases named in the issue — harmonic detuning, alien vocal effects, Shepard tones.

## Changes

- **`Source/Modules/FX/PitchShifterModule.h`** (new)
  - **Pitch mode** — two-tap crossfaded delay line with cubic Hermite interpolation. Phase advances at `(1 - ratio) / windowSamples`, which is the condition for the read position to advance at `ratio`; taps sit half a window apart and are summed with an equal-power `sin`/`|cos|` window so each tap's wrap-around lands exactly where its own gain is zero. Range -24..+24 semitones plus ±100 cents fine.
  - **Unity dead zone** — at `|ratio - 1| < 1e-4` the two taps would sit at fixed, different delays and comb-filter the input, so the module emits the signal untransposed. The default (Pitch 0, Mix 1) is therefore bit-transparent, which is asserted in a test.
  - **Frequency mode** — single-sideband modulation. A Hilbert transform pair (two cascaded 4-section 2nd-order allpass chains using Niemitalo's wideband 90° coefficients) feeds a quadrature oscillator. Measured rejection of the unwanted sideband is ~55 dB. A negative Shift just runs the oscillator backwards — no separate code path.
  - **Feedback** (0–0.95, `tanh` soft-clipped) re-shifts the output on every pass: cascading octaves in Pitch mode, barber-pole / Shepard-tone illusions in Frequency mode.
  - Honours the bypass/mute contract as two separate branches; clears CV channels ≥2 on both paths.
- **CV inputs** — Pitch (ch2, ±24 semitones), Shift (ch3, ±1000 Hz), Mix (ch4), Feedback (ch5). Raw CV maps onto each target's full native range per the fully-modular routing rule; depth stays on the cable attenuverter, no internal "mod amount" knobs.
- **Registration** — `ModuleType::PitchShifter`, `CMakeLists.txt`, AI factory + `getFactoryTypeName` + `audioNodeTypes` auto-connect set, `LayoutUtil::roleRank`, the module library list/description, and the Modulation FX swap menu.
- **Docs** — new `docs/fx_modules.md` section (algorithms, dead zone, CV ranges, parameters), `docs/architecture.md` `ModuleType` list, `docs/testing.md` suite table, plus the FX lists in `CLAUDE.md` / `AGENTS.md` / `GEMINI.md`.

## Test Plan

- [x] All existing tests pass — 750/750 (the 6 `SettingsMigrationTest` failures reproduce on an unmodified checkout and are a local filesystem-sandbox artifact; they pass when run unsandboxed)
- [x] New tests added for new functionality — 26 new tests
  - `Tests/PitchShifterModuleTests.cpp` (22): both engines verified **spectrally** via Goertzel peak search — +12 semitones moves 440 → 880 Hz and -12 moves it to 220 Hz (ratio), while +200 Hz moves 1000 → 1200 Hz (offset) with the 800 Hz sideband suppressed below 25% — that last assertion is what distinguishes a real SSB shifter from ring modulation. Also: fine-tune in cents, default transparency, Mix = 0 dry equality, per-target CV routing (including that CV never writes back into the parameter), feedback stability at 0.95 over 3 s in both modes, extreme parameters, zero-length/single-sample/mono buffers, process-before-prepare, and parameter state round-trip.
  - `Tests/FXModuleTests.cpp` (1): port labels alongside the other FX.
  - `Tests/ModuleBypassTests.cpp` (3): bypass dry pass-through, CV-channel clearing, mute silencing.
  - Existing registry lists extended: `E2EWorkflowTests` drop-all-types, `AIStateMapperTests` factory coverage, `ModuleLibraryComponentTests` descriptions.
- [x] Tested locally (build + run) — `Core`, `Tests` and the `AgentSynth` GUI target all build clean; `clang-format` 22.1.2 lint clean
- [x] Documentation updated

### Note on how the SSB sign was settled

The first implementation summed the quadrature branch with the wrong sign, which put all the energy in the opposite sideband. Rather than guess, I probed all four convention combinations (coefficient squaring × delay branch × sign) offline and picked the one measuring ~55 dB rejection. The tests now pin that behaviour down spectrally, so a future regression in either the sign or the coefficients fails loudly.

## Screenshots

N/A — the module uses the generic knob/combo layout, so no new UI code was needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)