### PR TITLE
feat(ui): zoomable Graph Editor minimap with toggle button and Cmd+K (#159)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,6 +125,8 @@ add_library(Core STATIC
     Source/UI/StatusBarComponent.cpp
     Source/UI/ToolbarComponent.h
     Source/UI/ToolbarComponent.cpp
+    Source/UI/MinimapComponent.h
+    Source/UI/MinimapComponent.cpp
     # Theme system
     Source/UI/Theme/Theme.h
     Source/UI/Theme/ThemeManager.h
@@ -268,6 +270,8 @@ juce_add_binary_data(Assets SOURCES
     assets/icons/waveform-saw.svg
     assets/icons/waveform-square.svg
     assets/icons/waveform-triangle.svg
+    # Minimap toggle (issue #159).
+    assets/icons/toggle-minimap.svg
 )
 
 # The themed LookAndFeel lives in Core and pulls typefaces from BinaryData;

--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -566,7 +566,13 @@ bool MainComponent::perform(const InvocationInfo& info) {
     }
 }
 
-void MainComponent::updateCommandShortcuts() { commandManager.commandStatusChanged(); }
+void MainComponent::updateCommandShortcuts() {
+    commandManager.commandStatusChanged();
+    // Tooltips embed the resolved key ("Save preset  (Cmd+S)"), so a rebind has to re-run them or
+    // every toolbar hint — and the minimap's — keeps advertising the old binding until some
+    // unrelated toggle happens to refresh it.
+    applyToolbarIcons();
+}
 
 // ---- Snippets (issue #156) ----
 
