### PR TITLE
ci: read cache-matched-key from actions/cache/restore, and fail safe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,9 +97,15 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y cmake ninja-build libasound2-dev libx11-dev libxinerama-dev libxext-dev libxcomposite-dev libxcursor-dev libxrandr-dev libxrender-dev libfontconfig1-dev libfreetype6-dev libglu1-mesa-dev libcurl4-openssl-dev libgtk-3-dev libjack-jackd2-dev freeglut3-dev pkg-config llvm clang ccache xvfb
 
-    - name: Cache FetchContent Dependencies
+    # NOTE: restore + save are split deliberately. The combined `actions/cache` action declares
+    # exactly ONE output, `cache-hit` (true only on an exact primary-key match); only
+    # `actions/cache/restore` exposes `cache-matched-key`, which is the one signal that reports
+    # whether a restore-key fallback matched. The health check below needs that, and reading it
+    # off the combined action silently yields an empty string — which made the check report MISS
+    # on a run that had in fact restored at a 100% ccache hit rate.
+    - name: Restore FetchContent Dependencies
       id: deps-cache
-      uses: actions/cache@v5
+      uses: actions/cache/restore@v5
       with:
         path: build/_deps
         # Keyed on the dependency pins ALONE (cmake/DependencyVersions.cmake), not on
@@ -112,9 +118,9 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-deps3-
 
-    - name: Cache ccache
+    - name: Restore ccache
       id: ccache-cache
-      uses: actions/cache@v5
+      uses: actions/cache/restore@v5
       with:
         path: ${{ env.CCACHE_DIR }}
         # Exact key is per-commit (never hits) — the restore-keys are what actually match:
@@ -159,6 +165,23 @@ jobs:
         CACHE_MATCHED_KEY: ${{ steps.ccache-cache.outputs.cache-matched-key }}
         DEPS_MATCHED_KEY: ${{ steps.deps-cache.outputs.cache-matched-key }}
       run: bash scripts/ci-cache-check.sh
+
+    # Saved right after the build, `if: always()`, so a compile that succeeded is never thrown
+    # away because a later test failed. `_deps` is skipped on an exact hit — re-uploading an
+    # identical ~350 MB entry only burns budget.
+    - name: Save FetchContent Dependencies
+      if: always() && steps.deps-cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v5
+      with:
+        path: build/_deps
+        key: ${{ steps.deps-cache.outputs.cache-primary-key }}
+
+    - name: Save ccache
+      if: always()
+      uses: actions/cache/save@v5
+      with:
+        path: ${{ env.CCACHE_DIR }}
+        key: ${{ steps.ccache-cache.outputs.cache-primary-key }}
 
     - name: Run Tests
       timeout-minutes: 10
@@ -232,9 +255,10 @@ jobs:
     - name: Install Dependencies
       run: brew install cmake ninja ccache
 
-    - name: Cache FetchContent Dependencies
+    # See the build-and-test job for why restore and save are split.
+    - name: Restore FetchContent Dependencies
       id: deps-cache
-      uses: actions/cache@v5
+      uses: actions/cache/restore@v5
       with:
         path: build/_deps
         # See the build-and-test job for why this keys on the pins file alone.
@@ -242,9 +266,9 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-deps3-
 
-    - name: Cache ccache
+    - name: Restore ccache
       id: ccache-cache
-      uses: actions/cache@v5
+      uses: actions/cache/restore@v5
       with:
         path: ${{ env.CCACHE_DIR }}
         key: ${{ runner.os }}-ccache-${{ github.ref_name }}-${{ github.sha }}
@@ -279,6 +303,20 @@ jobs:
         DEPS_MATCHED_KEY: ${{ steps.deps-cache.outputs.cache-matched-key }}
       run: bash scripts/ci-cache-check.sh
 
+    - name: Save FetchContent Dependencies
+      if: always() && steps.deps-cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v5
+      with:
+        path: build/_deps
+        key: ${{ steps.deps-cache.outputs.cache-primary-key }}
+
+    - name: Save ccache
+      if: always()
+      uses: actions/cache/save@v5
+      with:
+        path: ${{ env.CCACHE_DIR }}
+        key: ${{ steps.ccache-cache.outputs.cache-primary-key }}
+
     - name: Run Tests
       working-directory: ./build/Tests
       run: ./Tests
@@ -296,9 +334,10 @@ jobs:
     steps:
     - uses: actions/checkout@v6
 
-    - name: Cache FetchContent Dependencies
+    # See the build-and-test job for why restore and save are split.
+    - name: Restore FetchContent Dependencies
       id: deps-cache
-      uses: actions/cache@v5
+      uses: actions/cache/restore@v5
       with:
         path: build/_deps
         # See the build-and-test job for why this keys on the pins file alone.
