### PR TITLE
ci: build only on push to main, skip redundant tests/lint/coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,8 +68,21 @@ env:
   CACHE_CHECK_ENFORCE: ${{ vars.CI_CACHE_CHECK_ENFORCE || 'false' }}
 
 jobs:
+  # On push to main the jobs below exist ONLY to seed the caches that pull requests restore from,
+  # so everything that is not compilation is skipped there: linting, test execution and coverage
+  # all ran on the pull request against this same tree, and re-running them on the merge result
+  # costs runner minutes without adding signal. `build-artifacts.yml` has always taken this
+  # position for the release build ("no tests — CI already ran them on the PR").
+  #
+  # Crucially this does NOT weaken the cache: `cmake --build build` still compiles the Tests
+  # target, so every test translation unit lands in ccache either way. Only *running* the binary
+  # is skipped. Before this, a push run spent 9.4 runner-minutes; roughly a third of that was
+  # redundant — the macOS job in particular was an 8-second build carrying 118 seconds of tests.
   lint:
     name: Lint
+    # Formatting cannot change between the PR run and the merge commit, and this job also carries
+    # the cache-check unit tests, which are equally a PR-time concern.
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
@@ -188,7 +201,10 @@ jobs:
         path: ${{ env.CCACHE_DIR }}
         key: ${{ steps.ccache-cache.outputs.cache-primary-key }}
 
+    # Test execution, coverage and its artifact are pull-request concerns; a push run is only here
+    # to seed the cache (see the note above the `lint` job).
     - name: Run Tests
+      if: github.event_name == 'pull_request'
       timeout-minutes: 10
       run: |
         export LLVM_PROFILE_FILE="default.profraw"
@@ -197,10 +213,11 @@ jobs:
         ./build/Tests/Tests
 
     - name: Check Coverage
+      if: github.event_name == 'pull_request'
       run: xvfb-run bash scripts/coverage.sh --report-only
 
     - name: Upload Coverage Artifact (Optional)
-      if: always()
+      if: always() && github.event_name == 'pull_request'
       uses: actions/upload-artifact@v7
       with:
         name: coverage-report
@@ -322,7 +339,10 @@ jobs:
         path: ${{ env.CCACHE_DIR }}
         key: ${{ steps.ccache-cache.outputs.cache-primary-key }}
 
+    # Pull-request only — a push run seeds the cache (see the note above the `lint` job). This is
+    # the starkest case: an 8-second cached build was carrying 118 seconds of test execution.
     - name: Run Tests
+      if: github.event_name == 'pull_request'
       working-directory: ./build/Tests
       run: ./Tests
 
@@ -408,7 +428,9 @@ jobs:
         path: ${{ env.CCACHE_DIR }}
         key: ${{ steps.ccache-cache.outputs.cache-primary-key }}
 
+    # Pull-request only — a push run seeds the cache (see the note above the `lint` job).
     - name: Run Tests
+      if: github.event_name == 'pull_request'
       shell: bash
       run: |
         find build -name "Tests.exe" -exec {} \;

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -370,6 +370,12 @@ CI runs via `.github/workflows/ci.yml` on pull requests to `main` **and on pushe
 
 The push-to-`main` trigger exists **to seed the build caches** — see [Build caching](#build-caching). Removing it silently doubles every PR's build time, so it is load-bearing, not redundant with the artifact workflow.
 
+**Push runs build only.** Linting, test execution and the coverage check are gated to `pull_request`: they already ran on the PR against this same tree, so repeating them on the merge result costs runner minutes without adding signal — the position `build-artifacts.yml` has always taken for the release build. This does not weaken the cache, because `cmake --build build` still compiles the `Tests` target; only *running* the binary is skipped, so every test translation unit still lands in ccache. It trims a push run from ~9.4 to ~6 runner-minutes; the macOS job was the worst offender, an 8-second cached build carrying 118 seconds of tests.
+
+What this gives up: a post-merge run no longer catches two PRs that are each green alone but conflict once both land. The exposure is small — the next PR's CI runs against the merged result, and the release build still fails if the merge does not compile.
+
+> **Do not rename the `Lint`, `Build, Test, and Coverage`, `Build and Test (macOS)` or `Build and Test (Windows)` jobs.** Those four strings are configured as required status checks in `main`'s branch protection; renaming one leaves a required check permanently pending and blocks every merge. Skipping a job on `push` is safe (protection only gates pull requests) — renaming it is not.
+
 A `concurrency` group cancels superseded runs on the same PR (main is never cancelled, since those runs seed the cache).
 
 There are **five jobs**:


### PR DESCRIPTION
## Summary

Post-merge runs were doing far more than seeding the cache. Measured on `2580f91`: **9.4 runner-minutes** across four jobs, roughly a third of it redundant.

| Job | Build | Tests + coverage | Total |
|---|---|---|---|
| macOS | **8s** | **118s** | 158s |
| Linux | 78s | 41s | 174s |
| Windows | 141s | 31s | 230s |
| Lint | — | — | 6s |

The macOS row is the clearest case: an 8-second cached build carrying two minutes of test execution.

## Changes

Linting, test execution and the coverage check are gated to `pull_request`. All three already ran on the PR against this same tree, so repeating them on the merge result costs runner minutes without adding signal — the position `build-artifacts.yml` has always taken for the release build (*"no tests — CI already ran them on the PR"*).

**This does not weaken the cache**, which is the entire point of the push runs: `cmake --build build` still compiles the `Tests` target, so every test translation unit still lands in ccache. Only *running* the binary is skipped. Expected: ~9.4 → ~6 runner-minutes per merge, and one fewer check in the post-merge modal.

Wall-clock to a release is unchanged either way — the two workflows run concurrently and the release run is not on the critical path of the CI run.

## What this gives up

A post-merge run no longer catches the case where two PRs are each green alone but conflict once both land. The exposure is small: the next PR's CI runs against the merged result, and the release build still fails if the merge does not compile. Flagging it explicitly rather than burying it — say so and I will restore tests on `main`.

## Deliberately not done: renaming jobs

Renaming `Build, Test, and Coverage` to something like `Seed Cache` would make the post-merge modal self-explanatory, but **`main`'s branch protection lists `Lint`, `Build, Test, and Coverage`, `Build and Test (macOS)` and `Build and Test (Windows)` as required status checks.** Renaming one leaves a required check permanently pending and blocks every merge. *Skipping* a job on `push` is safe — protection only gates pull requests — but renaming is not. Documented in `docs/testing.md` so the next person does not walk into it.

## Test Plan

- [x] All existing tests pass — CI configuration only, no product code. Tests still run on every pull request, unchanged.
- [x] New tests added for new functionality — n/a; this removes work rather than adding behaviour.
- [x] Tested locally — both workflows validated as parsing YAML; verified programmatically that all four required-check job names are byte-identical to the branch-protection contexts, and that exactly the five intended steps carry the `pull_request` gate.
- [x] Documentation updated — `docs/testing.md` records that push runs build only, why that is safe for the cache, what it gives up, and the do-not-rename warning.

## Note

This PR's own CI is a `pull_request` run, so it exercises the *unchanged* path — tests, lint and coverage all still run here. The trimmed path only takes effect on the merge commit, which is where it should be checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)