### PR TITLE
feat(auth): device-id + client-side anonymous trial handling (P3-3)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,8 @@ add_library(Core STATIC
     Source/Auth/InMemoryTokenStore.h
     Source/Auth/KeychainTokenStore.h
     Source/Auth/KeychainTokenStore.cpp
+    Source/Auth/DeviceIdStore.h
+    Source/Auth/DeviceIdStore.cpp
     # UI utilities
     Source/UI/LayoutUtil.h
     Source/UI/LayoutUtil.cpp

--- a/Source/AI/AIProvider.h
+++ b/Source/AI/AIProvider.h
@@ -37,8 +37,27 @@ public:
     /**
      * @brief Categorizes why a request failed, so callers can react appropriately
      *        (retry, prompt sign-in, show an upgrade path, etc.) instead of parsing error text.
+     *
+     * TrialExhausted and ServiceCapacityExceeded are both surfaced by the capability endpoints as
+     * distinct 402/503 response shapes (see RemoteProvider::processRequest) and are deliberately
+     * NOT folded into Quota/Server: TrialExhausted is the free-trial-to-account conversion moment
+     * (the server's message invites signing in when the caller isn't authenticated yet), and
+     * ServiceCapacityExceeded is a service-wide daily cap unrelated to the caller's own usage —
+     * both need their own user-facing text rather than a generic failure message.
      */
-    enum class AIErrorKind { None, Network, Auth, Quota, RateLimit, Server, Schema, Cancelled, Timeout };
+    enum class AIErrorKind {
+        None,
+        Network,
+        Auth,
+        Quota,
+        RateLimit,
+        Server,
+        Schema,
+        Cancelled,
+        Timeout,
+        TrialExhausted,
+        ServiceCapacityExceeded
+    };
 
     struct AIError {
         AIErrorKind kind = AIErrorKind::None;

--- a/Source/AI/AccountService.cpp
+++ b/Source/AI/AccountService.cpp
@@ -1,4 +1,5 @@
 #include "AccountService.h"
+#include "../Auth/DeviceIdStore.h"
 #include "../Auth/KeychainTokenStore.h"
 
 namespace synth {
@@ -34,7 +35,11 @@ juce::String maskEmail(const juce::String& email) {
 
 AccountService::AccountService(juce::String host)
     : Thread("AccountServiceThread")
-    , authClient(std::move(host))
+    // DeviceIdStore() (no explicit path) resolves to the app's standard settings-folder
+    // convention and persists on first read — see Source/Auth/DeviceIdStore.h. A stable id, not
+    // a secret, so reading/generating it here (rather than caching a member) is fine: every call
+    // against the same file returns the same value.
+    , authClient(std::move(host), "synth-desktop", DeviceIdStore().getDeviceId())
     , tokenStore(std::make_unique<KeychainTokenStore>()) {}
 
 AccountService::AccountService(juce::String host, AuthClient::HttpPerformer performer,

--- a/Source/AI/AuthClient.cpp
+++ b/Source/AI/AuthClient.cpp
@@ -140,9 +140,10 @@ AuthClient::HttpResult performHttpUnavailable(const juce::String&, const juce::S
 
 } // namespace
 
-AuthClient::AuthClient(juce::String hostIn, juce::String clientIdIn)
+AuthClient::AuthClient(juce::String hostIn, juce::String clientIdIn, juce::String deviceIdIn)
     : host(std::move(hostIn))
     , clientId(std::move(clientIdIn))
+    , deviceId(std::move(deviceIdIn))
 #ifndef _WIN32
     , performHttp(performHttpWithCurl)
 #else
@@ -151,9 +152,10 @@ AuthClient::AuthClient(juce::String hostIn, juce::String clientIdIn)
 {
 }
 
-AuthClient::AuthClient(juce::String hostIn, juce::String clientIdIn, HttpPerformer performer)
+AuthClient::AuthClient(juce::String hostIn, juce::String clientIdIn, HttpPerformer performer, juce::String deviceIdIn)
     : host(std::move(hostIn))
     , clientId(std::move(clientIdIn))
+    , deviceId(std::move(deviceIdIn))
     , performHttp(std::move(performer)) {}
 
 AuthClient::DeviceCodeResult AuthClient::requestDeviceCode(const std::atomic<bool>& cancelled) const {
@@ -162,7 +164,10 @@ AuthClient::DeviceCodeResult AuthClient::requestDeviceCode(const std::atomic<boo
     juce::StringPairArray headers;
     headers.set("Content-Type", "application/x-www-form-urlencoded");
 
-    const juce::String body = formEncode({{"client_id", clientId}});
+    std::vector<std::pair<juce::String, juce::String>> params{{"client_id", clientId}};
+    if (deviceId.isNotEmpty())
+        params.emplace_back("device_id", deviceId);
+    const juce::String body = formEncode(params);
     const auto http = performHttp("POST", host + "/v1/auth/device/code", headers, body, kRequestTimeoutMs, cancelled);
 
     if (http.transportFailed || http.timedOut) {
@@ -242,17 +247,22 @@ AuthClient::TokenPollResult AuthClient::postToken(const juce::String& formBody,
 
 AuthClient::TokenPollResult AuthClient::pollDeviceToken(const juce::String& deviceCode,
                                                         const std::atomic<bool>& cancelled) const {
-    const juce::String body = formEncode({{"grant_type", "urn:ietf:params:oauth:grant-type:device_code"},
-                                          {"device_code", deviceCode},
-                                          {"client_id", clientId}});
-    return postToken(body, cancelled);
+    std::vector<std::pair<juce::String, juce::String>> params{
+        {"grant_type", "urn:ietf:params:oauth:grant-type:device_code"},
+        {"device_code", deviceCode},
+        {"client_id", clientId}};
+    if (deviceId.isNotEmpty())
+        params.emplace_back("device_id", deviceId);
+    return postToken(formEncode(params), cancelled);
 }
 
 AuthClient::TokenPollResult AuthClient::refreshToken(const juce::String& refreshTokenValue,
                                                      const std::atomic<bool>& cancelled) const {
-    const juce::String body =
-        formEncode({{"grant_type", "refresh_token"}, {"refresh_token", refreshTokenValue}, {"client_id", clientId}});
-    return postToken(body, cancelled);
+    std::vector<std::pair<juce::String, juce::String>> params{
+        {"grant_type", "refresh_token"}, {"refresh_token", refreshTokenValue}, {"client_id", clientId}};
+    if (deviceId.isNotEmpty())
+        params.emplace_back("device_id", deviceId);
+    return postToken(formEncode(params), cancelled);
 }
 
 AuthClient::MeResult AuthClient::fetchMe(const juce::String& accessToken, const std::atomic<bool>& cancelled) const {

--- a/Source/AI/AuthClient.h
+++ b/Source/AI/AuthClient.h
@@ -76,10 +76,12 @@ public:
         juce::String transportError;
     };
 
-    explicit AuthClient(juce::String host = "http://localhost:8787", juce::String clientId = "synth-desktop");
+    explicit AuthClient(juce::String host = "http://localhost:8787", juce::String clientId = "synth-desktop",
+                        juce::String deviceId = "");
 
-    // Test-specific constructor to inject a fake HTTP transport (no real sockets).
-    AuthClient(juce::String host, juce::String clientId, HttpPerformer performer);
+    // Test-specific constructor to inject a fake HTTP transport (no real sockets). `deviceId`
+    // defaults to empty (omitted from requests) so existing 3-arg call sites keep compiling.
+    AuthClient(juce::String host, juce::String clientId, HttpPerformer performer, juce::String deviceId = "");
 
     /** POST /v1/auth/device/code — starts a device-code flow. */
     DeviceCodeResult requestDeviceCode(const std::atomic<bool>& cancelled) const;
@@ -106,6 +108,11 @@ public:
 private:
     juce::String host;
     juce::String clientId;
+    // A stable per-install identifier (see Source/Auth/DeviceIdStore.h), sent as the `device_id`
+    // form field on device-code issuance and token exchange whenever non-empty. NOT a secret —
+    // unlike clientId/HttpPerformer this is optional: an empty string just omits the field, which
+    // is what every pre-existing 3-arg constructor call (all current callers) gets.
+    juce::String deviceId;
     HttpPerformer performHttp;
 
     /** Shared implementation for pollDeviceToken()/refreshToken(): both hit the same endpoint and

--- a/Source/AI/RemoteProvider.cpp
+++ b/Source/AI/RemoteProvider.cpp
@@ -1,4 +1,5 @@
 #include "RemoteProvider.h"
+#include "../Auth/DeviceIdStore.h"
 #include "../Branding.h"
 #include <algorithm>
 
@@ -38,6 +39,24 @@ juce::String extractErrorDetail(const juce::String& body) {
                 auto message = errorObj->getProperty("message");
                 if (message.isString())
                     return message.toString();
+            }
+        }
+    }
+    return {};
+}
+
+/** Extracts `error.code` from a JSON error body (e.g. "TRIAL_EXHAUSTED",
+    "SERVICE_CAPACITY_EXCEEDED"), if present and a string. Returns an empty string otherwise —
+    callers fall back to the generic HTTP-status-only mapping for that status. */
+juce::String extractErrorCode(const juce::String& body) {
+    auto parsed = juce::JSON::parse(body);
+    if (auto* obj = parsed.getDynamicObject()) {
+        if (obj->hasProperty("error")) {
+            auto errorVar = obj->getProperty("error");
+            if (auto* errorObj = errorVar.getDynamicObject()) {
+                auto code = errorObj->getProperty("code");
+                if (code.isString())
+                    return code.toString();
             }
         }
     }
@@ -169,6 +188,9 @@ RemoteProvider::HttpResult performHttpUnavailable(const juce::String&, const juc
 RemoteProvider::RemoteProvider(const juce::String& host)
     : Thread("RemoteProviderThread")
     , remoteHost(host)
+    // DeviceIdStore() (no explicit path) resolves to the app's standard settings-folder
+    // convention and persists on first read — see Source/Auth/DeviceIdStore.h.
+    , deviceId(DeviceIdStore().getDeviceId())
 #ifndef _WIN32
     , performHttp(performHttpWithCurl)
 #else
@@ -177,9 +199,10 @@ RemoteProvider::RemoteProvider(const juce::String& host)
 {
 }
 
-RemoteProvider::RemoteProvider(const juce::String& host, HttpPerformer performer)
+RemoteProvider::RemoteProvider(const juce::String& host, HttpPerformer performer, juce::String deviceIdIn)
     : Thread("RemoteProviderThread")
     , remoteHost(host)
+    , deviceId(std::move(deviceIdIn))
     , performHttp(std::move(performer)) {}
 
 RemoteProvider::~RemoteProvider() {
@@ -490,6 +513,10 @@ void RemoteProvider::processRequest(const Request& req) {
     requestHeaders.set("Content-Type", "application/json");
     if (authToken.isNotEmpty())
         requestHeaders.set("Authorization", "Bearer " + authToken);
+    // Sent whether or not authToken is set: an anonymous free-request-tier signal when there's no
+    // bearer token, anti-abuse signal when there is one. Harmless either way (not a secret).
+    if (deviceId.isNotEmpty())
+        requestHeaders.set("X-Device-Id", deviceId);
 
     const juce::String url = remoteHost + "/v1/capability/patch.generate";
 
@@ -539,10 +566,36 @@ void RemoteProvider::processRequest(const Request& req) {
     }
 
     if (httpStatus == 402) {
+        // TRIAL_EXHAUSTED is a distinct, user-facing state (the free-trial-to-account conversion
+        // moment — see AIErrorKind::TrialExhausted's doc comment), not a generic quota failure: the
+        // server's message is surfaced verbatim rather than folded into a canned "insufficient
+        // quota" string, since (when the caller isn't signed in) that message specifically invites
+        // signing in to continue. Any other 402 shape keeps the pre-existing generic Quota mapping.
+        if (extractErrorCode(result.body) == "TRIAL_EXHAUSTED") {
+            const auto detail = extractErrorDetail(result.body);
+            deliverErr(AIErrorKind::TrialExhausted,
+                       detail.isNotEmpty() ? detail : "Error: Your free trial has been used up.");
+            return;
+        }
+
         deliverErr(AIErrorKind::Quota, withErrorDetail("Error: Remote provider at " + remoteHost +
                                                            " reported insufficient quota (HTTP 402)",
                                                        result.body));
         return;
+    }
+
+    if (httpStatus == 503) {
+        // SERVICE_CAPACITY_EXCEEDED is a service-wide daily cap, unrelated to the caller's own
+        // usage — distinct from TRIAL_EXHAUSTED and from a generic 5xx, so it gets its own kind
+        // and the server's own message verbatim. Any other 503 shape falls through to the generic
+        // Server mapping below.
+        if (extractErrorCode(result.body) == "SERVICE_CAPACITY_EXCEEDED") {
+            const auto detail = extractErrorDetail(result.body);
+            deliverErr(AIErrorKind::ServiceCapacityExceeded,
+                       detail.isNotEmpty() ? detail
+                                           : "Error: The service is at capacity right now. Please try again shortly.");
+            return;
+        }
     }
 
     if (httpStatus == 400 || httpStatus == 404) {

--- a/Source/AI/RemoteProvider.h
+++ b/Source/AI/RemoteProvider.h
@@ -51,8 +51,10 @@ public:
 
     RemoteProvider(const juce::String& host = "http://localhost:8787");
 
-    // Test-specific constructor to inject a fake HTTP transport (no real sockets).
-    RemoteProvider(const juce::String& host, HttpPerformer performer);
+    // Test-specific constructor to inject a fake HTTP transport (no real sockets). `deviceId`
+    // defaults to empty (X-Device-Id header omitted) so existing 2-arg call sites keep compiling
+    // and never touch the real per-install DeviceIdStore file.
+    RemoteProvider(const juce::String& host, HttpPerformer performer, juce::String deviceId = "");
 
     ~RemoteProvider() override;
 
@@ -92,6 +94,12 @@ private:
     juce::String remoteHost;
     juce::String currentModel; // cosmetic only: the service picks its own model server-side
     juce::String authToken;
+    // A stable per-install identifier (Source/Auth/DeviceIdStore.h), sent as the X-Device-Id
+    // header on every capability request whether or not authToken is set — used for an anonymous
+    // free-trial tier when there's no bearer token, and as anti-abuse signal once there is one.
+    // NOT a secret. Populated from DeviceIdStore in the production constructor; empty (header
+    // omitted) for the test constructor, mirroring authToken's default-empty/opt-in shape.
+    juce::String deviceId;
     HttpPerformer performHttp;
     bool isTestMode = false;
 

--- a/Source/Auth/DeviceIdStore.cpp
+++ b/Source/Auth/DeviceIdStore.cpp
@@ -1,0 +1,64 @@
+#include "DeviceIdStore.h"
+#include "../Branding.h"
+
+namespace synth {
+
+namespace {
+
+/** A plausible device id: a juce::Uuid rendered via toDashedString() is 36 characters
+    (8-4-4-4-12 hex groups joined by hyphens). Loosely validated by shape rather than a strict
+    parse — the goal is "does this look like a real id, or is it empty/truncated/binary garbage
+    left behind by a crash or a hand-edited file", not cryptographic verification. Anything that
+    doesn't pass just means a fresh id gets generated, which is harmless (see class doc comment). */
+bool isPlausibleDeviceId(const juce::String& value) {
+    if (value.length() < 32 || value.length() > 36)
+        return false;
+
+    int hexCount = 0;
+    for (auto character : value) {
+        const bool isHex = (character >= '0' && character <= '9') || (character >= 'a' && character <= 'f') ||
+                           (character >= 'A' && character <= 'F');
+        if (isHex) {
+            ++hexCount;
+        } else if (character != '-') {
+            return false;
+        }
+    }
+
+    return hexCount >= 32;
+}
+
+juce::File defaultDeviceIdFile() {
+    return juce::File::getSpecialLocation(juce::File::userApplicationDataDirectory)
+        .getChildFile(synth::branding::kSettingsFolderName)
+        .getChildFile("device_id");
+}
+
+} // namespace
+
+DeviceIdStore::DeviceIdStore()
+    : file(defaultDeviceIdFile())
+    , deviceId(loadOrCreate()) {}
+
+DeviceIdStore::DeviceIdStore(juce::File idFile)
+    : file(std::move(idFile))
+    , deviceId(loadOrCreate()) {}
+
+juce::String DeviceIdStore::loadOrCreate() const {
+    const auto existing = file.existsAsFile() ? file.loadFileAsString().trim() : juce::String();
+    if (isPlausibleDeviceId(existing))
+        return existing;
+
+    // Missing, empty, or corrupted: generate a fresh id and persist it so subsequent runs (and
+    // subsequent DeviceIdStore instances pointed at the same file) see the same value from here on.
+    const auto freshId = juce::Uuid().toDashedString();
+
+    const auto parent = file.getParentDirectory();
+    if (!parent.exists())
+        parent.createDirectory();
+    file.replaceWithText(freshId);
+
+    return freshId;
+}
+
+} // namespace synth

--- a/Source/Auth/DeviceIdStore.h
+++ b/Source/Auth/DeviceIdStore.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <juce_core/juce_core.h>
+
+namespace synth {
+
+/**
+ * @class DeviceIdStore
+ * @brief Generates and persists a stable per-install device identifier.
+ *
+ * The device id is NOT a secret -- it is not tied to account access and grants no capability by
+ * itself; it just lets the backend recognize "this install" for an anonymous free-trial tier and
+ * as anti-abuse signal once signed in (see docs/AI_Engine.md). That is exactly why it belongs in a
+ * plain file rather than the Keychain (contrast with KeychainTokenStore, which stores the refresh
+ * token -- a real credential).
+ *
+ * One id is generated with juce::Uuid on first run and reused for the lifetime of the install.
+ * If the backing file is missing, empty, or its contents don't look like a plausible id (wrong
+ * shape -- truncated, corrupted, binary garbage), a fresh id is generated and written rather than
+ * crashing or leaving the id blank; a lost/corrupted id just means the backend sees this install
+ * as new, which is harmless.
+ */
+class DeviceIdStore {
+public:
+    /** Production use: stores the id under the app's standard settings folder (same
+        userApplicationDataDirectory/<kSettingsFolderName> convention as ThemeManager and
+        SnippetManager). */
+    DeviceIdStore();
+
+    /** Test use (and any caller that wants an explicit location): reads/writes the id at exactly
+        this file, so tests never share a location with (and can never collide with) a real
+        install's device id. */
+    explicit DeviceIdStore(juce::File idFile);
+
+    /** The device id for this install. Stable across instances constructed against the same file,
+        and across process restarts. Never empty. */
+    juce::String getDeviceId() const { return deviceId; }
+
+private:
+    juce::File file;
+    juce::String deviceId;
+
+    /** Reads `file`; if its contents are missing or don't look like a plausible id, generates a
+        fresh juce::Uuid, writes it to `file` (creating parent directories as needed), and returns
+        that instead. */
+    juce::String loadOrCreate() const;
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(DeviceIdStore)
+};
+
+} // namespace synth

--- a/Tests/AIIntegrationServiceTests.cpp
+++ b/Tests/AIIntegrationServiceTests.cpp
@@ -21,8 +21,8 @@ public:
         AIResponse response;
         if (shouldFail) {
             response.success = false;
-            response.error.kind = AIErrorKind::Server;
-            response.error.message = "Error";
+            response.error.kind = mockErrorKind;
+            response.error.message = mockErrorMessage;
         } else {
             response.success = true;
             response.content = mockResponse;
@@ -51,6 +51,11 @@ public:
 
     juce::String mockResponse = "{\"nodes\": [], \"connections\": []}";
     bool shouldFail = false;
+    // Configurable so tests can exercise any AIErrorKind (e.g. TrialExhausted) through
+    // AIIntegrationService without needing a real RemoteProvider/HTTP mock — see
+    // TrialExhaustedErrorPassesThroughWithServerMessageIntact below.
+    AIErrorKind mockErrorKind = AIErrorKind::Server;
+    juce::String mockErrorMessage = "Error";
     juce::String currentModel;
     juce::String lastAuthToken;
     std::vector<Message> lastConversation;
@@ -234,6 +239,47 @@ TEST_F(AIIntegrationServiceTest, SetAuthTokenBeforeProviderInstalledIsRePushedBy
     service->setProvider(std::move(provider));
 
     EXPECT_EQ(rawProvider->lastAuthToken, "token-xyz");
+}
+
+// P3-3 (anonymous trial): a mocked 402 TRIAL_EXHAUSTED response from the provider must reach the
+// caller as a distinct AIErrorKind::TrialExhausted with the server's message intact — not
+// collapsed into a generic failure. The actual HTTP-status-to-AIErrorKind mapping is RemoteProvider's
+// job (see Tests/RemoteProviderTests.cpp's TrialExhaustedMapsToDistinctKindWithServerMessageIntact
+// for that); this test locks down that AIIntegrationService::sendMessage() is a transparent
+// pass-through and never rewrites error.kind/error.message on the way to the UI-facing callback.
+TEST_F(AIIntegrationServiceTest, TrialExhaustedErrorPassesThroughWithServerMessageIntact) {
+    auto provider = std::make_unique<MockAIProvider>();
+    provider->shouldFail = true;
+    provider->mockErrorKind = AIProvider::AIErrorKind::TrialExhausted;
+    provider->mockErrorMessage = "Your free trial has been used up. Sign in with Google to continue.";
+    service->setProvider(std::move(provider));
+
+    AIProvider::AIResponse received;
+    service->sendMessage("make a bass patch",
+                         [&received](const AIProvider::AIResponse& response) { received = response; });
+
+    EXPECT_FALSE(received.success);
+    EXPECT_EQ(received.error.kind, AIProvider::AIErrorKind::TrialExhausted);
+    EXPECT_EQ(received.error.message,
+              juce::String("Your free trial has been used up. Sign in with Google to continue."));
+}
+
+// Same pass-through guarantee for the other new distinct kind (a service-wide capacity cap,
+// unrelated to the caller's own trial/quota).
+TEST_F(AIIntegrationServiceTest, ServiceCapacityExceededErrorPassesThroughWithServerMessageIntact) {
+    auto provider = std::make_unique<MockAIProvider>();
+    provider->shouldFail = true;
+    provider->mockErrorKind = AIProvider::AIErrorKind::ServiceCapacityExceeded;
+    provider->mockErrorMessage = "The service is at its daily capacity. Please try again later.";
+    service->setProvider(std::move(provider));
+
+    AIProvider::AIResponse received;
+    service->sendMessage("make a bass patch",
+                         [&received](const AIProvider::AIResponse& response) { received = response; });
+
+    EXPECT_FALSE(received.success);
+    EXPECT_EQ(received.error.kind, AIProvider::AIErrorKind::ServiceCapacityExceeded);
+    EXPECT_EQ(received.error.message, juce::String("The service is at its daily capacity. Please try again later."));
 }
 
 TEST_F(AIIntegrationServiceTest, ApplyPatch_MergeMode_PreservesExisting) {

--- a/Tests/AuthClientTests.cpp
+++ b/Tests/AuthClientTests.cpp
@@ -8,6 +8,7 @@ namespace {
 
 const juce::String kHost = "http://mock-host:8787";
 const juce::String kClientId = "synth-desktop";
+const juce::String kDeviceId = "device-uuid-1234";
 
 synth::AuthClient::HttpResult makeStatus(int status, const juce::String& body,
                                          const juce::StringPairArray& headers = {}) {
@@ -86,6 +87,53 @@ TEST(AuthClientTest, RequestDeviceCodeHappyPathParsesEveryField) {
     EXPECT_EQ(parseForm(capturedBody)["client_id"], kClientId);
 }
 
+TEST(AuthClientTest, RequestDeviceCodeIncludesDeviceIdWhenConfigured) {
+    juce::String capturedBody;
+
+    auto performer = [&](const juce::String&, const juce::String&, const juce::StringPairArray&,
+                         const juce::String& body, int, const std::atomic<bool>&) -> synth::AuthClient::HttpResult {
+        capturedBody = body;
+        return makeStatus(200, R"({
+            "device_code": "devcode-abc",
+            "user_code": "ABCD-1234",
+            "verification_uri": "https://example.com/activate",
+            "verification_uri_complete": "https://example.com/activate?user_code=ABCD-1234",
+            "expires_in": 900,
+            "interval": 5
+        })");
+    };
+
+    synth::AuthClient client{kHost, kClientId, performer, kDeviceId};
+    const auto result = client.requestDeviceCode(kNeverCancelled);
+
+    ASSERT_TRUE(result.ok);
+    EXPECT_EQ(parseForm(capturedBody)["device_id"], kDeviceId);
+}
+
+TEST(AuthClientTest, RequestDeviceCodeOmitsDeviceIdWhenNotConfigured) {
+    juce::String capturedBody;
+
+    auto performer = [&](const juce::String&, const juce::String&, const juce::StringPairArray&,
+                         const juce::String& body, int, const std::atomic<bool>&) -> synth::AuthClient::HttpResult {
+        capturedBody = body;
+        return makeStatus(200, R"({
+            "device_code": "devcode-abc",
+            "user_code": "ABCD-1234",
+            "verification_uri": "https://example.com/activate",
+            "verification_uri_complete": "https://example.com/activate?user_code=ABCD-1234",
+            "expires_in": 900,
+            "interval": 5
+        })");
+    };
+
+    // 3-arg constructor: deviceId defaults to empty, so the field must be omitted entirely
+    // (not sent as "device_id=") rather than a parallel mechanism being required to opt out.
+    synth::AuthClient client{kHost, kClientId, performer};
+    client.requestDeviceCode(kNeverCancelled);
+
+    EXPECT_EQ(parseForm(capturedBody).count("device_id"), 0u);
+}
+
 TEST(AuthClientTest, RequestDeviceCodeTransportFailure) {
     auto performer = [](const juce::String&, const juce::String&, const juce::StringPairArray&, const juce::String&,
                         int,
@@ -131,6 +179,21 @@ TEST(AuthClientTest, PollDeviceTokenSuccessParsesEveryFieldAndSendsCorrectBody) 
     EXPECT_EQ(form.at("grant_type"), juce::String("urn:ietf:params:oauth:grant-type:device_code"));
     EXPECT_EQ(form.at("device_code"), juce::String("devcode-abc"));
     EXPECT_EQ(form.at("client_id"), kClientId);
+}
+
+TEST(AuthClientTest, PollDeviceTokenIncludesDeviceIdWhenConfigured) {
+    juce::String capturedBody;
+
+    auto performer = [&](const juce::String&, const juce::String&, const juce::StringPairArray&,
+                         const juce::String& body, int, const std::atomic<bool>&) -> synth::AuthClient::HttpResult {
+        capturedBody = body;
+        return makeStatus(200, R"({"access_token":"a","token_type":"Bearer","expires_in":60,"refresh_token":"r"})");
+    };
+
+    synth::AuthClient client{kHost, kClientId, performer, kDeviceId};
+    client.pollDeviceToken("devcode-abc", kNeverCancelled);
+
+    EXPECT_EQ(parseForm(capturedBody)["device_id"], kDeviceId);
 }
 
 struct PollErrorCase {
@@ -203,6 +266,21 @@ TEST(AuthClientTest, RefreshTokenSuccessSendsCorrectBody) {
     EXPECT_EQ(form.at("grant_type"), juce::String("refresh_token"));
     EXPECT_EQ(form.at("refresh_token"), juce::String("old-refresh-token"));
     EXPECT_EQ(form.at("client_id"), kClientId);
+}
+
+TEST(AuthClientTest, RefreshTokenIncludesDeviceIdWhenConfigured) {
+    juce::String capturedBody;
+
+    auto performer = [&](const juce::String&, const juce::String&, const juce::StringPairArray&,
+                         const juce::String& body, int, const std::atomic<bool>&) -> synth::AuthClient::HttpResult {
+        capturedBody = body;
+        return makeStatus(200, R"({"access_token":"a2","token_type":"Bearer","expires_in":60,"refresh_token":"r2"})");
+    };
+
+    synth::AuthClient client{kHost, kClientId, performer, kDeviceId};
+    client.refreshToken("old-refresh-token", kNeverCancelled);
+
+    EXPECT_EQ(parseForm(capturedBody)["device_id"], kDeviceId);
 }
 
 TEST(AuthClientTest, RefreshTokenInvalidGrant) {

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -42,6 +42,7 @@ add_executable(Tests
     AuthClientTests.cpp
     AccountServiceTests.cpp
     KeychainTokenStoreTests.cpp
+    DeviceIdStoreTests.cpp
     MainComponentTests.cpp
     GraphEditorTests.cpp
     ModuleComponentTests.cpp

--- a/Tests/DeviceIdStoreTests.cpp
+++ b/Tests/DeviceIdStoreTests.cpp
@@ -1,0 +1,80 @@
+#include "../Source/Auth/DeviceIdStore.h"
+#include <gtest/gtest.h>
+#include <juce_core/juce_core.h>
+
+namespace {
+
+class DeviceIdStoreTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        parentDir = juce::File::getSpecialLocation(juce::File::tempDirectory)
+                        .getChildFile("DeviceIdStoreTest")
+                        .getNonexistentChildFile("run", "", false);
+        parentDir.createDirectory();
+    }
+
+    void TearDown() override { parentDir.deleteRecursively(); }
+
+    juce::File idFile() const { return parentDir.getChildFile("device_id"); }
+
+    juce::File parentDir;
+};
+
+} // namespace
+
+TEST_F(DeviceIdStoreTest, FreshLocationProducesAValidNonEmptyId) {
+    synth::DeviceIdStore store{idFile()};
+
+    const auto id = store.getDeviceId();
+    EXPECT_TRUE(id.isNotEmpty());
+    EXPECT_GE(id.length(), 32);
+
+    // Persisted for the next instance/process to pick up.
+    EXPECT_TRUE(idFile().existsAsFile());
+    EXPECT_EQ(idFile().loadFileAsString().trim(), id);
+}
+
+TEST_F(DeviceIdStoreTest, TwoInstancesAtTheSameFileReturnTheSameId) {
+    synth::DeviceIdStore first{idFile()};
+    const auto firstId = first.getDeviceId();
+
+    synth::DeviceIdStore second{idFile()};
+    const auto secondId = second.getDeviceId();
+
+    EXPECT_EQ(firstId, secondId);
+    EXPECT_TRUE(firstId.isNotEmpty());
+}
+
+TEST_F(DeviceIdStoreTest, CorruptedExistingFileIsRecoveredFromWithAFreshId) {
+    idFile().getParentDirectory().createDirectory();
+    idFile().replaceWithText("!!! not a device id, just garbage bytes !!!");
+
+    synth::DeviceIdStore store{idFile()};
+    const auto id = store.getDeviceId();
+
+    EXPECT_TRUE(id.isNotEmpty());
+    EXPECT_NE(id, juce::String("!!! not a device id, just garbage bytes !!!"));
+    // The corrupted file is overwritten with the freshly generated id, not left as-is.
+    EXPECT_EQ(idFile().loadFileAsString().trim(), id);
+}
+
+TEST_F(DeviceIdStoreTest, EmptyExistingFileIsRecoveredFromWithAFreshId) {
+    idFile().getParentDirectory().createDirectory();
+    idFile().replaceWithText("");
+
+    synth::DeviceIdStore store{idFile()};
+    const auto id = store.getDeviceId();
+
+    EXPECT_TRUE(id.isNotEmpty());
+}
+
+TEST_F(DeviceIdStoreTest, MissingParentDirectoryIsCreated) {
+    // idFile()'s parent (parentDir) exists from SetUp(), but point at a location nested one level
+    // deeper that has never been created, to exercise the parent-directory-creation path.
+    const auto nestedFile = parentDir.getChildFile("nested").getChildFile("device_id");
+
+    synth::DeviceIdStore store{nestedFile};
+
+    EXPECT_TRUE(store.getDeviceId().isNotEmpty());
+    EXPECT_TRUE(nestedFile.existsAsFile());
+}

--- a/Tests/RemoteProviderTests.cpp
+++ b/Tests/RemoteProviderTests.cpp
@@ -191,6 +191,48 @@ TEST_F(RemoteProviderTest, AuthorizationHeaderOnlySentWhenTokenSet) {
     EXPECT_EQ(capturedHeaders.getValue("Authorization", ""), juce::String("Bearer secret-token-123"));
 }
 
+TEST_F(RemoteProviderTest, DeviceIdHeaderSentWhenConfiguredRegardlessOfAuthToken) {
+    juce::StringPairArray capturedHeaders;
+    auto performer = [&](const juce::String&, const juce::StringPairArray& headers, const juce::String&, int,
+                         const std::atomic<bool>&) -> synth::RemoteProvider::HttpResult {
+        capturedHeaders = headers;
+        return makeSuccess(R"({"data":{}})");
+    };
+
+    // No setAuthToken() call: X-Device-Id must still be sent — it is an anonymous free-trial
+    // signal when signed out, not something gated on having a bearer token.
+    synth::RemoteProvider provider{kMockHost, performer, "device-uuid-1234"};
+    provider.setTestMode(true);
+
+    MockPromptCallback callback;
+    provider.sendPrompt(
+        {{"user", "hi"}}, [&callback](const synth::AIProvider::AIResponse& r) { callback(r); }, makeSchema());
+    callback.getResult();
+    provider.stopThread(5000);
+
+    EXPECT_EQ(capturedHeaders.getValue("X-Device-Id", ""), juce::String("device-uuid-1234"));
+}
+
+TEST_F(RemoteProviderTest, DeviceIdHeaderOmittedWhenNotConfigured) {
+    juce::StringPairArray capturedHeaders;
+    auto performer = [&](const juce::String&, const juce::StringPairArray& headers, const juce::String&, int,
+                         const std::atomic<bool>&) -> synth::RemoteProvider::HttpResult {
+        capturedHeaders = headers;
+        return makeSuccess(R"({"data":{}})");
+    };
+
+    synth::RemoteProvider provider{kMockHost, performer};
+    provider.setTestMode(true);
+
+    MockPromptCallback callback;
+    provider.sendPrompt(
+        {{"user", "hi"}}, [&callback](const synth::AIProvider::AIResponse& r) { callback(r); }, makeSchema());
+    callback.getResult();
+    provider.stopThread(5000);
+
+    EXPECT_FALSE(capturedHeaders.containsKey("X-Device-Id"));
+}
+
 // ============================================================================
 // Fail-fast: no network call
 // ============================================================================
@@ -419,6 +461,95 @@ TEST_F(RemoteProviderTest, ErrorBodyMessageIsAppendedToDeliveredError) {
     EXPECT_FALSE(result.success);
     EXPECT_EQ(result.error.kind, synth::AIProvider::AIErrorKind::Server);
     EXPECT_TRUE(result.error.message.contains("model timed out mid-generation"));
+}
+
+TEST_F(RemoteProviderTest, TrialExhaustedMapsToDistinctKindWithServerMessageIntact) {
+    auto performer = [](const juce::String&, const juce::StringPairArray&, const juce::String&, int,
+                        const std::atomic<bool>&) -> synth::RemoteProvider::HttpResult {
+        return makeStatus(402, R"({"error":{"code":"TRIAL_EXHAUSTED",)"
+                               R"("message":"Your free trial has been used up. Sign in with Google to continue."}})");
+    };
+
+    synth::RemoteProvider provider{kMockHost, performer};
+    provider.setTestMode(true);
+
+    MockPromptCallback callback;
+    provider.sendPrompt(
+        {{"user", "hi"}}, [&callback](const synth::AIProvider::AIResponse& r) { callback(r); }, makeSchema());
+
+    auto result = callback.getResult();
+    provider.stopThread(5000);
+
+    EXPECT_FALSE(result.success);
+    EXPECT_EQ(result.error.kind, synth::AIProvider::AIErrorKind::TrialExhausted);
+    EXPECT_EQ(result.error.message, juce::String("Your free trial has been used up. Sign in with Google to continue."));
+}
+
+// A 402 with no TRIAL_EXHAUSTED code (e.g. a signed-in paid account genuinely out of quota) must
+// keep the pre-existing generic Quota mapping — this is a REGRESSION LOCK on the existing
+// StatusMappingCase{402, Quota} behavior now that 402 has a second branch.
+TEST_F(RemoteProviderTest, NonTrialFourOhTwoStaysGenericQuota) {
+    auto performer = [](const juce::String&, const juce::StringPairArray&, const juce::String&, int,
+                        const std::atomic<bool>&) -> synth::RemoteProvider::HttpResult {
+        return makeStatus(402, "{}");
+    };
+
+    synth::RemoteProvider provider{kMockHost, performer};
+    provider.setTestMode(true);
+
+    MockPromptCallback callback;
+    provider.sendPrompt(
+        {{"user", "hi"}}, [&callback](const synth::AIProvider::AIResponse& r) { callback(r); }, makeSchema());
+
+    auto result = callback.getResult();
+    provider.stopThread(5000);
+
+    EXPECT_FALSE(result.success);
+    EXPECT_EQ(result.error.kind, synth::AIProvider::AIErrorKind::Quota);
+}
+
+TEST_F(RemoteProviderTest, ServiceCapacityExceededMapsToDistinctKindWithServerMessageIntact) {
+    auto performer = [](const juce::String&, const juce::StringPairArray&, const juce::String&, int,
+                        const std::atomic<bool>&) -> synth::RemoteProvider::HttpResult {
+        return makeStatus(503, R"({"error":{"code":"SERVICE_CAPACITY_EXCEEDED",)"
+                               R"("message":"The service is at its daily capacity. Please try again later."}})");
+    };
+
+    synth::RemoteProvider provider{kMockHost, performer};
+    provider.setTestMode(true);
+
+    MockPromptCallback callback;
+    provider.sendPrompt(
+        {{"user", "hi"}}, [&callback](const synth::AIProvider::AIResponse& r) { callback(r); }, makeSchema());
+
+    auto result = callback.getResult();
+    provider.stopThread(5000);
+
+    EXPECT_FALSE(result.success);
+    EXPECT_EQ(result.error.kind, synth::AIProvider::AIErrorKind::ServiceCapacityExceeded);
+    EXPECT_EQ(result.error.message, juce::String("The service is at its daily capacity. Please try again later."));
+}
+
+// A 503 with no SERVICE_CAPACITY_EXCEEDED code must fall through to the generic Server mapping,
+// same as any other unrecognized 5xx.
+TEST_F(RemoteProviderTest, NonCapacityFiveOhThreeFallsBackToGenericServer) {
+    auto performer = [](const juce::String&, const juce::StringPairArray&, const juce::String&, int,
+                        const std::atomic<bool>&) -> synth::RemoteProvider::HttpResult {
+        return makeStatus(503, "{}");
+    };
+
+    synth::RemoteProvider provider{kMockHost, performer};
+    provider.setTestMode(true);
+
+    MockPromptCallback callback;
+    provider.sendPrompt(
+        {{"user", "hi"}}, [&callback](const synth::AIProvider::AIResponse& r) { callback(r); }, makeSchema());
+
+    auto result = callback.getResult();
+    provider.stopThread(5000);
+
+    EXPECT_FALSE(result.success);
+    EXPECT_EQ(result.error.kind, synth::AIProvider::AIErrorKind::Server);
 }
 
 // ============================================================================

--- a/docs/AI_Engine.md
+++ b/docs/AI_Engine.md
@@ -609,14 +609,20 @@ same as `OllamaProvider` checks `wasCancelled()` right after the network call re
 | `cancelled`                                   | `Cancelled`                      |
 | HTTP 401 / 403                                | `Auth`                            |
 | HTTP 429 (reads `Retry-After`)                | `RateLimit`                      |
-| HTTP 402                                      | `Quota`                           |
+| HTTP 402, `error.code == "TRIAL_EXHAUSTED"`   | `TrialExhausted` (see "Device Id and Anonymous Trial" below) |
+| HTTP 402, any other/no code                   | `Quota`                           |
+| HTTP 503, `error.code == "SERVICE_CAPACITY_EXCEEDED"` | `ServiceCapacityExceeded` (see below) |
 | HTTP 400 / 404                                | `Schema` (client/request-shape problem, not worth retrying as-is) |
-| HTTP 500 / 502 / any other unexpected non-2xx | `Server`                          |
+| HTTP 500 / 502 / 503 (any other code) / any other unexpected non-2xx | `Server` |
 | 2xx with no parseable `data`                  | `Schema`                          |
 
 Whenever the response body parses as JSON with a string `error.message`, it is appended to the
 delivered error message (mirrors the "name the specific failure" ethos on
 `AIIntegrationService::buildCorrectionPrompt`); otherwise the message just names the HTTP status.
+`TrialExhausted` and `ServiceCapacityExceeded` are the two exceptions to "appended": the server's
+`error.message` there is a complete, user-facing sentence on its own (see below), so it is
+delivered verbatim as `AIError::message` rather than tacked onto a generic "reported insufficient
+quota (HTTP 402)"-style prefix.
 
 **Cancellation, simplified vs `OllamaProvider`.** libcurl doesn't need the
 `StreamPublisher`/`activeStream`/`streamLock` machinery `OllamaProvider` uses to abort a
@@ -657,6 +663,46 @@ through `RemoteProvider` instead of `OllamaProvider` via `--provider remote`, so
 scored through the exact stack a user hits — client -> service -> Ollama/Groq — instead of an
 approximation of it. The service picks its own model server-side; the harness's `--model` is a
 report label only in this mode.
+
+### Device Id and Anonymous Trial (P3-3)
+
+`Source/Auth/DeviceIdStore.h/.cpp` generates a stable per-install identifier (`juce::Uuid`,
+dashed-string form) the first time it runs and persists it under the app's standard settings
+folder (`userApplicationDataDirectory/<kSettingsFolderName>/device_id`, the same
+`getSpecialLocation`/`kSettingsFolderName` convention `ThemeManager`/`SnippetManager` use), then
+reuses it for the lifetime of the install. If the file is missing, empty, or its contents don't
+look like a plausible id, a fresh one is generated and written rather than crashing or leaving the
+id blank — a lost/corrupted id just makes the backend see this install as new, which is harmless.
+
+**Not a secret.** Unlike the refresh token (`KeychainTokenStore`, Keychain-backed), the device id
+grants no account access by itself — it is only a "this install" signal — so it is deliberately
+stored in a plain file, not the Keychain. Both `AccountService` (for `AuthClient`) and
+`RemoteProvider` construct their own `DeviceIdStore` in their production constructors and read the
+same persisted value; their test constructors take an explicit `deviceId` string instead (default
+empty, field/header omitted) so unit tests never touch the real per-install file.
+
+**Where it's sent:**
+
+- `AuthClient::requestDeviceCode()` / `pollDeviceToken()` / `refreshToken()` — `device_id` form
+  field alongside the existing `client_id`, whenever non-empty.
+- `RemoteProvider` — `X-Device-Id` header on every `/v1/capability/*` request, sent whether or not
+  `Authorization` is also set: an anonymous free-request-tier signal when there's no bearer token,
+  anti-abuse signal once there is one.
+
+**Trial-exhausted UX path.** When the free trial is used up, the capability endpoint answers
+`402 {"error":{"code":"TRIAL_EXHAUSTED","message":"..."}}`, mapped by `RemoteProvider` to
+`AIErrorKind::TrialExhausted` with the server's `message` carried through unchanged (see the
+error-kind table above). That response reaches `AIChatComponent` through the same path every other
+provider error already does — appended to the conversation as an assistant bubble
+(`"Error: " + error.message`) — so no new UI surface is needed. When the caller is not signed in,
+the server's message text specifically invites signing in with Google to continue; the existing
+`AccountRow` "Sign in" affordance (see "Account Sign-In Surface" above) is already visible
+immediately above the chat whenever an `AccountService` is attached, so the next step (opening
+`SignInDialog`) is always one click away without this feature needing to auto-launch it. A
+service-wide `503 {"error":{"code":"SERVICE_CAPACITY_EXCEEDED","message":"..."}}` is handled the
+same way but mapped to the distinct `AIErrorKind::ServiceCapacityExceeded` — it's a daily cap on
+the service as a whole, unrelated to the caller's own trial/quota, and gets its own message rather
+than being confused with either.
 
 ## 6. Future Considerations
 


### PR DESCRIPTION
## Summary
- Adds `Source/Auth/DeviceIdStore` — a stable per-install `juce::Uuid` persisted in a plain file (not the Keychain — it's not a secret, unlike the refresh token in `KeychainTokenStore`). Recovers cleanly from a missing/empty/corrupted file by generating a fresh id rather than crashing.
- Wires the device id as a `device_id` form field on `AuthClient`'s device-code and token-exchange requests, and as an `X-Device-Id` header on every `RemoteProvider` capability request — sent whether or not the user is signed in.
- Adds distinct `AIErrorKind::TrialExhausted` / `ServiceCapacityExceeded` for the backend's new `402 TRIAL_EXHAUSTED` / `503 SERVICE_CAPACITY_EXCEEDED` capability responses, carrying the server's message through verbatim rather than a canned string. Any other 402/503 shape keeps the pre-existing generic `Quota`/`Server` mapping.
- No new UI needed: `AIChatComponent` already renders `error.message` verbatim, and `AccountRow`'s "Sign in" button is already visible whenever signed out — so the trial-to-account conversion moment (an exhausted anonymous trial inviting Google sign-in) is reachable with no changes there.

Pairs with the backend half: https://github.com/Diabl0269/synth-platform/pull/23

This branch was rebased onto current `main` after review to pick up the theme/module-additions work that landed in parallel; the rebase was conflict-free and the full suite was re-run afterward.

## Test plan
- [x] Full build (`cmake --build build --target Tests`) succeeds
- [x] Full suite: 1319/1319 tests pass, including new `DeviceIdStoreTest.*` (fresh/stable/corrupted-recovery), `AuthClientTest.*DeviceId*`, `RemoteProviderTest.*DeviceId*`/`*TrialExhausted*`/`*Capacity*`, and `AIIntegrationServiceTest.*ExhaustedError*`
- [x] `clang-format --dry-run --Werror` clean on all touched/new files

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>