@@ -306,9 +345,9 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-deps3-
 
-    - name: Cache ccache
+    - name: Restore ccache
       id: ccache-cache
-      uses: actions/cache@v5
+      uses: actions/cache/restore@v5
       with:
         path: ${{ env.CCACHE_DIR }}
         key: ${{ runner.os }}-ccache-${{ github.ref_name }}-${{ github.sha }}
@@ -349,6 +388,20 @@ jobs:
         CACHE_MATCHED_KEY: ${{ steps.ccache-cache.outputs.cache-matched-key }}
         DEPS_MATCHED_KEY: ${{ steps.deps-cache.outputs.cache-matched-key }}
       run: bash scripts/ci-cache-check.sh
+
+    - name: Save FetchContent Dependencies
+      if: always() && steps.deps-cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v5
+      with:
+        path: build/_deps
+        key: ${{ steps.deps-cache.outputs.cache-primary-key }}
+
+    - name: Save ccache
+      if: always()
+      uses: actions/cache/save@v5
+      with:
+        path: ${{ env.CCACHE_DIR }}
+        key: ${{ steps.ccache-cache.outputs.cache-primary-key }}
 
     - name: Run Tests
       shell: bash

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -381,14 +381,18 @@ Two caches carry work between runs. Both are easy to break in ways that look exa
 
 #### The cache health check
 
-`scripts/ci-cache-check.sh` runs after the build on Linux, macOS, and Windows. It reads each `actions/cache` step's `cache-matched-key` output plus `ccache --show-stats`, writes a summary table to the job summary, and:
+`scripts/ci-cache-check.sh` runs after the build on Linux, macOS, and Windows. It reads each cache step's `cache-matched-key` output plus `ccache --show-stats`, writes a summary table to the job summary, and:
 
 - **fails** when a cache that should have restored did not (PR runs only — a miss on the `main` seeding run is expected and reported as a notice);
 - **warns** when the ccache hit rate is under `CACHE_MIN_HIT_RATE` (default 25%), which drops legitimately whenever a PR touches a widely-included header.
 
 Enforcement is off by default. Set the repository variable **`CI_CACHE_CHECK_ENFORCE=true`** (Settings → Secrets and variables → Actions → Variables) to make a cold cache fail the build; leave it unset to report only. It ships off so that PRs opened before `main` has seeded its caches don't fail on a miss that is genuinely expected — turn it on once one merge to `main` has completed.
 
-The script has its own tests (`scripts/tests/ci-cache-check.test.sh`, run by the Lint job): if the thing that detects a broken cache breaks silently, we are back to shipping cold builds unnoticed.
+**4. Cache steps use `actions/cache/restore` + `actions/cache/save`, not the combined `actions/cache`.** The combined action declares exactly one output, `cache-hit`, which is true only on an *exact* primary-key match — and the ccache primary key embeds `github.sha`, so it never matches exactly even when a restore-key fallback works perfectly. Only `actions/cache/restore` exposes **`cache-matched-key`**, the one value that reports a fallback hit. Reading it off the combined action yields an empty string forever: run `31301691346` restored every cache and compiled at a **100% ccache hit rate** while the check reported `MISS` on all three platforms. Enforcement would have failed every build. The split also lets the save step run `if: always()`, so a successful compile is not discarded because a later test failed.
+
+Because of that near-miss the check **fails safe**: an empty `cache-matched-key` contradicted by a high ccache hit rate (≥ `CACHE_SELFCHECK_HIT_RATE`, default 50%) is reported as *a misconfigured check*, not a cold cache, and does not fail the build — a cold build cannot hit 100%, since its only hits are files compiled into two targets in the same run (~15%). A genuinely cold cache still fails.
+
+The script has its own tests (`scripts/tests/ci-cache-check.test.sh`, 14 cases, run by the Lint job): if the thing that detects a broken cache breaks silently, we are back to shipping cold builds unnoticed. Those tests scrub every input variable before each case — `ci.yml` exports `CACHE_CHECK_ENFORCE` and `CACHE_WARM_EXPECTED` workflow-wide, the Lint job inherits them, and a non-hermetic harness silently inherited CI's values and passed cases it should have failed.
 
 To inspect cache state directly:
 

--- a/scripts/ci-cache-check.sh
+++ b/scripts/ci-cache-check.sh
@@ -110,7 +110,33 @@ printf 'ccache cache      : %s\n' "$ccache_state"
 printf 'ccache hit rate   : %s%% (%s hits / %s compiles)\n' "$hit_rate" "$hits" "$total"
 
 # --- verdict ------------------------------------------------------------------------------