@@ -745,6 +751,10 @@ void MainComponent::applyToolbarIcons() {
 
     const juce::String minimapBase = graphEditor.isMinimapVisible() ? "Hide Minimap" : "Show Minimap";
     toggleMinimapButton.setTooltip(hint(minimapBase, "toggleMinimap"));
+    // The map itself advertises the same binding on hover. MinimapComponent has no ShortcutManager
+    // dependency, so the display string is resolved here and pushed down.
+    graphEditor.getMinimap().setShortcutHint(
+        ShortcutManager::keyPressToDisplayString(shortcutManager.getBinding("toggleMinimap")));
 
     const juce::String aiBase = isAiPanelVisible ? "Hide AI Panel" : "Show AI Panel";
     toggleAiPanelButton.setTooltip(hint(aiBase, "toggleAiPanel"));

--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -73,6 +73,10 @@ void MainComponent::initialiseCommon(std::unique_ptr<synth::AIProvider> provider
     graphEditor.setAlignmentGuidesEnabled(
         appProperties.getUserSettings()->getBoolValue("alignmentGuidesEnabled", true));
 
+    // Minimap overlay visibility (issue #159), defaults to visible.
+    const bool minimapVisible = appProperties.getUserSettings()->getBoolValue("minimapVisible", true);
+    graphEditor.setMinimapVisible(minimapVisible);
+
     // Cable colour config (issue #157). Restored HERE rather than only in AppearanceSettingsTab:
     // that tab is built lazily when the Settings window opens, so leaving it to the tab would
     // mean the canvas ignored the user's saved colours until they went looking for them.
@@ -253,6 +257,15 @@ void MainComponent::initialiseCommon(std::unique_ptr<synth::AIProvider> provider
         animatePanelTransition(fromResult, toResult, /*hideLib=*/false, /*hideAi=*/!newVisible);
     };
 
+    addAndMakeVisible(toggleMinimapButton);
+    toggleMinimapButton.setComponentID("toggleMinimap");
+    toggleMinimapButton.onClick = [this] {
+        graphEditor.toggleMinimapVisibility();
+        appProperties.getUserSettings()->setValue("minimapVisible", graphEditor.isMinimapVisible() ? "1" : "0");
+        appProperties.getUserSettings()->saveIfNeeded();
+        applyToolbarIcons();
+    };
+
     addAndMakeVisible(toggleModMatrixButton);
     toggleModMatrixButton.setComponentID("toggleModMatrix");
     toggleModMatrixButton.onClick = [this] {
@@ -295,8 +308,8 @@ void MainComponent::initialiseCommon(std::unique_ptr<synth::AIProvider> provider
     // resized() -> layoutButtons() pass finds the registered buttons and positions them.
     // Calling setSize() before setButtons() leaves all buttons with zero bounds on first launch.
     toolbar.setButtons({&toggleLibraryButton, &newButton, &saveButton, &loadButton, &settingsButton, &undoButton,
-                        &redoButton, &autoArrangeButton, &toggleModMatrixButton, &toggleAiPanelButton,
-                        &themeToggleButton});
+                        &redoButton, &autoArrangeButton, &toggleMinimapButton, &toggleModMatrixButton,
+                        &toggleAiPanelButton, &themeToggleButton});
 
     // Now that buttons are registered, trigger the first layout pass. resized() calls
     // toolbar.layoutButtons() which positions the buttons using their registered pointers.
@@ -410,8 +423,8 @@ void MainComponent::paint(juce::Graphics& g) {
 void MainComponent::getAllCommands(juce::Array<juce::CommandID>& commands) {
     commands.addArray({AppCommands::openSettings, AppCommands::savePreset, AppCommands::openPreset,
                        AppCommands::newPatch, AppCommands::undo, AppCommands::redo, AppCommands::toggleModMatrix,
-                       AppCommands::toggleAiPanel, AppCommands::autoArrange, AppCommands::toggleLibrary,
-                       AppCommands::selectAllModules, AppCommands::saveSnippet});
+                       AppCommands::toggleMinimap, AppCommands::toggleAiPanel, AppCommands::autoArrange,
+                       AppCommands::toggleLibrary, AppCommands::selectAllModules, AppCommands::saveSnippet});
 }
 
 void MainComponent::getCommandInfo(juce::CommandID commandID, juce::ApplicationCommandInfo& result) {
@@ -455,6 +468,12 @@ void MainComponent::getCommandInfo(juce::CommandID commandID, juce::ApplicationC
     case AppCommands::toggleModMatrix: {
         result.setInfo("Toggle Mod Matrix", "Toggle the modulation matrix panel", "View", 0);
         auto kp = shortcutManager.getBinding("toggleModMatrix");
+        result.addDefaultKeypress(kp.getKeyCode(), kp.getModifiers());
+        break;
+    }
+    case AppCommands::toggleMinimap: {
+        result.setInfo("Toggle Minimap", "Toggle the graph editor minimap overlay", "View", 0);
+        auto kp = shortcutManager.getBinding("toggleMinimap");
         result.addDefaultKeypress(kp.getKeyCode(), kp.getModifiers());
         break;
     }
@@ -522,6 +541,9 @@ bool MainComponent::perform(const InvocationInfo& info) {
         return true;
     case AppCommands::toggleModMatrix:
         toggleModMatrixButton.triggerClick();
+        return true;
+    case AppCommands::toggleMinimap:
+        toggleMinimapButton.triggerClick();
         return true;
     case AppCommands::toggleAiPanel:
         toggleAiPanelButton.triggerClick();
@@ -676,6 +698,7 @@ void MainComponent::applyToolbarIcons() {
     setIcon(redoButton, Icon::ActionRedo);
     setIcon(autoArrangeButton, Icon::ActionAutoArrange);
     setIcon(toggleModMatrixButton, Icon::ToggleMatrix);
+    setIcon(toggleMinimapButton, Icon::ToggleMinimap);
     setIcon(toggleAiPanelButton, Icon::ToggleAI);
     setIcon(themeToggleButton, Icon::ThemeToggle);
 
@@ -694,6 +717,8 @@ void MainComponent::applyToolbarIcons() {
     autoArrangeButton.setButtonText(iconOnly ? "" : "Auto Arrange");
     toggleModMatrixButton.setButtonText(iconOnly ? ""
                                                  : (graphEditor.isModMatrixVisible() ? "Hide Matrix" : "Show Matrix"));
+    toggleMinimapButton.setButtonText(iconOnly ? ""
+                                               : (graphEditor.isMinimapVisible() ? "Hide Minimap" : "Show Minimap"));
     toggleAiPanelButton.setButtonText(iconOnly ? "" : (isAiPanelVisible ? "Hide AI" : "Show AI"));
     toggleLibraryButton.setButtonText(iconOnly ? "" : (isLibraryVisible ? "Hide Library" : "Show Library"));
     themeToggleButton.setButtonText(
@@ -717,6 +742,9 @@ void MainComponent::applyToolbarIcons() {
 
     const juce::String matrixBase = graphEditor.isModMatrixVisible() ? "Hide Mod Matrix" : "Show Mod Matrix";
     toggleModMatrixButton.setTooltip(hint(matrixBase, "toggleModMatrix"));
+
+    const juce::String minimapBase = graphEditor.isMinimapVisible() ? "Hide Minimap" : "Show Minimap";
+    toggleMinimapButton.setTooltip(hint(minimapBase, "toggleMinimap"));
 
     const juce::String aiBase = isAiPanelVisible ? "Hide AI Panel" : "Show AI Panel";
     toggleAiPanelButton.setTooltip(hint(aiBase, "toggleAiPanel"));

--- a/Source/MainComponent.h
+++ b/Source/MainComponent.h
@@ -68,6 +68,10 @@ public:
         if (toggleModMatrixButton.onClick)
             toggleModMatrixButton.onClick();
     }
+    void simulateToggleMinimapClick() {
+        if (toggleMinimapButton.onClick)
+            toggleMinimapButton.onClick();
+    }
     void simulateToggleLibraryClick() {
         if (toggleLibraryButton.onClick)
             toggleLibraryButton.onClick();
@@ -172,6 +176,7 @@ private:
     juce::DrawableButton redoButton{"redo", juce::DrawableButton::ImageAboveTextLabel};
     juce::DrawableButton toggleAiPanelButton{"toggleAi", juce::DrawableButton::ImageAboveTextLabel};
     juce::DrawableButton toggleModMatrixButton{"toggleMatrix", juce::DrawableButton::ImageAboveTextLabel};
+    juce::DrawableButton toggleMinimapButton{"toggleMinimap", juce::DrawableButton::ImageAboveTextLabel};
     juce::DrawableButton autoArrangeButton{"autoArrange", juce::DrawableButton::ImageAboveTextLabel};
     juce::DrawableButton toggleLibraryButton{"toggleLibrary", juce::DrawableButton::ImageAboveTextLabel};
     juce::DrawableButton themeToggleButton{"toggleTheme", juce::DrawableButton::ImageAboveTextLabel};

--- a/Source/MainComponent.h
+++ b/Source/MainComponent.h
@@ -79,6 +79,7 @@ public:
     GraphEditor& getGraphEditor() { return graphEditor; }
     ToolbarComponent& getToolbar() { return toolbar; }
     StatusBarComponent& getStatusBar() { return statusBar; }
+    ShortcutManager& getShortcutManager() { return shortcutManager; }
     void simulateNewPatchClick() {
         if (newButton.onClick)
             newButton.onClick();

--- a/Source/ShortcutManager.h
+++ b/Source/ShortcutManager.h
@@ -11,6 +11,7 @@ enum CommandIDs {
     undo,
     redo,
     toggleModMatrix,
+    toggleMinimap,
     toggleAiPanel,
     autoArrange,
     toggleLibrary,
@@ -33,6 +34,8 @@ inline juce::CommandID getCommandForAction(const juce::String& actionId) {
         return redo;
     if (actionId == "toggleModMatrix")
         return toggleModMatrix;
+    if (actionId == "toggleMinimap")
+        return toggleMinimap;
     if (actionId == "toggleAiPanel")
         return toggleAiPanel;
     if (actionId == "autoArrange")
@@ -114,6 +117,9 @@ public:
         bindings["redo"] =
             juce::KeyPress('z', juce::ModifierKeys::commandModifier | juce::ModifierKeys::shiftModifier, 0);
         bindings["toggleModMatrix"] = juce::KeyPress('m', juce::ModifierKeys::commandModifier, 0);
+        // 'k' with plain Cmd is unused by any other binding (Cmd+, / S / O / N / Z / Shift+Z / M
+        // / A / L / B, Shift+A, Shift+S) — safe to claim for the minimap toggle (issue #159).
+        bindings["toggleMinimap"] = juce::KeyPress('k', juce::ModifierKeys::commandModifier, 0);
         bindings["toggleAiPanel"] = juce::KeyPress('a', juce::ModifierKeys::commandModifier, 0);
         bindings["autoArrange"] = juce::KeyPress('l', juce::ModifierKeys::commandModifier, 0);
         bindings["toggleLibrary"] = juce::KeyPress('b', juce::ModifierKeys::commandModifier, 0);
@@ -186,6 +192,8 @@ public:
             return "Redo";
         if (actionId == "toggleModMatrix")
             return "Toggle Mod Matrix";
+        if (actionId == "toggleMinimap")
+            return "Toggle Minimap";
         if (actionId == "toggleAiPanel")
             return "Toggle AI Panel";
         if (actionId == "autoArrange")
@@ -218,9 +226,9 @@ private:
     std::map<juce::String, juce::KeyPress> bindings;
     juce::ApplicationProperties* appProperties = nullptr;
 
-    juce::StringArray actionIds{"openSettings", "savePreset",    "openPreset",       "newPatch",
-                                "undo",         "redo",          "toggleModMatrix",  "toggleAiPanel",
-                                "autoArrange",  "toggleLibrary", "selectAllModules", "saveSnippet"};
+    juce::StringArray actionIds{"openSettings",  "savePreset",       "openPreset",    "newPatch",      "undo",
+                                "redo",          "toggleModMatrix",  "toggleMinimap", "toggleAiPanel", "autoArrange",
+                                "toggleLibrary", "selectAllModules", "saveSnippet"};
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(ShortcutManager)
 };

--- a/Source/UI/GraphEditor.cpp
+++ b/Source/UI/GraphEditor.cpp
@@ -120,6 +120,14 @@ GraphEditor::GraphEditor(AudioEngine& engine, AppUndoManager* undoMgr)
     addAndMakeVisible(modMatrix);
     content.setInterceptsMouseClicks(false, true); // Fallback clicks to parent
 
+    // Minimap (issue #159): visibility is driven by setMinimapVisible(), called by the owner once
+    // it has restored the persisted preference — NOT addAndMakeVisible, which would show it before
+    // that preference is known.
+    addChildComponent(minimap);
+    minimap.setVisible(minimapVisible);
+    minimap.onNavigate = [this](juce::Point<float> p) { centreViewOn(p); };
+    minimap.onZoom = [this](float d) { zoomAroundCentre(d); };
+
     // Tooltips on GraphEditor-owned affordances.
     // The canvas itself hints at pan/zoom. Double-click on an attenuverter knob removes it.
     setTooltip(synth::ui::formatShortcutHint("Patch canvas - drag modules here to build your patch",
@@ -885,6 +893,24 @@ void GraphEditor::resized() {
         modMatrixTargetBounds = isMatrixVisible ? juce::Rectangle<int>(getWidth() - 600, 0, 600, getHeight())
                                                 : juce::Rectangle<int>(getWidth(), 0, 600, getHeight());
     }
+
+    // ---- Minimap (issue #159) ----
+    // Bottom-LEFT with a 12px margin — the mod-matrix panel occupies a 600px panel on the right.
+    // Auto-hide when the editor is too small to show it without swallowing the view, but never
+    // clobber the user's preference: `minimapVisible` still reflects what they asked for, and
+    // resized() just recomputes whether that preference currently fits.
+    {
+        constexpr int kMargin = 12;
+        // Absolute floors, not a fraction of the editor: a fraction-of-self test is always
+        // satisfied (w/4 * 2 <= w for any w), so it would never actually hide anything.
+        constexpr int kMinEditorW = 480, kMinEditorH = 360;
+        const int mmW = juce::jmin(220, getWidth() / 4);
+        const int mmH = juce::jmin(150, getHeight() / 4);
+        const bool fits = getWidth() >= kMinEditorW && getHeight() >= kMinEditorH;
+        minimap.setBounds(kMargin, getHeight() - mmH - kMargin, mmW, mmH);
+        minimap.setVisible(minimapVisible && fits);
+    }
+
     updateTransform();
 }
 
@@ -937,31 +963,105 @@ void GraphEditor::updateTransform() {
     content.setBounds(0, 0, 10000, 10000);
     content.setTransform(t);
     repaint();
+
+    // Keep the minimap tracking pan/zoom immediately rather than waiting up to 33ms for the next
+    // timer tick. Only the viewport rect is pushed here: pan/zoom move what you're LOOKING at, not
+    // where the modules and cables are, so rebuilding the full model on every drag frame would
+    // re-walk every graph edge for nothing. The 30 Hz tick owns node/cable changes.
+    if (minimap.isVisible())
+        minimap.setViewport(getVisibleCanvasRect());
 }
 
-void GraphEditor::mouseWheelMove(const juce::MouseEvent& e, const juce::MouseWheelDetails& wheel) {
+void GraphEditor::applyZoomAt(float wheelDelta, juce::Point<float> screenAnchor) {
     float oldZoom = zoomLevel;
-    zoomLevel += wheel.deltaY * 0.1f * zoomLevel;
+    zoomLevel += wheelDelta * 0.1f * zoomLevel;
     zoomLevel = juce::jlimit(0.1f, 2.0f, zoomLevel);
 
     if (oldZoom != zoomLevel) {
-        auto mousePos = e.position;
-        // Transform the mouse position to get the graph point before scaling
+        // Transform the anchor position to get the graph point before scaling
         auto invT =
             juce::AffineTransform::translation(-panOffset.x, -panOffset.y).scaled(1.0f / oldZoom, 1.0f / oldZoom);
-        float gx = mousePos.x;
-        float gy = mousePos.y;
+        float gx = screenAnchor.x;
+        float gy = screenAnchor.y;
         invT.transformPoint(gx, gy);
 
-        // Transform the mouse position to get the graph point after scaling
-        // We want to keep the graph point under the mouse constant
-        // mousePos = (graphPointBefore * zoomLevel) + newPanOffset
-        // newPanOffset = mousePos - (graphPointBefore * zoomLevel)
-        panOffset.x = mousePos.x - (gx * zoomLevel);
-        panOffset.y = mousePos.y - (gy * zoomLevel);
+        // We want to keep the graph point under the anchor constant:
+        // anchor = (graphPointBefore * zoomLevel) + newPanOffset
+        // newPanOffset = anchor - (graphPointBefore * zoomLevel)
+        panOffset.x = screenAnchor.x - (gx * zoomLevel);
+        panOffset.y = screenAnchor.y - (gy * zoomLevel);
     }
 
     updateTransform();
+}
+
+void GraphEditor::mouseWheelMove(const juce::MouseEvent& e, const juce::MouseWheelDetails& wheel) {
+    applyZoomAt(wheel.deltaY, e.position);
+}
+
+juce::Rectangle<float> GraphEditor::getVisibleCanvasRect() const {
+    // Rebuilt from zoomLevel/panOffset rather than reading content.getTransform(), so this stays
+    // independent of child state and can be const.
+    const juce::AffineTransform t = juce::AffineTransform().scaled(zoomLevel, zoomLevel).translated(panOffset);
+    return getLocalBounds().toFloat().transformedBy(t.inverted());
+}
+
+void GraphEditor::centreViewOn(juce::Point<float> canvasPoint) {
+    panOffset = getLocalBounds().getCentre().toFloat() - canvasPoint * zoomLevel;
+    updateTransform();
+}
+
+void GraphEditor::zoomAroundCentre(float wheelDelta) {
+    applyZoomAt(wheelDelta, getLocalBounds().getCentre().toFloat());
+}
+
+void GraphEditor::setMinimapVisible(bool shouldBeVisible) {
+    minimapVisible = shouldBeVisible;
+    // resized() recomputes the effective (preference && fits) visibility.
+    resized();
+    // Seed the full model on the way in: updateTransform() only pushes the viewport, so without
+    // this the map would show an empty canvas until the next 30 Hz tick.
+    if (minimap.isVisible())
+        minimap.setModel(buildMinimapModel());
+}
+
+void GraphEditor::toggleMinimapVisibility() { setMinimapVisible(!minimapVisible); }
+
+synth::ui::MinimapModel GraphEditor::buildMinimapModel() {
+    synth::ui::MinimapModel model;
+
+    auto* lf = dynamic_cast<synth::theme::AppLookAndFeel*>(&getLookAndFeel());
+    static const synth::theme::Colors fallbackColors{};
+    const auto& colors = lf != nullptr ? lf->getTheme().colors : fallbackColors;
+
+    for (auto* comp : content.getModules()) {
+        if (comp == nullptr || comp->getModule() == nullptr)
+            continue;
+
+        // Per-category theme colour, the same source buildVisibleCables()/colourForCable() use for
+        // "By source module" cable colouring — there is no cheap per-instance colour on
+        // ModuleComponent itself, but category IS available cheaply via ModuleBase::getModuleType().
+        auto category = synth::ui::ModuleCategory::Utility;
+        if (auto* mb = dynamic_cast<ModuleBase*>(comp->getModule()))
+            category = synth::ui::categoryFor(mb->getModuleType());
+
+        synth::ui::MinimapModel::Node node;
+        node.bounds = comp->getBounds().toFloat();
+        node.colour = synth::ui::themeColourForCategory(colors, category);
+        node.selected = isNodeSelected(comp->getNodeId());
+        model.nodes.push_back(node);
+    }
+
+    for (const auto& cable : buildVisibleCables()) {
+        synth::ui::MinimapModel::Cable mc;
+        mc.p1 = cable.p1;
+        mc.p2 = cable.p2;
+        mc.colour = colourForCable(cable);
+        model.cables.push_back(mc);
+    }
+
+    model.viewport = getVisibleCanvasRect();
+    return model;
 }
 
 void GraphEditor::mouseMove(const juce::MouseEvent& e) {
@@ -1744,6 +1844,12 @@ void GraphEditor::timerCallback() {
     if (content.connectionAnimPhase >= 1.0f)
         content.connectionAnimPhase -= 1.0f;
     content.repaint();
+
+    // Minimap (issue #159): only build the model while visible, and only when it's needed —
+    // setModel() itself only repaints when the model actually changed (no repaint storm on a
+    // static patch).
+    if (minimap.isVisible())
+        minimap.setModel(buildMinimapModel());
 }
 
 // ============================================================================

--- a/Source/UI/GraphEditor.h
+++ b/Source/UI/GraphEditor.h
@@ -11,6 +11,7 @@
 #include <vector>
 
 class ModuleComponent;
+#include "MinimapComponent.h"
 #include "ModMatrixComponent.h"
 
 class GraphEditor
@@ -39,6 +40,26 @@ public:
     void updateComponents();
     void toggleModMatrixVisibility();
     bool isModMatrixVisible() const { return isMatrixVisible; }
+
+    // ---- Minimap (issue #159) ----
+    void setMinimapVisible(bool shouldBeVisible);
+    void toggleMinimapVisibility();
+    bool isMinimapVisible() const noexcept { return minimapVisible; }
+    synth::ui::MinimapComponent& getMinimap() noexcept { return minimap; }
+
+    /** The canvas rect currently visible in the editor — the inverse of the content transform
+     *  applied to getLocalBounds(). */
+    juce::Rectangle<float> getVisibleCanvasRect() const;
+
+    /** Pans so `canvasPoint` sits at the centre of the visible area. Zoom is unchanged. */
+    void centreViewOn(juce::Point<float> canvasPoint);
+
+    /** Multiplies zoom around the centre of the visible area, clamped to the same [0.1, 2.0]
+     *  range as wheel zoom, so the point under the centre stays put. */
+    void zoomAroundCentre(float wheelDelta);
+
+    // Test accessor. Non-const because it calls buildVisibleCables(), which is non-const.
+    synth::ui::MinimapModel buildMinimapModel();
 
     // Interactions
     void beginConnectionDrag(ModuleComponent* sourceModule, int channelIndex, bool isInput, bool isMidi,
@@ -313,6 +334,11 @@ private:
     ModMatrixComponent modMatrix;
     bool isMatrixVisible = false;
 
+    // ---- Minimap (issue #159) ----
+    synth::ui::MinimapComponent minimap;
+    // User preference, independent of resized()'s auto-hide-when-tiny effective visibility.
+    bool minimapVisible = true;
+
     // Navigation State
     float zoomLevel = 1.0f;
     juce::Point<float> panOffset;
@@ -402,6 +428,11 @@ private:
     bool alignmentGuidesEnabled = true;
 
     void updateTransform();
+
+    // Shared zoom math for mouseWheelMove and zoomAroundCentre — keeps the formula (and the
+    // [0.1, 2.0] clamp) in exactly one place. `screenAnchor` is the point (in GraphEditor local/
+    // screen coordinates) whose underlying canvas point must stay put under the cursor/centre.
+    void applyZoomAt(float wheelDelta, juce::Point<float> screenAnchor);
 
     // Internal: start the drop-landing animation for a newly placed module component.
     void animateDropLanding(ModuleComponent* module, juce::Point<int> fromPos, juce::Point<int> toPos);

--- a/Source/UI/MinimapComponent.cpp
+++ b/Source/UI/MinimapComponent.cpp
@@ -1,0 +1,180 @@
+#include "MinimapComponent.h"
+#include "Theme/AppLookAndFeel.h"
+
+namespace synth::ui {
+
+//==============================================================================
+MinimapComponent::MinimapComponent() {
+    setInterceptsMouseClicks(true, false);
+    setTooltip("Minimap - click or drag to navigate, scroll to zoom");
+}
+
+void MinimapComponent::setModel(MinimapModel model) {
+    if (model_ == model)
+        return;
+    model_ = std::move(model);
+    repaint();
+}
+
+void MinimapComponent::setViewport(juce::Rectangle<float> viewport) {
+    if (model_.viewport == viewport)
+        return;
+    model_.viewport = viewport;
+    repaint();
+}
+
+//==============================================================================
+// Pure geometry helpers
+//==============================================================================
+
+juce::Rectangle<float> MinimapComponent::computeWorldBounds(const MinimapModel& model) noexcept {
+    // Union the viewport (when meaningful) with every node's bounds. Starting from an empty
+    // viewport and unioning it in unconditionally would drag the origin into the union even when
+    // nothing is actually there, so it only seeds the accumulator when non-empty.
+    bool haveBounds = !model.viewport.isEmpty();
+    juce::Rectangle<float> bounds = haveBounds ? model.viewport : juce::Rectangle<float>();
+
+    for (const auto& node : model.nodes) {
+        bounds = haveBounds ? bounds.getUnion(node.bounds) : node.bounds;
+        haveBounds = true;
+    }
+
+    // Nothing at all (no viewport, no nodes): fall through with a zero rect at the origin, which
+    // the margin + min-span clamp below turns into a kMinWorldSpan square centred on the origin.
+    bounds = bounds.expanded(kWorldMargin);
+
+    const auto centre = bounds.getCentre();
+    if (bounds.getWidth() < kMinWorldSpan)
+        bounds.setWidth(kMinWorldSpan);
+    if (bounds.getHeight() < kMinWorldSpan)
+        bounds.setHeight(kMinWorldSpan);
+    bounds.setCentre(centre);
+
+    return bounds;
+}
+
+juce::AffineTransform MinimapComponent::computeWorldToMap(juce::Rectangle<float> world,
+                                                          juce::Rectangle<float> mapArea) noexcept {
+    if (world.getWidth() <= 0.0f || world.getHeight() <= 0.0f || mapArea.getWidth() <= 0.0f ||
+        mapArea.getHeight() <= 0.0f)
+        return {}; // degenerate input — identity rather than a divide-by-zero scale
+
+    const float scale = juce::jmin(mapArea.getWidth() / world.getWidth(), mapArea.getHeight() / world.getHeight());
+    const float scaledW = world.getWidth() * scale;
+    const float scaledH = world.getHeight() * scale;
+    // Centre the (possibly non-square, since aspect is preserved) scaled world rect in mapArea.
+    const float offsetX = mapArea.getX() + (mapArea.getWidth() - scaledW) * 0.5f;
+    const float offsetY = mapArea.getY() + (mapArea.getHeight() - scaledH) * 0.5f;
+
+    return juce::AffineTransform::translation(-world.getX(), -world.getY()).scaled(scale).translated(offsetX, offsetY);
+}
+
+juce::Point<float> MinimapComponent::mapToWorld(juce::Point<float> mapPoint, juce::Rectangle<float> world,
+                                                juce::Rectangle<float> mapArea) noexcept {
+    return mapPoint.transformedBy(computeWorldToMap(world, mapArea).inverted());
+}
+
+//==============================================================================
+juce::Rectangle<float> MinimapComponent::getMapArea() const { return getLocalBounds().toFloat().reduced(4.0f); }
+
+void MinimapComponent::navigateTo(juce::Point<float> localPos) {
+    if (!onNavigate)
+        return;
+    onNavigate(mapToWorld(localPos, computeWorldBounds(model_), getMapArea()));
+}
+
+//==============================================================================
+void MinimapComponent::paint(juce::Graphics& g) {
+    auto* lnf = dynamic_cast<synth::theme::AppLookAndFeel*>(&getLookAndFeel());
+
+    // Headless tests install the stock JUCE LnF; fall back to the token defaults (see
+    // StatusBarComponent::paint for the same shape) so colour resolution stays exercised.
+    juce::Colour bg0, bg1, border, accent;
+    float cornerRadius, borderWidth;
+    if (lnf) {
+        const auto& c = lnf->getTheme().colors;
+        const auto& m = lnf->getTheme().metrics;
+        bg0 = c.bg0;
+        bg1 = c.bg1;
+        border = c.border;
+        accent = c.accent;
+        cornerRadius = m.cornerRadius;
+        borderWidth = m.borderWidth;
+    } else {
+        bg0 = juce::Colours::black;
+        bg1 = juce::Colour(0xff13161b);
+        border = juce::Colours::grey;
+        accent = juce::Colours::cyan;
+        cornerRadius = 8.0f;
+        borderWidth = 1.0f;
+    }
+
+    const auto bounds = getLocalBounds().toFloat();
+
+    // Floating panel background + frame.
+    g.setColour(bg1.withAlpha(0.92f));
+    g.fillRoundedRectangle(bounds, cornerRadius);
+    g.setColour(border);
+    g.drawRoundedRectangle(bounds.reduced(borderWidth * 0.5f), cornerRadius, borderWidth);
+
+    const auto mapArea = getMapArea();
+    const auto world = computeWorldBounds(model_);
+    const auto transform = computeWorldToMap(world, mapArea);
+
+    // Cables: thin straight lines (this is a thumbnail, not the bezier the canvas draws).
+    for (const auto& cable : model_.cables) {
+        const auto p1 = cable.p1.transformedBy(transform);
+        const auto p2 = cable.p2.transformedBy(transform);
+        g.setColour(cable.colour.withAlpha(0.5f));
+        g.drawLine(p1.x, p1.y, p2.x, p2.y, 1.0f);
+    }
+
+    // Nodes: filled rounded rects, clamped to a minimum on-screen size so tiny/zoomed-out modules
+    // stay visible, selection stroked in the accent colour.
+    constexpr float kMinNodeSize = 2.0f;
+    constexpr float kNodeCornerRadius = 1.5f;
+    for (const auto& node : model_.nodes) {
+        auto r = node.bounds.transformedBy(transform);
+        const auto centre = r.getCentre();
+        if (r.getWidth() < kMinNodeSize)
+            r.setWidth(kMinNodeSize);
+        if (r.getHeight() < kMinNodeSize)
+            r.setHeight(kMinNodeSize);
+        r.setCentre(centre);
+
+        g.setColour(node.colour);
+        g.fillRoundedRectangle(r, kNodeCornerRadius);
+        if (node.selected) {
+            g.setColour(accent);
+            g.drawRoundedRectangle(r, kNodeCornerRadius, 1.5f);
+        }
+    }
+
+    // Viewport: dim everything outside it with a translucent wash (even-odd fill between the map
+    // area and the viewport rect leaves a "hole" over the viewport), then stroke the viewport.
+    const auto viewportMap = model_.viewport.transformedBy(transform).getIntersection(mapArea);
+
+    juce::Path wash;
+    wash.addRectangle(mapArea);
+    if (!viewportMap.isEmpty())
+        wash.addRectangle(viewportMap);
+    wash.setUsingNonZeroWinding(false); // even-odd: the viewport rect punches a hole in the wash
+    g.setColour(bg0.withAlpha(0.45f));
+    g.fillPath(wash);
+
+    if (!viewportMap.isEmpty()) {
+        g.setColour(accent);
+        g.drawRect(viewportMap, 1.5f);
+    }
+}
+
+//==============================================================================
+void MinimapComponent::mouseDown(const juce::MouseEvent& e) { navigateTo(e.position); }
+void MinimapComponent::mouseDrag(const juce::MouseEvent& e) { navigateTo(e.position); }
+
+void MinimapComponent::mouseWheelMove(const juce::MouseEvent&, const juce::MouseWheelDetails& wheel) {
+    if (onZoom)
+        onZoom(wheel.deltaY);
+}
+
+} // namespace synth::ui

--- a/Source/UI/MinimapComponent.cpp
+++ b/Source/UI/MinimapComponent.cpp
@@ -1,12 +1,27 @@
 #include "MinimapComponent.h"
 #include "Theme/AppLookAndFeel.h"
+#include "UIAnimation.h"
 
 namespace synth::ui {
 
 //==============================================================================
 MinimapComponent::MinimapComponent() {
     setInterceptsMouseClicks(true, false);
-    setTooltip("Minimap - click or drag to navigate, scroll to zoom");
+    updateTooltip();
+}
+
+void MinimapComponent::setShortcutHint(const juce::String& shortcutDisplay) {
+    if (shortcutDisplay_ == shortcutDisplay)
+        return;
+    shortcutDisplay_ = shortcutDisplay;
+    updateTooltip();
+}
+
+void MinimapComponent::updateTooltip() {
+    // Leads with the toggle action + its shortcut, matching how the toolbar buttons read
+    // ("Hide Minimap  (Cmd+K)"), then the navigation gestures. The verb is always "Hide" because
+    // the map can only be hovered while it is on screen.
+    setTooltip(formatShortcutHint("Hide Minimap", shortcutDisplay_) + " - click or drag to navigate, scroll to zoom");
 }
 
 void MinimapComponent::setModel(MinimapModel model) {

--- a/Source/UI/MinimapComponent.h
+++ b/Source/UI/MinimapComponent.h
@@ -1,0 +1,118 @@
+#pragma once
+
+#include <functional>
+#include <juce_gui_basics/juce_gui_basics.h>
+#include <vector>
+
+// Small zoomable overview map for the Graph Editor (issue #159).
+//
+// The minimap is a plain untransformed sibling overlay on top of GraphEditor's canvas — it never
+// lives inside the panned/zoomed GraphContentComponent, so its own bounds are always in normal
+// screen space (same pattern as ModMatrixComponent). Everything IT draws is expressed in CANVAS
+// coordinates (the coordinate space ModuleComponents and cables already live in) and mapped down
+// to the small map area with computeWorldToMap().
+//
+// Data flow: GraphEditor builds a MinimapModel snapshot (buildMinimapModel()) and hands it to
+// setModel(). setModel() only repaints when the model actually changed — the owner ticks at
+// 30 Hz and a static patch must not turn into a free-running repaint (see the no-continuous-
+// repaint invariant in CLAUDE.md).
+namespace synth::ui {
+
+/** Everything the minimap draws, in CANVAS coordinates. Rebuilt by the owner only while the
+ *  minimap is visible, and only repainted when it differs from the previous frame. */
+struct MinimapModel {
+    struct Node {
+        juce::Rectangle<float> bounds; // canvas coords
+        juce::Colour colour;
+        bool selected = false;
+
+        bool operator==(const Node& o) const noexcept {
+            return bounds == o.bounds && colour == o.colour && selected == o.selected;
+        }
+        bool operator!=(const Node& o) const noexcept { return !(*this == o); }
+    };
+
+    struct Cable {
+        juce::Point<float> p1, p2; // canvas coords
+        juce::Colour colour;
+
+        bool operator==(const Cable& o) const noexcept { return p1 == o.p1 && p2 == o.p2 && colour == o.colour; }
+        bool operator!=(const Cable& o) const noexcept { return !(*this == o); }
+    };
+
+    std::vector<Node> nodes;
+    std::vector<Cable> cables;
+    juce::Rectangle<float> viewport; // the canvas rect currently visible in the editor
+
+    bool operator==(const MinimapModel& o) const noexcept {
+        return nodes == o.nodes && cables == o.cables && viewport == o.viewport;
+    }
+    bool operator!=(const MinimapModel& o) const noexcept { return !(*this == o); }
+};
+
+class MinimapComponent
+    : public juce::Component
+    , public juce::SettableTooltipClient {
+public:
+    MinimapComponent();
+
+    /** Replaces the model. Repaints ONLY when the new model differs from the current one —
+     *  the owner ticks at 30 Hz and a static patch must not cause a repaint storm. */
+    void setModel(MinimapModel model);
+    const MinimapModel& getModel() const noexcept { return model_; }
+
+    /** Updates only the visible-canvas rect. Pan and zoom move the viewport without moving a
+     *  single module or cable, so the owner uses this on every pan/zoom frame instead of
+     *  rebuilding the whole model (which would re-walk the graph's edges per frame). Repaints
+     *  only on an actual change, same as setModel(). */
+    void setViewport(juce::Rectangle<float> viewport);
+
+    /** Canvas point the user asked to centre the view on (click or drag on the map). */
+    std::function<void(juce::Point<float>)> onNavigate;
+
+    /** Wheel on the map zooms the main editor. Argument is a wheel deltaY (same sign/scale as
+     *  juce::MouseWheelDetails::deltaY) so the owner can apply its own zoom curve. */
+    std::function<void(float)> onZoom;
+
+    // ---- Pure geometry helpers (static, no GUI state — unit-tested directly) ----
+
+    /** World rect the map shows: the union of every node's bounds and the viewport, inflated by
+     *  a small margin, and never narrower/shorter than kMinWorldSpan (so a single module doesn't
+     *  blow up to fill the map). Falls back to the viewport when there are no nodes, and to a
+     *  kMinWorldSpan square at the origin when the model is entirely empty. */
+    static juce::Rectangle<float> computeWorldBounds(const MinimapModel& model) noexcept;
+
+    /** Aspect-preserving world -> map-local mapping: the largest uniform scale that fits `world`
+     *  inside `mapArea`, centred. Returns identity-ish safe values for degenerate inputs
+     *  (zero/negative width or height on either rect) rather than dividing by zero. */
+    static juce::AffineTransform computeWorldToMap(juce::Rectangle<float> world,
+                                                   juce::Rectangle<float> mapArea) noexcept;
+
+    /** Inverse of computeWorldToMap applied to a map-local point -> canvas point. */
+    static juce::Point<float> mapToWorld(juce::Point<float> mapPoint, juce::Rectangle<float> world,
+                                         juce::Rectangle<float> mapArea) noexcept;
+
+    static constexpr float kMinWorldSpan = 1200.0f;
+    static constexpr float kWorldMargin = 80.0f;
+
+    void paint(juce::Graphics& g) override;
+    void mouseDown(const juce::MouseEvent& e) override;
+    void mouseDrag(const juce::MouseEvent& e) override;
+    void mouseWheelMove(const juce::MouseEvent& e, const juce::MouseWheelDetails& wheel) override;
+
+private:
+    /** The inset drawable area (4px in from the component bounds) that computeWorldToMap etc.
+     *  should map into — shared by paint() and the mouse handlers so the map they draw and the
+     *  map they hit-test agree. */
+    juce::Rectangle<float> getMapArea() const;
+
+    /** Shared by mouseDown/mouseDrag: converts the event position to a canvas point and fires
+     *  onNavigate. */
+    void navigateTo(juce::Point<float> localPos);
+
+    MinimapModel model_;
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MinimapComponent)
+};
+
+} // namespace synth::ui

--- a/Source/UI/MinimapComponent.h
+++ b/Source/UI/MinimapComponent.h
@@ -67,6 +67,13 @@ public:
      *  only on an actual change, same as setModel(). */
     void setViewport(juce::Rectangle<float> viewport);
 
+    /** Sets the display string for the show/hide shortcut (e.g. "Cmd+K") and rebuilds the tooltip,
+     *  so hovering the map surfaces the same binding the toolbar button advertises. The owner
+     *  supplies it already resolved: the binding is rebindable and lives in ShortcutManager, which
+     *  this component deliberately doesn't depend on. Pass an empty string for "no binding", and
+     *  the shortcut is simply omitted. */
+    void setShortcutHint(const juce::String& shortcutDisplay);
+
     /** Canvas point the user asked to centre the view on (click or drag on the map). */
     std::function<void(juce::Point<float>)> onNavigate;
 
@@ -110,7 +117,11 @@ private:
      *  onNavigate. */
     void navigateTo(juce::Point<float> localPos);
 
+    /** Rebuilds the tooltip from the fixed description plus the current shortcut display. */
+    void updateTooltip();
+
     MinimapModel model_;
+    juce::String shortcutDisplay_;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MinimapComponent)
 };

--- a/Source/UI/Theme/AppLookAndFeel.cpp
+++ b/Source/UI/Theme/AppLookAndFeel.cpp
@@ -213,6 +213,7 @@ void AppLookAndFeel::retintIcons() {
     iconLibrary_.setTintColour(Icon::ToggleMatrix, c.textPrimary);
     iconLibrary_.setTintColour(Icon::ToggleLibrary, c.textPrimary);
     iconLibrary_.setTintColour(Icon::ThemeToggle, c.textPrimary);
+    iconLibrary_.setTintColour(Icon::ToggleMinimap, c.textPrimary);
 
     // TransportPlay is scaffolding only (no DrawableButton wired this phase); tint muted so it
     // reads as inactive if ever surfaced.

--- a/Source/UI/Theme/IconLibrary.cpp
+++ b/Source/UI/Theme/IconLibrary.cpp
@@ -83,6 +83,8 @@ std::pair<const void*, int> IconLibrary::binaryDataForIcon(Icon id) {
         {BinaryData::waveformsaw_svg, BinaryData::waveformsaw_svgSize},
         {BinaryData::waveformsquare_svg, BinaryData::waveformsquare_svgSize},
         {BinaryData::waveformtriangle_svg, BinaryData::waveformtriangle_svgSize},
+        // Minimap toggle (issue #159).
+        {BinaryData::toggleminimap_svg, BinaryData::toggleminimap_svgSize},
     };
     static_assert(std::size(kTable) == (size_t)Icon::kCount,
                   "kTable size does not match Icon::kCount — update binaryDataForIcon lookup table");

--- a/Source/UI/Theme/IconLibrary.h
+++ b/Source/UI/Theme/IconLibrary.h
@@ -45,6 +45,8 @@ enum class Icon : int {
     WaveformSaw,
     WaveformSquare,
     WaveformTriangle,
+    // Toolbar toggle for the GraphEditor minimap overlay (issue #159).
+    ToggleMinimap,
     kCount
 };
 

--- a/Source/UI/ToolbarComponent.cpp
+++ b/Source/UI/ToolbarComponent.cpp
@@ -21,6 +21,7 @@ void ToolbarComponent::layoutButtons(juce::Rectangle<int> bounds) {
         72.0f,  // Undo
         72.0f,  // Redo
         120.0f, // AutoArrange
+        108.0f, // ToggleMinimap ("Hide Minimap"/"Show Minimap")
         104.0f, // ToggleModMatrix
         92.0f,  // ToggleAiPanel
         110.0f  // ToggleTheme
@@ -44,8 +45,8 @@ void ToolbarComponent::layoutButtons(juce::Rectangle<int> bounds) {
     // Flexible spacer pushes the right group to the far edge.
     fb.items.add(juce::FlexItem().withFlex(1.0f));
 
-    // Right group: ToggleModMatrix, ToggleAiPanel, ToggleTheme.
-    for (int slot = ToggleModMatrix; slot <= ToggleTheme; ++slot)
+    // Right group: ToggleMinimap, ToggleModMatrix, ToggleAiPanel, ToggleTheme.
+    for (int slot = ToggleMinimap; slot <= ToggleTheme; ++slot)
         if (buttons_[(size_t)slot] != nullptr)
             fb.items.add(juce::FlexItem(*buttons_[(size_t)slot])
                              .withMinWidth(0.0f)

--- a/Source/UI/ToolbarComponent.h
+++ b/Source/UI/ToolbarComponent.h
@@ -19,7 +19,7 @@
 class ToolbarComponent : public juce::Component {
 public:
     // Logical slot order — matches the left group [Library..AutoArrange] + right group
-    // [ToggleModMatrix, ToggleAiPanel]. NumSlots is the array size.
+    // [ToggleMinimap, ToggleModMatrix, ToggleAiPanel, ToggleTheme]. NumSlots is the array size.
     enum Slot {
         Library = 0,
         New,
@@ -29,6 +29,9 @@ public:
         Undo,
         Redo,
         AutoArrange,
+        // ToggleMinimap sits before ToggleModMatrix so the right-hand group reads
+        // minimap -> mod matrix -> AI panel -> theme (issue #159).
+        ToggleMinimap,
         ToggleModMatrix,
         ToggleAiPanel,
         ToggleTheme,

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -94,6 +94,7 @@ add_executable(Tests
     SnippetManagerTests.cpp
     MultiSelectTests.cpp
     PanelAnimationAndLoadingTests.cpp
+    MinimapComponentTests.cpp
     ../Source/MainComponent.cpp
     ../Source/UI/GraphEditor.cpp
     ../Source/UI/ModMatrixComponent.cpp

--- a/Tests/GraphEditorTests.cpp
+++ b/Tests/GraphEditorTests.cpp
@@ -810,3 +810,188 @@ TEST_F(GraphEditorTest, AlignmentGuideDrawingThemeAware) {
     // Verify line width matches spec
     EXPECT_FLOAT_EQ(m.guideLineWidth, 1.5f);
 }
+
+// ============================================================================
+// Minimap (issue #159)
+// ============================================================================
+
+namespace {
+
+// Hand-built MouseEvent, same pattern as MinimapComponentTests.cpp — no OS mouse source exists
+// headlessly, but MouseInputSource is copyable and Desktop always exposes one.
+juce::MouseEvent makeGraphEditorMouseEvent(juce::Component& comp, juce::Point<float> position) {
+    return juce::MouseEvent(juce::Desktop::getInstance().getMainMouseSource(), position, juce::ModifierKeys(), 0.0f,
+                            0.0f, 0.0f, 0.0f, 0.0f, &comp, &comp, juce::Time::getCurrentTime(), position,
+                            juce::Time::getCurrentTime(), 1, false);
+}
+
+// Maps a GraphEditor-local screen point to the canvas point currently under it, derived purely
+// from getVisibleCanvasRect() (no access to the private pan/zoom state needed).
+juce::Point<float> screenToCanvas(const GraphEditor& editor, juce::Point<float> screenPt) {
+    const auto rect = editor.getVisibleCanvasRect();
+    const auto w = static_cast<float>(editor.getWidth());
+    const auto h = static_cast<float>(editor.getHeight());
+    return {rect.getX() + (screenPt.x / w) * rect.getWidth(), rect.getY() + (screenPt.y / h) * rect.getHeight()};
+}
+
+} // namespace
+
+// toggleMinimapVisibility() flips the reported preference each call.
+TEST_F(GraphEditorTest, ToggleMinimapVisibilityFlipsState) {
+    AudioEngine engine;
+    GraphEditor editor(engine);
+    editor.setSize(800, 600);
+
+    ASSERT_TRUE(editor.isMinimapVisible());
+    editor.toggleMinimapVisibility();
+    EXPECT_FALSE(editor.isMinimapVisible());
+    editor.toggleMinimapVisibility();
+    EXPECT_TRUE(editor.isMinimapVisible());
+}
+
+// setMinimapVisible(false) actually hides the child component, not just the preference flag.
+TEST_F(GraphEditorTest, SetMinimapVisibleFalseHidesChildComponent) {
+    AudioEngine engine;
+    GraphEditor editor(engine);
+    editor.setSize(800, 600);
+
+    ASSERT_TRUE(editor.getMinimap().isVisible());
+    editor.setMinimapVisible(false);
+    EXPECT_FALSE(editor.isMinimapVisible());
+    EXPECT_FALSE(editor.getMinimap().isVisible());
+}
+
+// Below the 480x360 auto-hide threshold the minimap child must not be visible even though the
+// user preference is untouched; growing back above the threshold restores it.
+TEST_F(GraphEditorTest, MinimapAutoHidesBelowThresholdAndPreferenceSurvives) {
+    AudioEngine engine;
+    GraphEditor editor(engine);
+    editor.setSize(800, 600);
+    ASSERT_TRUE(editor.getMinimap().isVisible());
+
+    editor.setSize(400, 300); // below kMinEditorW/H
+    EXPECT_TRUE(editor.isMinimapVisible()) << "preference must survive an auto-hide";
+    EXPECT_FALSE(editor.getMinimap().isVisible());
+
+    editor.setSize(800, 600); // back above threshold
+    EXPECT_TRUE(editor.isMinimapVisible());
+    EXPECT_TRUE(editor.getMinimap().isVisible());
+}
+
+// getVisibleCanvasRect() at identity zoom/pan equals the editor's own local bounds.
+TEST_F(GraphEditorTest, VisibleCanvasRectAtIdentityEqualsLocalBounds) {
+    AudioEngine engine;
+    GraphEditor editor(engine);
+    editor.setSize(800, 600);
+
+    const auto rect = editor.getVisibleCanvasRect();
+    EXPECT_NEAR(rect.getX(), 0.0f, 0.01f);
+    EXPECT_NEAR(rect.getY(), 0.0f, 0.01f);
+    EXPECT_NEAR(rect.getWidth(), 800.0f, 0.01f);
+    EXPECT_NEAR(rect.getHeight(), 600.0f, 0.01f);
+}
+
+// centreViewOn(p) must put p at the centre of the returned visible-canvas rect.
+TEST_F(GraphEditorTest, CentreViewOnMovesViewportCentreToRequestedPoint) {
+    AudioEngine engine;
+    GraphEditor editor(engine);
+    editor.setSize(800, 600);
+
+    const juce::Point<float> target(1000.0f, -200.0f);
+    editor.centreViewOn(target);
+
+    const auto rect = editor.getVisibleCanvasRect();
+    EXPECT_NEAR(rect.getCentreX(), target.x, 0.5f);
+    EXPECT_NEAR(rect.getCentreY(), target.y, 0.5f);
+}
+
+// zoomAroundCentre's sign matches wheel-zoom direction: positive narrows the visible rect (zoom
+// in), negative widens it (zoom out).
+TEST_F(GraphEditorTest, ZoomAroundCentreMatchesWheelZoomDirection) {
+    AudioEngine engine;
+    GraphEditor editor(engine);
+    editor.setSize(800, 600);
+
+    const auto widthBefore = editor.getVisibleCanvasRect().getWidth();
+    editor.zoomAroundCentre(1.0f);
+    EXPECT_LT(editor.getVisibleCanvasRect().getWidth(), widthBefore);
+
+    const auto widthBeforeOut = editor.getVisibleCanvasRect().getWidth();
+    editor.zoomAroundCentre(-1.0f);
+    EXPECT_GT(editor.getVisibleCanvasRect().getWidth(), widthBeforeOut);
+}
+
+// zoomAroundCentre keeps the canvas point at the viewport centre fixed while zooming.
+TEST_F(GraphEditorTest, ZoomAroundCentreKeepsCanvasCentrePointFixed) {
+    AudioEngine engine;
+    GraphEditor editor(engine);
+    editor.setSize(800, 600);
+
+    const auto canvasCentreBefore = editor.getVisibleCanvasRect().getCentre();
+    editor.zoomAroundCentre(1.0f);
+    const auto canvasCentreAfter = editor.getVisibleCanvasRect().getCentre();
+
+    EXPECT_NEAR(canvasCentreAfter.x, canvasCentreBefore.x, 0.5f);
+    EXPECT_NEAR(canvasCentreAfter.y, canvasCentreBefore.y, 0.5f);
+}
+
+// Zoom stays clamped to [0.1, 2.0] no matter how many times it's driven in one direction.
+TEST_F(GraphEditorTest, ZoomAroundCentreStaysClampedUnderRepeatedCalls) {
+    AudioEngine engine;
+    GraphEditor editor(engine);
+    editor.setSize(800, 600);
+
+    for (int i = 0; i < 200; ++i)
+        editor.zoomAroundCentre(10.0f);
+    EXPECT_NEAR(editor.getVisibleCanvasRect().getWidth(), 800.0f / 2.0f, 1.0f) << "zoom must clamp at 2.0";
+
+    for (int i = 0; i < 200; ++i)
+        editor.zoomAroundCentre(-10.0f);
+    EXPECT_NEAR(editor.getVisibleCanvasRect().getWidth(), 800.0f / 0.1f, 1.0f) << "zoom must clamp at 0.1";
+}
+
+// Regression guard for the applyZoomAt extraction (shared by mouseWheelMove and
+// zoomAroundCentre): a wheel event at an arbitrary screen position must still keep the canvas
+// point under the cursor fixed, and must still actually change the zoom.
+TEST_F(GraphEditorTest, WheelZoomKeepsCanvasPointUnderCursorFixed) {
+    AudioEngine engine;
+    GraphEditor editor(engine);
+    editor.setSize(800, 600);
+
+    // Start from a non-trivial pan so this isn't only exercising the identity case.
+    editor.centreViewOn({300.0f, 250.0f});
+
+    const juce::Point<float> cursor(150.0f, 400.0f);
+    const auto canvasBefore = screenToCanvas(editor, cursor);
+    const auto widthBefore = editor.getVisibleCanvasRect().getWidth();
+
+    juce::MouseWheelDetails wheel;
+    wheel.deltaY = 1.5f;
+    editor.mouseWheelMove(makeGraphEditorMouseEvent(editor, cursor), wheel);
+
+    const auto canvasAfter = screenToCanvas(editor, cursor);
+    EXPECT_NEAR(canvasAfter.x, canvasBefore.x, 0.5f);
+    EXPECT_NEAR(canvasAfter.y, canvasBefore.y, 0.5f);
+    EXPECT_LT(editor.getVisibleCanvasRect().getWidth(), widthBefore) << "the wheel event must still have zoomed";
+}
+
+// buildMinimapModel() returns one node per rendered ModuleComponent, and a viewport equal to
+// getVisibleCanvasRect().
+TEST_F(GraphEditorTest, BuildMinimapModelReturnsOneNodePerModuleAndMatchingViewport) {
+    AudioEngine engine;
+    GraphEditor editor(engine);
+    editor.setSize(800, 600);
+
+    auto& graph = engine.getGraph();
+    auto oscNode = graph.addNode(std::make_unique<OscillatorModule>());
+    oscNode->properties.set("x", 50);
+    oscNode->properties.set("y", 50);
+    auto filterNode = graph.addNode(std::make_unique<FilterModule>());
+    filterNode->properties.set("x", 400);
+    filterNode->properties.set("y", 300);
+    editor.updateComponents();
+
+    const auto model = editor.buildMinimapModel();
+    EXPECT_EQ(model.nodes.size(), 2u);
+    EXPECT_TRUE(model.viewport == editor.getVisibleCanvasRect());
+}

--- a/Tests/IconLibraryTests.cpp
+++ b/Tests/IconLibraryTests.cpp
@@ -256,10 +256,10 @@ TEST(IconLibraryTest, WaveformIconBinaryDataSymbols) {
 // 11. WaveformIconEnumCountCoversNewIcons
 // ---------------------------------------------------------------------------
 TEST(IconLibraryTest, WaveformIconEnumCountCoversNewIcons) {
-    // The enum must now contain 28 entries (22 Phase-3 + ActionNew + ThemeToggle + 4 waveform). The
-    // static_assert in IconLibrary.cpp enforces kTable alignment at compile time; this runtime
-    // check catches any mismatch that slips through without a rebuild.
-    EXPECT_EQ((int)Icon::kCount, 28);
+    // The enum must now contain 29 entries (22 Phase-3 + ActionNew + ThemeToggle + 4 waveform +
+    // ToggleMinimap). The static_assert in IconLibrary.cpp enforces kTable alignment at compile
+    // time; this runtime check catches any mismatch that slips through without a rebuild.
+    EXPECT_EQ((int)Icon::kCount, 29);
     // Spot-check ordinal positions of the new waveform icons (shifted +2 by ActionNew at index 6 and ThemeToggle at
     // index 11).
     EXPECT_EQ((int)Icon::WaveformSine, 24);

--- a/Tests/MainComponentTests.cpp
+++ b/Tests/MainComponentTests.cpp
@@ -145,6 +145,34 @@ TEST_F(MainComponentTest, SimulateToggleMinimapClickFlipsMinimapVisibility) {
     EXPECT_EQ(mainComp.getGraphEditor().isMinimapVisible(), before);
 }
 
+// MainComponent must push the resolved binding into the minimap, so hovering the map shows the
+// same shortcut the toolbar button advertises (MinimapComponent has no ShortcutManager of its own).
+TEST_F(MainComponentTest, MinimapTooltipAdvertisesTheToggleShortcut) {
+    MainComponent mainComp(std::make_unique<MockProvider>());
+
+    const auto tooltip = mainComp.getGraphEditor().getMinimap().getTooltip();
+    const auto expected =
+        ShortcutManager::keyPressToDisplayString(mainComp.getShortcutManager().getBinding("toggleMinimap"));
+    ASSERT_FALSE(expected.isEmpty());
+    EXPECT_TRUE(tooltip.contains(expected)) << tooltip;
+}
+
+// Rebinding the shortcut must refresh the advertised key. Tooltips embed the resolved keypress, so
+// without a re-run on onBindingsChanged they keep showing the stale binding.
+TEST_F(MainComponentTest, MinimapTooltipFollowsARebind) {
+    MainComponent mainComp(std::make_unique<MockProvider>());
+    auto& shortcuts = mainComp.getShortcutManager();
+
+    // In-memory rebind only — saveToProperties() would write to the shared real settings file.
+    shortcuts.setBinding("toggleMinimap", juce::KeyPress('j', juce::ModifierKeys::commandModifier, 0));
+    ASSERT_TRUE(shortcuts.onBindingsChanged != nullptr);
+    shortcuts.onBindingsChanged();
+
+    const auto tooltip = mainComp.getGraphEditor().getMinimap().getTooltip();
+    const auto rebound = ShortcutManager::keyPressToDisplayString(shortcuts.getBinding("toggleMinimap"));
+    EXPECT_TRUE(tooltip.contains(rebound)) << tooltip;
+}
+
 TEST_F(MainComponentTest, CommandManagerHasCommands) {
     MainComponent mainComp(std::make_unique<MockProvider>());
     auto& cm = mainComp.getCommandManager();

--- a/Tests/MainComponentTests.cpp
+++ b/Tests/MainComponentTests.cpp
@@ -71,6 +71,7 @@ protected:
         if (auto* s = props.getUserSettings()) {
             s->setValue("librarySidebarVisible", "1"); // default: visible
             s->setValue("aiPanelVisible", "0");        // default: hidden
+            s->setValue("minimapVisible", "1");        // default: visible
             s->saveIfNeeded();
         }
     }
@@ -132,20 +133,33 @@ TEST_F(MainComponentTest, ToggleModMatrixHidesAndShows) {
     EXPECT_FALSE(mainComp.getGraphEditor().isModMatrixVisible());
 }
 
+// simulateToggleMinimapClick() must flip the GraphEditor's minimap visibility (issue #159).
+TEST_F(MainComponentTest, SimulateToggleMinimapClickFlipsMinimapVisibility) {
+    MainComponent mainComp(std::make_unique<MockProvider>());
+
+    const bool before = mainComp.getGraphEditor().isMinimapVisible();
+    mainComp.simulateToggleMinimapClick();
+    EXPECT_EQ(mainComp.getGraphEditor().isMinimapVisible(), !before);
+
+    mainComp.simulateToggleMinimapClick();
+    EXPECT_EQ(mainComp.getGraphEditor().isMinimapVisible(), before);
+}
+
 TEST_F(MainComponentTest, CommandManagerHasCommands) {
     MainComponent mainComp(std::make_unique<MockProvider>());
     auto& cm = mainComp.getCommandManager();
     juce::ignoreUnused(cm);
-    // Verify all 12 commands are registered (5 original + New Patch + 2 toggles + Auto Arrange +
-    // Toggle Library + Select All Modules + Save Snippet).
+    // Verify all 13 commands are registered (5 original + New Patch + 2 toggles + Auto Arrange +
+    // Toggle Library + Select All Modules + Save Snippet + Toggle Minimap).
     juce::Array<juce::CommandID> commands;
     mainComp.getAllCommands(commands);
-    EXPECT_EQ(commands.size(), 12);
+    EXPECT_EQ(commands.size(), 13);
 
     // Spot-check by identity, not just by count, so a rename can't silently keep the total right.
     EXPECT_TRUE(commands.contains(AppCommands::undo));
     EXPECT_TRUE(commands.contains(AppCommands::selectAllModules));
     EXPECT_TRUE(commands.contains(AppCommands::saveSnippet));
+    EXPECT_TRUE(commands.contains(AppCommands::toggleMinimap));
 
     // Every registered command must resolve real info (name + category), or the native menu bar
     // renders a blank row.

--- a/Tests/MinimapComponentTests.cpp
+++ b/Tests/MinimapComponentTests.cpp
@@ -334,6 +334,39 @@ TEST(MinimapComponentTest, HasNonEmptyTooltip) {
     EXPECT_FALSE(comp.getTooltip().isEmpty());
 }
 
+// Hovering the map must advertise the show/hide shortcut, the same way the toolbar buttons do.
+TEST(MinimapComponentTest, ShortcutHintAppearsInTooltip) {
+    MinimapComponent comp;
+    comp.setShortcutHint("Cmd+K");
+
+    const auto tooltip = comp.getTooltip();
+    EXPECT_TRUE(tooltip.contains("Cmd+K")) << tooltip;
+    EXPECT_TRUE(tooltip.contains("Hide Minimap")) << tooltip;
+    // The navigation gestures must survive alongside the shortcut, not be replaced by it.
+    EXPECT_TRUE(tooltip.contains("navigate")) << tooltip;
+}
+
+// A rebind replaces the advertised key rather than appending to it.
+TEST(MinimapComponentTest, ShortcutHintIsReplacedOnRebind) {
+    MinimapComponent comp;
+    comp.setShortcutHint("Cmd+K");
+    comp.setShortcutHint("Cmd+J");
+
+    const auto tooltip = comp.getTooltip();
+    EXPECT_TRUE(tooltip.contains("Cmd+J")) << tooltip;
+    EXPECT_FALSE(tooltip.contains("Cmd+K")) << tooltip;
+}
+
+// An unbound action must degrade to the plain description, with no empty "()" left behind.
+TEST(MinimapComponentTest, EmptyShortcutHintOmitsTheShortcut) {
+    MinimapComponent comp;
+    comp.setShortcutHint("");
+
+    const auto tooltip = comp.getTooltip();
+    EXPECT_FALSE(tooltip.isEmpty());
+    EXPECT_FALSE(tooltip.contains("(")) << tooltip;
+}
+
 // ---------------------------------------------------------------------------
 // Mouse interaction — onNavigate
 // ---------------------------------------------------------------------------

--- a/Tests/MinimapComponentTests.cpp
+++ b/Tests/MinimapComponentTests.cpp
@@ -1,0 +1,417 @@
+// MinimapComponentTests.cpp
+// Headless unit tests for synth::ui::MinimapComponent / MinimapModel (issue #159).
+
+#include "../Source/UI/MinimapComponent.h"
+#include <cmath>
+#include <gtest/gtest.h>
+#include <juce_gui_basics/juce_gui_basics.h>
+
+using synth::ui::MinimapComponent;
+using synth::ui::MinimapModel;
+
+namespace {
+
+// Builds a MouseEvent by hand (no precedent for this elsewhere in the suite): headless tests have
+// no real OS mouse source, but MouseInputSource is copyable and Desktop always exposes one.
+juce::MouseEvent makeMouseEvent(juce::Component& comp, juce::Point<float> position) {
+    return juce::MouseEvent(juce::Desktop::getInstance().getMainMouseSource(), position, juce::ModifierKeys(), 0.0f,
+                            0.0f, 0.0f, 0.0f, 0.0f, &comp, &comp, juce::Time::getCurrentTime(), position,
+                            juce::Time::getCurrentTime(), 1, false);
+}
+
+MinimapModel::Node makeNode(juce::Rectangle<float> bounds, juce::Colour colour = juce::Colours::red,
+                            bool selected = false) {
+    MinimapModel::Node n;
+    n.bounds = bounds;
+    n.colour = colour;
+    n.selected = selected;
+    return n;
+}
+
+MinimapModel::Cable makeCable(juce::Point<float> p1, juce::Point<float> p2,
+                              juce::Colour colour = juce::Colours::green) {
+    MinimapModel::Cable c;
+    c.p1 = p1;
+    c.p2 = p2;
+    c.colour = colour;
+    return c;
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// computeWorldBounds
+// ---------------------------------------------------------------------------
+
+// An entirely empty model (no nodes, no viewport) must fall back to a kMinWorldSpan square
+// centred on the origin, not a degenerate zero-size rect.
+TEST(MinimapComponentTest, ComputeWorldBounds_EmptyModel_ReturnsMinSpanSquareAtOrigin) {
+    MinimapModel model;
+    const auto bounds = MinimapComponent::computeWorldBounds(model);
+
+    EXPECT_FLOAT_EQ(bounds.getWidth(), MinimapComponent::kMinWorldSpan);
+    EXPECT_FLOAT_EQ(bounds.getHeight(), MinimapComponent::kMinWorldSpan);
+    EXPECT_NEAR(bounds.getCentreX(), 0.0f, 0.01f);
+    EXPECT_NEAR(bounds.getCentreY(), 0.0f, 0.01f);
+}
+
+// With nodes only (viewport empty), the result must contain every node's bounds.
+TEST(MinimapComponentTest, ComputeWorldBounds_NodesOnly_ContainsEveryNode) {
+    MinimapModel model;
+    model.nodes.push_back(makeNode({10.0f, 10.0f, 50.0f, 50.0f}));
+    model.nodes.push_back(makeNode({600.0f, 800.0f, 40.0f, 20.0f}));
+
+    const auto bounds = MinimapComponent::computeWorldBounds(model);
+    for (const auto& node : model.nodes)
+        EXPECT_TRUE(bounds.contains(node.bounds)) << node.bounds.toString();
+}
+
+// With a viewport only (no nodes), the result must contain the viewport.
+TEST(MinimapComponentTest, ComputeWorldBounds_ViewportOnly_ContainsViewport) {
+    MinimapModel model;
+    model.viewport = {100.0f, 100.0f, 300.0f, 300.0f};
+
+    const auto bounds = MinimapComponent::computeWorldBounds(model);
+    EXPECT_TRUE(bounds.contains(model.viewport));
+}
+
+// With both nodes and a viewport, the result must contain both.
+TEST(MinimapComponentTest, ComputeWorldBounds_NodesAndViewport_ContainsBoth) {
+    MinimapModel model;
+    model.nodes.push_back(makeNode({-500.0f, -500.0f, 30.0f, 30.0f}));
+    model.viewport = {0.0f, 0.0f, 200.0f, 150.0f};
+
+    const auto bounds = MinimapComponent::computeWorldBounds(model);
+    EXPECT_TRUE(bounds.contains(model.nodes[0].bounds));
+    EXPECT_TRUE(bounds.contains(model.viewport));
+}
+
+// A single small node far from the origin must be clamped out to at least kMinWorldSpan per axis,
+// while staying centred on that node (not on the origin).
+TEST(MinimapComponentTest, ComputeWorldBounds_SingleSmallNode_ClampedAndCentredOnNode) {
+    MinimapModel model;
+    model.nodes.push_back(makeNode({1000.0f, -2000.0f, 10.0f, 10.0f}));
+
+    const auto bounds = MinimapComponent::computeWorldBounds(model);
+    EXPECT_GE(bounds.getWidth(), MinimapComponent::kMinWorldSpan);
+    EXPECT_GE(bounds.getHeight(), MinimapComponent::kMinWorldSpan);
+    EXPECT_NEAR(bounds.getCentreX(), model.nodes[0].bounds.getCentreX(), 0.01f);
+    EXPECT_NEAR(bounds.getCentreY(), model.nodes[0].bounds.getCentreY(), 0.01f);
+}
+
+// ---------------------------------------------------------------------------
+// computeWorldToMap
+// ---------------------------------------------------------------------------
+
+// A square world dropped into a wide (non-square) map area must scale uniformly, not stretch:
+// two equal-length perpendicular segments in world space must stay equal length after transform.
+TEST(MinimapComponentTest, ComputeWorldToMap_PreservesAspectRatio) {
+    const juce::Rectangle<float> world(0.0f, 0.0f, 1000.0f, 1000.0f);
+    const juce::Rectangle<float> mapArea(0.0f, 0.0f, 400.0f, 100.0f); // wide, non-square
+
+    const auto transform = MinimapComponent::computeWorldToMap(world, mapArea);
+
+    const juce::Point<float> origin(500.0f, 500.0f);
+    const juce::Point<float> horiz(600.0f, 500.0f);
+    const juce::Point<float> vert(500.0f, 600.0f);
+
+    const auto o = origin.transformedBy(transform);
+    const auto h = horiz.transformedBy(transform);
+    const auto v = vert.transformedBy(transform);
+
+    EXPECT_NEAR(o.getDistanceFrom(h), o.getDistanceFrom(v), 0.01f)
+        << "a uniform scale must move equal-length perpendicular segments the same distance";
+}
+
+// The transformed world rect must land entirely inside mapArea and be centred there.
+TEST(MinimapComponentTest, ComputeWorldToMap_MapsInsideMapAreaAndCentred) {
+    const juce::Rectangle<float> world(-200.0f, -100.0f, 800.0f, 600.0f);
+    const juce::Rectangle<float> mapArea(4.0f, 4.0f, 212.0f, 142.0f);
+
+    const auto transform = MinimapComponent::computeWorldToMap(world, mapArea);
+    const auto topLeft = world.getTopLeft().transformedBy(transform);
+    const auto bottomRight = world.getBottomRight().transformedBy(transform);
+    const juce::Rectangle<float> mapped(topLeft, bottomRight);
+
+    EXPECT_TRUE(mapArea.expanded(0.01f).contains(mapped))
+        << "mapped=" << mapped.toString() << " mapArea=" << mapArea.toString();
+    EXPECT_NEAR(mapped.getCentreX(), mapArea.getCentreX(), 0.01f);
+    EXPECT_NEAR(mapped.getCentreY(), mapArea.getCentreY(), 0.01f);
+}
+
+// Degenerate (zero-width) world input must not divide by zero — identity-safe, no NaN/inf.
+TEST(MinimapComponentTest, ComputeWorldToMap_ZeroWidthWorld_NoNaNOrInf) {
+    const juce::Rectangle<float> world(0.0f, 0.0f, 0.0f, 100.0f);
+    const juce::Rectangle<float> mapArea(0.0f, 0.0f, 200.0f, 200.0f);
+
+    const auto transform = MinimapComponent::computeWorldToMap(world, mapArea);
+    const auto p = juce::Point<float>(5.0f, 5.0f).transformedBy(transform);
+
+    EXPECT_FALSE(std::isnan(p.x));
+    EXPECT_FALSE(std::isnan(p.y));
+    EXPECT_FALSE(std::isinf(p.x));
+    EXPECT_FALSE(std::isinf(p.y));
+}
+
+// Degenerate (zero-height) map area input must not divide by zero — identity-safe, no NaN/inf.
+TEST(MinimapComponentTest, ComputeWorldToMap_ZeroHeightMapArea_NoNaNOrInf) {
+    const juce::Rectangle<float> world(0.0f, 0.0f, 100.0f, 100.0f);
+    const juce::Rectangle<float> mapArea(0.0f, 0.0f, 200.0f, 0.0f);
+
+    const auto transform = MinimapComponent::computeWorldToMap(world, mapArea);
+    const auto p = juce::Point<float>(5.0f, 5.0f).transformedBy(transform);
+
+    EXPECT_FALSE(std::isnan(p.x));
+    EXPECT_FALSE(std::isnan(p.y));
+    EXPECT_FALSE(std::isinf(p.x));
+    EXPECT_FALSE(std::isinf(p.y));
+}
+
+// ---------------------------------------------------------------------------
+// mapToWorld — true inverse of computeWorldToMap
+// ---------------------------------------------------------------------------
+
+TEST(MinimapComponentTest, MapToWorld_RoundTripsSeveralPoints) {
+    const juce::Rectangle<float> world(-200.0f, -100.0f, 800.0f, 600.0f);
+    const juce::Rectangle<float> mapArea(4.0f, 4.0f, 212.0f, 142.0f);
+    const auto forward = MinimapComponent::computeWorldToMap(world, mapArea);
+
+    const juce::Point<float> worldPoints[] = {
+        world.getTopLeft(), world.getBottomRight(), world.getCentre(), {-50.0f, 250.0f}, {600.0f, -80.0f}};
+
+    for (const auto& wp : worldPoints) {
+        const auto mapped = wp.transformedBy(forward);
+        const auto back = MinimapComponent::mapToWorld(mapped, world, mapArea);
+        EXPECT_NEAR(back.x, wp.x, 0.01f);
+        EXPECT_NEAR(back.y, wp.y, 0.01f);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// MinimapModel::operator==/!=
+// ---------------------------------------------------------------------------
+
+TEST(MinimapModelTest, IdenticalModelsAreEqual) {
+    MinimapModel a;
+    a.viewport = {0.0f, 0.0f, 100.0f, 100.0f};
+    a.nodes.push_back(makeNode({1.0f, 1.0f, 10.0f, 10.0f}));
+    a.cables.push_back(makeCable({0.0f, 0.0f}, {5.0f, 5.0f}));
+
+    MinimapModel b = a;
+    EXPECT_TRUE(a == b);
+    EXPECT_FALSE(a != b);
+}
+
+TEST(MinimapModelTest, DifferingViewportMakesModelsUnequal) {
+    MinimapModel a, b;
+    a.viewport = {0.0f, 0.0f, 100.0f, 100.0f};
+    b.viewport = {0.0f, 0.0f, 200.0f, 100.0f};
+    EXPECT_TRUE(a != b);
+}
+
+TEST(MinimapModelTest, DifferingNodeCountMakesModelsUnequal) {
+    MinimapModel a, b;
+    a.nodes.push_back(makeNode({0.0f, 0.0f, 10.0f, 10.0f}));
+    b.nodes.push_back(makeNode({0.0f, 0.0f, 10.0f, 10.0f}));
+    b.nodes.push_back(makeNode({50.0f, 50.0f, 10.0f, 10.0f}));
+    EXPECT_TRUE(a != b);
+}
+
+TEST(MinimapModelTest, MovedNodeWithSameCountMakesModelsUnequal) {
+    MinimapModel a, b;
+    a.nodes.push_back(makeNode({0.0f, 0.0f, 10.0f, 10.0f}));
+    b.nodes.push_back(makeNode({1.0f, 0.0f, 10.0f, 10.0f})); // shifted by 1px
+    EXPECT_TRUE(a != b);
+}
+
+TEST(MinimapModelTest, NodeDifferingOnlyInSelectedMakesModelsUnequal) {
+    MinimapModel a, b;
+    a.nodes.push_back(makeNode({0.0f, 0.0f, 10.0f, 10.0f}, juce::Colours::red, false));
+    b.nodes.push_back(makeNode({0.0f, 0.0f, 10.0f, 10.0f}, juce::Colours::red, true));
+    EXPECT_TRUE(a != b);
+}
+
+TEST(MinimapModelTest, CableDifferingOnlyInColourMakesModelsUnequal) {
+    MinimapModel a, b;
+    a.cables.push_back(makeCable({0.0f, 0.0f}, {10.0f, 10.0f}, juce::Colours::red));
+    b.cables.push_back(makeCable({0.0f, 0.0f}, {10.0f, 10.0f}, juce::Colours::blue));
+    EXPECT_TRUE(a != b);
+}
+
+// ---------------------------------------------------------------------------
+// setModel — change detection, observed via getModel()
+// ---------------------------------------------------------------------------
+
+TEST(MinimapComponentTest, SetModel_DifferentModelIsReflectedByGetModel) {
+    MinimapComponent comp;
+
+    MinimapModel model1;
+    model1.viewport = {0.0f, 0.0f, 100.0f, 100.0f};
+    comp.setModel(model1);
+    EXPECT_TRUE(comp.getModel() == model1);
+
+    MinimapModel model2;
+    model2.viewport = {10.0f, 10.0f, 300.0f, 300.0f};
+    model2.nodes.push_back(makeNode({5.0f, 5.0f, 20.0f, 20.0f}));
+    comp.setModel(model2);
+    EXPECT_TRUE(comp.getModel() == model2);
+}
+
+TEST(MinimapComponentTest, SetModel_EqualModelLeavesGetModelUnchanged) {
+    MinimapComponent comp;
+
+    MinimapModel model;
+    model.viewport = {5.0f, 5.0f, 50.0f, 50.0f};
+    model.nodes.push_back(makeNode({1.0f, 1.0f, 10.0f, 10.0f}, juce::Colours::red, true));
+    comp.setModel(model);
+    ASSERT_TRUE(comp.getModel() == model);
+
+    // Handing back an equal (but distinct) copy must be a safe no-op and getModel() must still
+    // report the same data.
+    MinimapModel equalCopy = model;
+    EXPECT_NO_THROW(comp.setModel(equalCopy));
+    EXPECT_TRUE(comp.getModel() == model);
+}
+
+// ---------------------------------------------------------------------------
+// setViewport — updates only the viewport
+// ---------------------------------------------------------------------------
+
+TEST(MinimapComponentTest, SetViewport_UpdatesOnlyViewport) {
+    MinimapComponent comp;
+
+    MinimapModel model;
+    model.viewport = {0.0f, 0.0f, 10.0f, 10.0f};
+    model.nodes.push_back(makeNode({1.0f, 1.0f, 5.0f, 5.0f}));
+    model.cables.push_back(makeCable({0.0f, 0.0f}, {2.0f, 2.0f}));
+    comp.setModel(model);
+
+    const juce::Rectangle<float> newViewport(50.0f, 60.0f, 200.0f, 150.0f);
+    comp.setViewport(newViewport);
+
+    const auto& result = comp.getModel();
+    EXPECT_TRUE(result.viewport == newViewport);
+    EXPECT_EQ(result.nodes, model.nodes);
+    EXPECT_EQ(result.cables, model.cables);
+}
+
+// ---------------------------------------------------------------------------
+// Component-level: construction, painting, tooltip
+// ---------------------------------------------------------------------------
+
+TEST(MinimapComponentTest, ConstructsHeadlesslyAtRealisticSizeWithoutCrash) {
+    EXPECT_NO_THROW({
+        MinimapComponent comp;
+        comp.setSize(220, 150);
+    });
+}
+
+TEST(MinimapComponentTest, RendersNonEmptyImageAfterSetModel) {
+    MinimapComponent comp;
+    comp.setSize(220, 150);
+
+    MinimapModel model;
+    model.viewport = {0.0f, 0.0f, 800.0f, 600.0f};
+    model.nodes.push_back(makeNode({0.0f, 0.0f, 100.0f, 100.0f}, juce::Colours::red));
+    model.nodes.push_back(makeNode({500.0f, 400.0f, 80.0f, 60.0f}, juce::Colours::blue));
+    comp.setModel(model);
+
+    const juce::Image img = comp.createComponentSnapshot(comp.getLocalBounds());
+    ASSERT_TRUE(img.isValid());
+    EXPECT_EQ(img.getWidth(), 220);
+    EXPECT_EQ(img.getHeight(), 150);
+
+    bool hasOpaque = false;
+    for (int y = 0; y < img.getHeight() && !hasOpaque; ++y)
+        for (int x = 0; x < img.getWidth() && !hasOpaque; ++x)
+            if (img.getPixelAt(x, y).getAlpha() > 0)
+                hasOpaque = true;
+    EXPECT_TRUE(hasOpaque);
+}
+
+TEST(MinimapComponentTest, HasNonEmptyTooltip) {
+    MinimapComponent comp;
+    EXPECT_FALSE(comp.getTooltip().isEmpty());
+}
+
+// ---------------------------------------------------------------------------
+// Mouse interaction — onNavigate
+// ---------------------------------------------------------------------------
+
+// A click at the centre of the component must fire onNavigate with a canvas point near the
+// centre of the world bounds. The expectation is derived from mapToWorld itself (not a magic
+// number), since getMapArea()'s symmetric 4px inset keeps the component's centre and the map
+// area's centre identical.
+TEST(MinimapComponentTest, MouseDownAtCentreFiresOnNavigateNearWorldCentre) {
+    MinimapComponent comp;
+    comp.setSize(220, 150);
+
+    MinimapModel model;
+    model.viewport = {0.0f, 0.0f, 800.0f, 600.0f};
+    comp.setModel(model);
+
+    juce::Point<float> firedPoint;
+    bool fired = false;
+    comp.onNavigate = [&](juce::Point<float> p) {
+        fired = true;
+        firedPoint = p;
+    };
+
+    const auto centre = comp.getLocalBounds().toFloat().getCentre();
+    const auto event = makeMouseEvent(comp, centre);
+    comp.mouseDown(event);
+
+    ASSERT_TRUE(fired);
+
+    const auto world = MinimapComponent::computeWorldBounds(model);
+    const auto mapArea = comp.getLocalBounds().toFloat().reduced(4.0f);
+    const auto expected = MinimapComponent::mapToWorld(centre, world, mapArea);
+
+    EXPECT_NEAR(firedPoint.x, expected.x, 3.0f);
+    EXPECT_NEAR(firedPoint.y, expected.y, 3.0f);
+}
+
+// Dragging must also fire onNavigate (not just the initial mouseDown).
+TEST(MinimapComponentTest, MouseDragFiresOnNavigate) {
+    MinimapComponent comp;
+    comp.setSize(220, 150);
+
+    MinimapModel model;
+    model.viewport = {0.0f, 0.0f, 800.0f, 600.0f};
+    comp.setModel(model);
+
+    int callCount = 0;
+    comp.onNavigate = [&](juce::Point<float>) { ++callCount; };
+
+    const auto centre = comp.getLocalBounds().toFloat().getCentre();
+    comp.mouseDown(makeMouseEvent(comp, centre));
+    EXPECT_EQ(callCount, 1);
+
+    const auto dragPos = centre + juce::Point<float>(15.0f, 10.0f);
+    comp.mouseDrag(makeMouseEvent(comp, dragPos));
+    EXPECT_EQ(callCount, 2);
+}
+
+// ---------------------------------------------------------------------------
+// Callbacks safely no-op when unset
+// ---------------------------------------------------------------------------
+
+TEST(MinimapComponentTest, MouseAndWheelEventsAreSafeWithoutCallbacks) {
+    MinimapComponent comp;
+    comp.setSize(220, 150);
+
+    MinimapModel model;
+    model.viewport = {0.0f, 0.0f, 800.0f, 600.0f};
+    comp.setModel(model);
+
+    // onNavigate / onZoom deliberately left as default-constructed (null) std::function.
+    const auto centre = comp.getLocalBounds().toFloat().getCentre();
+    const auto event = makeMouseEvent(comp, centre);
+
+    EXPECT_NO_THROW(comp.mouseDown(event));
+    EXPECT_NO_THROW(comp.mouseDrag(event));
+
+    juce::MouseWheelDetails wheel;
+    wheel.deltaY = 0.5f;
+    EXPECT_NO_THROW(comp.mouseWheelMove(event, wheel));
+}

--- a/Tests/ShortcutManagerTests.cpp
+++ b/Tests/ShortcutManagerTests.cpp
@@ -90,3 +90,33 @@ TEST_F(ShortcutManagerTest, GetActionDescription_Works) {
     EXPECT_EQ(ShortcutManager::getActionDescription("undo"), "Undo");
     EXPECT_EQ(ShortcutManager::getActionDescription("redo"), "Redo");
 }
+
+// ---------------------------------------------------------------------------
+// Minimap toggle (issue #159)
+// ---------------------------------------------------------------------------
+
+// Default binding for the minimap toggle must be Cmd+K, with no extra modifiers.
+TEST_F(ShortcutManagerTest, ToggleMinimapDefaultBindingIsCmdK) {
+    const auto kp = manager.getBinding("toggleMinimap");
+    EXPECT_EQ(kp.getKeyCode(), 'k');
+    EXPECT_TRUE(kp.getModifiers().isCommandDown());
+    EXPECT_FALSE(kp.getModifiers().isShiftDown());
+    EXPECT_FALSE(kp.getModifiers().isAltDown());
+}
+
+// AppCommands::getCommandForAction must resolve "toggleMinimap" to the real command ID.
+TEST_F(ShortcutManagerTest, GetCommandForAction_ResolvesToggleMinimap) {
+    EXPECT_EQ(AppCommands::getCommandForAction("toggleMinimap"), AppCommands::toggleMinimap);
+}
+
+// "toggleMinimap" must be a registered action id (drives Settings' shortcut list).
+TEST_F(ShortcutManagerTest, ActionIds_ContainsToggleMinimap) {
+    EXPECT_TRUE(manager.getActionIds().contains("toggleMinimap"));
+}
+
+// The action needs a human-readable, non-empty description for the Settings UI.
+TEST_F(ShortcutManagerTest, GetActionDescription_ToggleMinimapIsNonEmpty) {
+    const auto description = ShortcutManager::getActionDescription("toggleMinimap");
+    EXPECT_FALSE(description.isEmpty());
+    EXPECT_EQ(description, "Toggle Minimap");
+}

--- a/assets/icons/toggle-minimap.svg
+++ b/assets/icons/toggle-minimap.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
+  <rect x="3" y="3" width="18" height="18" rx="2" fill="none" stroke="#FFFFFF" stroke-width="1.5"/>
+  <rect x="8" y="8" width="9" height="6" rx="1" fill="#FFFFFF"/>
+</svg>

--- a/docs/layout.md
+++ b/docs/layout.md
@@ -1098,3 +1098,87 @@ See [`docs/theming.md` §11](theming.md#11-cable-colours) for cable colour modes
 `cableCategory` palette and the user override layer. `GraphEditor` renders whatever mode and
 overrides it is handed via `setCableColourMode()` / `setCableColourOverrides()`; it never reads
 `ApplicationProperties` itself.
+
+---
+
+## 15. Minimap Overlay (issue #159)
+
+`Source/UI/MinimapComponent.h/.cpp` — `synth::ui::MinimapComponent`, a small always-current
+overview of the graph.
+
+### What it is
+
+An untransformed sibling overlay on `GraphEditor`, the same pattern as `ModMatrixComponent` — it
+does not live inside the panned/zoomed `GraphContentComponent`, so its own bounds are plain screen
+space. Everything it draws is expressed in **canvas coordinates** (the space `ModuleComponent`s and
+cables already live in) and mapped down to the small map area with `computeWorldToMap()`.
+
+### Placement, sizing, auto-hide
+
+Positioned **bottom-left** with a 12 px margin, sized `min(220, w/4) × min(150, h/4)`. Bottom-left
+is deliberate: the mod-matrix panel occupies the right-hand 600 px (§5). Below a 480×360 editor the
+minimap auto-hides — `GraphEditor::resized()` recomputes `minimapVisible && fits` on every layout
+pass against absolute floors (a fraction-of-self test like `w/4 * 2 <= w` is always true, so it
+would never actually hide anything). This never clobbers the user's preference: `minimapVisible`
+still records what they asked for, and reappears the moment the window grows back past the floor.
+
+### What it draws
+
+Renders from a `MinimapModel` snapshot — nodes, cables, and the current viewport rect, all in
+canvas coordinates:
+
+- **Nodes** — filled rounded rects in the module's per-category theme colour
+  (`themeColourForCategory`), clamped to a `kMinNodeSize` (2 px) floor so zoomed-out modules stay
+  visible; selected nodes get an additional `accent` stroke.
+- **Cables** — thin straight lines in the cable's colour at reduced alpha, not the bezier the
+  canvas draws — this is a thumbnail, not a second connection view.
+- **Viewport** — the area outside the currently visible canvas rect is dimmed with a translucent
+  `bg0` wash (an even-odd path fill punches a "hole" over the viewport rect rather than drawing
+  four separate bars); the viewport itself is stroked in `accent`.
+
+`computeWorldBounds()` derives what the map actually shows: the union of every node's bounds and
+the viewport, inflated by an 80 px margin (`kWorldMargin`), and never narrower/shorter than 1200 px
+(`kMinWorldSpan`) per axis, so a single module doesn't blow up to fill the map. All three drawing
+and hit-testing helpers (`computeWorldBounds`, `computeWorldToMap`, `mapToWorld`) are pure static
+functions with no `Component` state — unit-tested directly (`Tests/MinimapComponentTests.cpp`).
+
+### Interaction
+
+Click or drag on the map converts the event position to a canvas point (`mapToWorld`) and fires
+`onNavigate`, which `GraphEditor` wires to `centreViewOn()` — pans so that point is centred; zoom is
+unchanged. Scroll wheel fires `onZoom` with the wheel's `deltaY`, wired to `zoomAroundCentre()`.
+Both the minimap's wheel-zoom and the canvas's own wheel-zoom (`GraphEditor::mouseWheelMove`) share
+one private helper, `applyZoomAt(wheelDelta, screenAnchor)` — the canvas anchors on the mouse
+position, the minimap anchors on the visible area's centre, but the zoom curve and the `[0.1, 2.0]`
+clamp are identical.
+
+### Repaint discipline
+
+Follows §10. `setModel()` and `setViewport()` only `repaint()` when the incoming data actually
+differs from the current model (`MinimapModel::operator==`, a field-wise comparison over nodes,
+cables and viewport). `GraphEditor::timerCallback()` — the existing 30 Hz tick that already drives
+the connection-flow animation — pushes a freshly built model via `buildMinimapModel()` **only while
+the minimap is visible**, so a hidden minimap costs nothing: no graph walk, no model diffing.
+`updateTransform()` (called on every pan/zoom frame) pushes **only the viewport rect** via
+`setViewport()`, because panning/zooming changes what's visible, not where modules or cables are —
+rebuilding the full model on every drag frame would re-walk every graph edge for nothing.
+
+### GraphEditor API
+
+| Member | Purpose |
+|---|---|
+| `setMinimapVisible(bool)` | Sets the user preference and re-runs `resized()`'s fits check; also seeds a full model immediately so the map isn't blank until the next 30 Hz tick |
+| `toggleMinimapVisibility()` | `setMinimapVisible(!minimapVisible)` |
+| `isMinimapVisible()` | The user preference (not the fits-adjusted effective visibility) |
+| `getMinimap()` | Direct access to the `MinimapComponent` |
+| `getVisibleCanvasRect()` | The canvas rect currently visible — inverse of the content transform applied to `getLocalBounds()` |
+| `centreViewOn(canvasPoint)` | Pans so `canvasPoint` is centred; zoom unchanged |
+| `zoomAroundCentre(wheelDelta)` | `applyZoomAt` anchored on the visible area's centre |
+| `buildMinimapModel()` | Walks every module and `buildVisibleCables()` into a `MinimapModel` snapshot |
+
+### Toolbar, shortcut, persistence
+
+A toolbar toggle (`ToggleMinimap`, right-hand group, before `ToggleModMatrix`) and the **Cmd+K**
+shortcut (action id `toggleMinimap`; see [`shortcuts.md`](shortcuts.md)) both call
+`GraphEditor::toggleMinimapVisibility()`. Visibility persists under the `minimapVisible` key in
+`juce::ApplicationProperties`, default `true`.

--- a/docs/layout.md
+++ b/docs/layout.md
@@ -1152,6 +1152,15 @@ one private helper, `applyZoomAt(wheelDelta, screenAnchor)` — the canvas ancho
 position, the minimap anchors on the visible area's centre, but the zoom curve and the `[0.1, 2.0]`
 clamp are identical.
 
+Hovering the map shows a tooltip that leads with the show/hide shortcut, the same way the toolbar
+buttons read (`"Hide Minimap  (Cmd+K)  - click or drag to navigate, scroll to zoom"`). The binding
+is rebindable, so `MinimapComponent` does **not** depend on `ShortcutManager`: it exposes
+`setShortcutHint(displayString)` and `MainComponent::applyToolbarIcons()` resolves the current
+binding and pushes it down alongside the toolbar tooltips. Because tooltips embed the resolved
+keypress, `MainComponent::updateCommandShortcuts()` (the `ShortcutManager::onBindingsChanged` hook)
+re-runs `applyToolbarIcons()` — without that, every toolbar hint *and* the minimap's keeps
+advertising the pre-rebind key until some unrelated toggle happens to refresh it.
+
 ### Repaint discipline
 
 Follows §10. `setModel()` and `setViewport()` only `repaint()` when the incoming data actually

--- a/docs/shortcuts.md
+++ b/docs/shortcuts.md
@@ -11,6 +11,7 @@ Shortcuts are configurable in **Settings → Keyboard Shortcuts** tab (renamed f
 | Cmd+Z | Undo |
 | Cmd+Shift+Z | Redo |
 | Cmd+M | Toggle Mod Matrix |
+| Cmd+K | Toggle Minimap |
 | Cmd+A | Toggle AI Panel |
 | Cmd+L | Auto Arrange |
 | Cmd+B | Toggle Module Library Sidebar |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -226,6 +226,15 @@ New suite `Tests/WavetableDisplayTests.cpp` covering `Source/UI/WavetableDisplay
 |-------|-------|----------------|
 | WavetableDisplayTest | 8 | `QuantisePositionEndpointsAndClamping`/`QuantisePositionIsMonotonicAndCollapsesTinyChanges` — `quantisePosition` pins 0→0 and 1→`steps`, clamps out-of-range input, is monotonic, and maps sub-bucket jitter to the same bucket (this is the repaint gate); `RepeatedTimerTicksOnAnUnchangedModuleAreIdempotent` — five ticks leave the trace bit-identical, a real position change is still picked up; `DisplayWaveformTracksScanPosition` — position 0 and 1 traces differ by >0.2 and both stay bounded; `DisplayWaveformHandlesTinyPointCounts` — 0 and 1 requested points still yield ≥2 samples; `PaintSmokeBuiltInTable`/`PaintSmokeAtEveryScanPosition`/`PaintSmokeAtDegenerateSizes` — paints into a `juce::Image` with no crash at 11 scan positions and at 0×0/1×1/4×80 bounds |
 
+### Minimap Tests (25 tests)
+
+New suite `Tests/MinimapComponentTests.cpp` covering `Source/UI/MinimapComponent.h/.cpp` (issue #159). See [`layout.md` §15](layout.md#15-minimap-overlay-issue-159) for the feature.
+
+| Suite | Tests | What it covers |
+|-------|-------|----------------|
+| MinimapComponentTest | 19 | `computeWorldBounds` — empty model falls back to a `kMinWorldSpan` square at the origin, nodes-only/viewport-only/both are contained, a single small node is clamped out to the min span while staying centred on it; `computeWorldToMap` — preserves aspect ratio in a non-square map area, maps inside and centres in the map area, zero-width world / zero-height map area stay NaN/Inf-free; `mapToWorld` round-trips several points through the forward transform; `setModel` reflects a differing model and no-ops on an equal one (observed via `getModel()`); `setViewport` updates only the viewport, leaving nodes/cables untouched; construction at a realistic size and a non-empty tooltip; paints a non-empty image after `setModel`; `mouseDown`/`mouseDrag` fire `onNavigate` with the point `mapToWorld` itself predicts; mouse and wheel handlers are safe no-ops with `onNavigate`/`onZoom` unset |
+| MinimapModelTest | 6 | `MinimapModel::operator==`/`!=` — identical models are equal; differing viewport, node count, a moved node, a node differing only in `selected`, or a cable differing only in colour all make models unequal |
+
 ### E2E Workflow Tests (24 tests)
 
 Full application workflow tests in `Tests/E2EWorkflowTests.cpp`. Each test constructs a complete `MainComponent` with a mock AI provider and exercises real UI interaction code paths.

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -187,21 +187,24 @@ Agent Synth uses SVG `Drawable` icons — **not** an icon or glyph font. This av
 
 ### Icon enum
 
-26 icons are defined in `synth::theme::Icon` (in `Source/UI/Theme/IconLibrary.h`):
+29 icons are defined in `synth::theme::Icon` (in `Source/UI/Theme/IconLibrary.h`):
 
 ```
 TransportPlay    TransportStop    ActionUndo       ActionRedo
-ActionSave       ActionLoad       ActionSettings   ActionAutoArrange
-ToggleAI         ToggleMatrix     ToggleLibrary
-ModuleBypass     ModuleMute       ModuleDelete
+ActionSave       ActionLoad       ActionNew        ActionSettings
+ActionAutoArrange ToggleAI        ToggleMatrix     ToggleLibrary
+ThemeToggle      ModuleBypass     ModuleMute       ModuleDelete
 CatSources       CatSequencing    CatEnvelopes     CatFilters
 CatModulationFX  CatTimeFX        CatDynamics      CatUtility
 WaveformSine     WaveformSaw      WaveformSquare   WaveformTriangle
+ToggleMinimap
 ```
 
 **`Icon::TransportPlay` is scaffolding** — the SVG asset is present and the enum value exists, but no `DrawableButton` is wired to it. It is tinted to `textMuted` and reserved for a future transport affordance.
 
-The four **waveform icons** (`WaveformSine`, `WaveformSaw`, `WaveformSquare`, `WaveformTriangle`, indices 22–25) are rendered in the Oscillator waveform combo via `AppLookAndFeel::drawPopupMenuItem` (14×14 glyph left of the item text) and `drawComboBox` (selected waveform glyph in the closed combo). `positionComboBoxText` shifts the label right when the selected item has an icon.
+The four **waveform icons** (`WaveformSine`, `WaveformSaw`, `WaveformSquare`, `WaveformTriangle`, indices 24–27) are rendered in the Oscillator waveform combo via `AppLookAndFeel::drawPopupMenuItem` (14×14 glyph left of the item text) and `drawComboBox` (selected waveform glyph in the closed combo). `positionComboBoxText` shifts the label right when the selected item has an icon.
+
+**`Icon::ToggleMinimap`** (index 28, the last enum value before `kCount`) is the toolbar toggle for the Graph Editor minimap overlay — see [`layout.md` §15](layout.md#15-minimap-overlay-issue-159).
 
 ### Token → tint map
 


### PR DESCRIPTION
## Summary

Adds a small zoomable overview map in the corner of the Graph Editor for navigating large, sprawling patches, plus a toolbar toggle and a `Cmd+K` shortcut to show/hide it.

Closes #159.

`MinimapComponent` is an untransformed sibling overlay on `GraphEditor` — the same pattern `ModMatrixComponent` already uses — so it is unaffected by the canvas pan/zoom transform. It renders from a `MinimapModel` snapshot (nodes, cables and the visible viewport rect, all in canvas coordinates).

Placement is **bottom-left** deliberately: the mod-matrix panel occupies 600px on the right.

## Changes

- **`Source/UI/MinimapComponent.h/.cpp`** (new) — modules drawn as filled rects in their per-category theme colour (selection stroked in `accent`), cables as thin straight lines rather than the canvas bezier, and everything outside the current viewport dimmed with a translucent wash. Three static pure geometry helpers (`computeWorldBounds`, `computeWorldToMap`, `mapToWorld`) hold the maths, so it is unit-testable without a GUI.
- **Interaction** — click or drag navigates (`centreViewOn`), scroll zooms (`zoomAroundCentre`). The wheel-zoom maths was extracted into a shared `applyZoomAt(delta, anchor)` so the minimap and the canvas cannot drift apart; canvas wheel-zoom behaviour is unchanged and now has an explicit regression test.
- **Repaint discipline** (this is the part worth reviewing, given the no-continuous-repaint invariant in CLAUDE.md) — `setModel()`/`setViewport()` repaint only on an actual change; the 30 Hz tick pushes a full model **only while visible**; and `updateTransform()` pushes **only the viewport rect**, because pan/zoom changes what you're looking at rather than where the modules are, and rebuilding the full model there would re-walk every graph edge on every drag frame.
- **Auto-hide** below a 480x360 editor, without clobbering the user's preference.
- **Chrome** — toolbar toggle in the right-hand group, `Cmd+K`, and visibility persisted under `"minimapVisible"` (default on).
- **Docs** — `layout.md` §15, `shortcuts.md`, and a `theming.md` icon-count correction (26 → 29; `ActionNew` and `ThemeToggle` were already missing from that list before this PR).

## Test Plan

- [x] All existing tests pass — full suite **1342/1342**
- [x] New tests added for new functionality — **42 new tests**: geometry helpers, model change-detection, headless render and mouse-navigation (`MinimapComponentTests.cpp`); visibility, auto-hide, viewport/centre/zoom maths and the wheel-zoom regression guard (`GraphEditorTests.cpp`); plus button, command and shortcut coverage
- [x] Tested locally (build + run) — built and launched the app, confirmed the minimap renders correctly over a real multi-module patch and that the toolbar button shows the correct latched "Hide Minimap" label
- [x] Documentation updated

**One honest gap:** the `Cmd+K` binding is verified by unit test (default binding, action-id registration, command resolution), **not** by a live keypress — synthetic keystrokes via System Events don't reach the JUCE app in this environment. I confirmed this is environmental rather than a defect by testing the pre-existing `Cmd+M` (Toggle Mod Matrix), which fails to respond in exactly the same way. Worth a manual press of `Cmd+K` when reviewing.

## Screenshots

Verified visually in the running app: the minimap renders bottom-left over a real patch showing per-category coloured module blocks, faint cable lines, and the accent-stroked viewport rectangle with the surrounding area washed out. Terminal screenshot capture wasn't attachable to this PR.

## Note for the reviewer (pre-existing, not fixed here)

`docs/testing.md` lines 36-48 contain literal unresolved git merge-conflict markers (`<<<<<<< HEAD` / `=======` / `>>>>>>> origin/main`) that are already committed on `main`. This PR touches that file but deliberately leaves the markers alone as out of scope — flagging so they don't get lost. Confirmed via `git show HEAD:docs/testing.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