-if [ "$CACHE_WARM_EXPECTED" = "true" ]; then
+# Cross-validation, so this script fails SAFE. An empty matched-key alongside a high ccache hit
+# rate is self-contradictory: a genuinely cold build cannot hit ~100%, because on a cold cache the
+# only hits are the handful of files compiled into two targets within the same run (~15% here).
+# That combination means this script's own inputs are mis-wired, not that the cache is cold — and
+# it has happened: the workflow first read `cache-matched-key` off the combined `actions/cache`
+# action, which declares only `cache-hit`, so the value was always empty and every run was
+# reported as MISS even at a 100% hit rate. Enforcing on that would have failed every build. So
+# when the evidence disagrees, warn about the check instead of failing the build.
+#
+# Keyed on the CCACHE contradiction specifically: a high hit rate proves the *ccache* restored, so
+# an empty CACHE_MATCHED_KEY alongside it can only mean the key never reached this script. Both
+# keys arrive through the same plumbing, so that one signal condemns DEPS_MATCHED_KEY too, and
+# both errors are suppressed. A high hit rate on its own proves nothing about build/_deps — when
+# the ccache key IS populated (plumbing demonstrably fine) and only the deps key is empty, that is
+# a real dependency-cache miss and still fails.
+inputs_suspect=0
+if [ "$total" -gt 0 ] && [ "$hit_rate" -ge "${CACHE_SELFCHECK_HIT_RATE:-50}" ] &&
+    [ -z "$CACHE_MATCHED_KEY" ]; then
+    inputs_suspect=1
+    annotate warning "Cache reported as not restored, yet ccache hit ${hit_rate}% — a cold build \
+cannot do that. Treating this as a misconfigured check rather than a cold cache: verify the \
+workflow reads cache-matched-key from an actions/cache/restore step (the combined actions/cache \
+action does not expose it). Not failing the build on this."
+    warnings=$((warnings + 1))
+fi
+
+if [ "$CACHE_WARM_EXPECTED" = "true" ] && [ "$inputs_suspect" -eq 0 ]; then
     if [ -z "$DEPS_MATCHED_KEY" ]; then
         annotate error "build/_deps cache did not restore. Every dependency is being re-fetched \
 and rebuilt from scratch. Check that the push-to-main run seeded a cache for this runner OS and \
@@ -123,7 +149,8 @@ from cold. Verify CCACHE_DIR matches the actions/cache path for this OS, and tha
 push-to-main run has seeded the cache."
         failures=$((failures + 1))
     fi
-elif [ -z "$DEPS_MATCHED_KEY" ] || [ -z "$CACHE_MATCHED_KEY" ]; then
+elif [ "$CACHE_WARM_EXPECTED" != "true" ] &&
+    { [ -z "$DEPS_MATCHED_KEY" ] || [ -z "$CACHE_MATCHED_KEY" ]; }; then
     annotate notice "Cache miss on a cache-seeding run — expected; this run populates the cache \
 that pull requests will restore from."
 fi

--- a/scripts/tests/ci-cache-check.test.sh
+++ b/scripts/tests/ci-cache-check.test.sh
@@ -154,6 +154,51 @@ run "no ccache statistics at all warns" 0 "::warning::No ccache statistics avail
     CACHE_WARM_EXPECTED=true \
     CCACHE_STATS_FILE="$WORK/stats-empty.txt"
 
+# --- fail-safe cross-validation ------------------------------------------------------------
+# Regression cases for the mis-wired-inputs bug: run 31301691346 restored every cache and hit
+# 100%, yet the check reported MISS on all three platforms, because the workflow read
+# cache-matched-key off the combined actions/cache action (which only declares cache-hit) instead
+# of actions/cache/restore. Enforcing on that would have failed every build, so an empty matched
+# key contradicted by a high hit rate must warn about the check — never fail the build.
+cat >"$WORK/stats-perfect.txt" <<'EOF'
+Cacheable calls:   268 / 268 (100.0%)
+  Hits:            268 / 268 (100.0%)
+    Direct:        268 / 268 (100.0%)
+    Preprocessed:    0 / 268 (0.00%)
+  Misses:            0 / 268 (0.00%)
+EOF
+
+run "fail-safe: empty matched keys + 100% hit rate does not fail" 0 \
+    "::warning::Cache reported as not restored, yet ccache hit 100%" \
+    CACHE_MATCHED_KEY= \
+    DEPS_MATCHED_KEY= \
+    CACHE_WARM_EXPECTED=true \
+    CACHE_CHECK_ENFORCE=true \
+    CCACHE_STATS_FILE="$WORK/stats-perfect.txt"
+
+# Negative assertion: the contradiction must not be relabelled as the (benign) seeding-run case,
+# which would hide a mis-wired check behind a reassuring notice.
+contradiction_out="$(env -u CACHE_MATCHED_KEY -u DEPS_MATCHED_KEY -u CACHE_WARM_EXPECTED \
+    -u CACHE_MIN_HIT_RATE -u CACHE_CHECK_ENFORCE -u CCACHE_STATS_FILE \
+    CACHE_MATCHED_KEY= DEPS_MATCHED_KEY= CACHE_WARM_EXPECTED=true CACHE_CHECK_ENFORCE=true \
+    CCACHE_STATS_FILE="$WORK/stats-perfect.txt" \
+    GITHUB_STEP_SUMMARY="$WORK/summary.md" bash "$CHECK" 2>&1)"
+if printf '%s' "$contradiction_out" | grep -qF "cache-seeding run"; then
+    printf 'FAIL  fail-safe: does not misreport the contradiction as a seeding run\n%s\n' \
+        "$(defang "$contradiction_out")"
+    fail=$((fail + 1))
+else
+    printf 'ok    fail-safe: does not misreport the contradiction as a seeding run\n'
+    pass=$((pass + 1))
+fi
+
+run "fail-safe: a genuinely cold cache (15%) still fails" 1 "::error::" \
+    CACHE_MATCHED_KEY= \
+    DEPS_MATCHED_KEY= \
+    CACHE_WARM_EXPECTED=true \
+    CACHE_CHECK_ENFORCE=true \
+    CCACHE_STATS_FILE="$WORK/stats-cold.txt"
+
 # --- job summary is written ---------------------------------------------------------------
 if grep -q "Build cache health" "$WORK/summary.md"; then
     printf 'ok    writes a GitHub job summary\n'


### PR DESCRIPTION
## Summary

Follow-up to #183. The health check reported `MISS — nothing restored` on all three platforms in run [`31301691346`](https://github.com/Diabl0269/agentsynth/actions/runs/31301691346) — a run that had actually restored every cache and compiled at a **100% ccache hit rate**, finishing in **3.8 min against 17.4 min cold**.

The check read `cache-matched-key` off the combined `actions/cache` action, which declares [exactly one output, `cache-hit`](https://github.com/actions/cache/blob/v5/action.yml). Only `actions/cache/restore` exposes `cache-matched-key`. The value was always the empty string, so the check would have reported every run as cold forever — **turning on `CI_CACHE_CHECK_ENFORCE` would have failed every build.**

`cache-hit` is not a substitute: it is true only on an exact primary-key match, and the ccache primary key embeds `github.sha`, so it is false on precisely the restore-key fallback we depend on.

## Changes

- **Split cache steps into `actions/cache/restore` + `actions/cache/save`** across all three build jobs, so `cache-matched-key` is actually populated. The split also lets save run `if: always()` — a compile that succeeded is no longer discarded because a later test failed — and skips re-uploading an identical ~350 MB `_deps` entry on an exact hit.
- **The check now fails safe.** An empty `cache-matched-key` contradicted by a high ccache hit rate (>= `CACHE_SELFCHECK_HIT_RATE`, default 50%) is reported as *a misconfigured check*, not a cold cache, and does not fail the build. A cold build cannot hit 100% — its only hits are files compiled into two targets in the same run (~15% here). The guard keys on the **ccache** contradiction alone: a high hit rate proves the ccache restored and both keys share the same plumbing, but it proves nothing about `build/_deps`, so a deps-only miss with a populated ccache key is still a real failure and still fails.

## Test Plan

- [x] All existing tests pass — no product code touched.
- [x] New tests added — 14 cases (was 11): the exact regression (empty keys + 100% hit rate must not fail), a negative assertion that the contradiction is not relabelled as the benign seeding-run case, and confirmation a genuinely cold 15% cache still fails. These caught an over-broad first draft of the guard that suppressed a legitimate deps-only miss.
- [x] Tested locally — 14/14 with a clean environment **and** 14/14 with `CACHE_CHECK_ENFORCE`/`CACHE_WARM_EXPECTED` exported as CI sets them. Both cache sub-action interfaces verified against the actual `action.yml` at `v5` rather than from memory.
- [x] Documentation updated — `docs/testing.md` gains rule 4 (restore/save split and why `cache-hit` cannot substitute) plus the fail-safe behaviour and the test-hermeticity note.

## Context: the caching itself is working

`main` seeded correctly after #183 merged — `Linux-ccache-main-0bf6263` (151 MB), plus Windows/macOS ccache and all three `deps3` entries. Repo cache is ~1.7 GB against the 10 GB limit, down from 10.18 GB. The 3.8 min run above is what a warm build looks like; a same-day PR without these changes (`feature/issue-122`) still took 18.4 min.

**Do not set `CI_CACHE_CHECK_ENFORCE=true` until this merges** — on current `main` the check still reads the always-empty value, so enforcement would fail every build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)