### PR TITLE
fix(poly): deterministic voice stealing + Voice Steal modes (#198)

### DIFF
--- a/Source/Modules/PolyMidiModule.h
+++ b/Source/Modules/PolyMidiModule.h
@@ -1,25 +1,36 @@
 #pragma once
 
 #include "ModuleBase.h"
+#include <algorithm>
 #include <atomic>
 
 class PolyMidiModule : public ModuleBase {
 public:
+    /** Voice-steal strategy, in `voiceSteal` choice order. Index 0 is the historical behaviour,
+     *  so a patch saved before this parameter existed loads with unchanged voice allocation. */
+    enum class StealMode { Oldest = 0, RoundRobin, Random };
+
     PolyMidiModule()
         : ModuleBase("Poly MIDI", 0, 16) {
         // Port 0: Pitch CV (8 channels)
         // Port 1: Gate CV (8 channels)
+        addParameter(voiceStealParam = new juce::AudioParameterChoice("voiceSteal", "Voice Steal",
+                                                                      {"Oldest", "Round-Robin", "Random"}, 0));
         enableVisualBuffer(true);
     }
 
     bool acceptsMidi() const override { return true; }
 
     void prepareToPlay(double sampleRate, int samplesPerBlock) override {
-        juce::ignoreUnused(sampleRate, samplesPerBlock);
+        juce::ignoreUnused(samplesPerBlock);
+        sampleCounter_ = 0;
+        lastStamp_ = 0;
+        roundRobinCursor_ = 0;
+        stealRandom_.setSeed(kStealSeed);
         for (auto& v : voices) {
             v.note = -1;
             v.active = false;
-            v.lastUsedTime = 0;
+            v.lastUsedSample = 0;
             v.currentFreq = 0.0f;
             v.smoothedGate.reset(sampleRate, 0.005); // 5ms smoothing for gates
             v.smoothedFreq.reset(sampleRate, 0.005); // 5ms smoothing for pitch
@@ -27,6 +38,15 @@ public:
     }
 
     void processBlock(juce::AudioBuffer<float>& buffer, juce::MidiBuffer& midiMessages) override {
+        int numSamples = buffer.getNumSamples();
+
+        // Voice age is measured in samples elapsed since prepareToPlay, never in wall-clock time
+        // (issue #198): a sample counter is deterministic across runs and finer-grained than the
+        // block rate, so a chord delivered inside one block still steals in arrival order. Advanced
+        // before the bypass check so ages stay ordered across a bypass toggle.
+        const juce::int64 blockStartSample = sampleCounter_;
+        sampleCounter_ += numSamples;
+
         if (isBypassed()) {
             buffer.clear();
             return;
@@ -34,7 +54,6 @@ public:
 
         buffer.clear();
 
-        int numSamples = buffer.getNumSamples();
         int currentSample = 0;
 
         int midiEventCount = 0;
@@ -50,7 +69,7 @@ public:
             }
 
             if (msg.isNoteOn()) {
-                handleNoteOn(msg.getNoteNumber(), msg.getFloatVelocity());
+                handleNoteOn(msg.getNoteNumber(), msg.getFloatVelocity(), blockStartSample + triggerSample);
                 ++midiEventCount;
             } else if (msg.isNoteOff()) {
                 handleNoteOff(msg.getNoteNumber());
@@ -110,22 +129,36 @@ public:
         return ModuleBase::mapOutputChannel(raw);
     }
 
+    /** Current voice-steal strategy. Cheap enough to read per note-on from the audio thread. */
+    StealMode getStealMode() const noexcept { return static_cast<StealMode>(voiceStealParam->getIndex()); }
+
 private:
     static constexpr int MAX_VOICES = 8;
+
+    // Fixed PRNG seed for StealMode::Random. Re-applied in prepareToPlay so every render of a
+    // patch makes the same "random" choices — the whole point of issue #198.
+    static constexpr juce::int64 kStealSeed = 0x5EED0B01; // arbitrary — only its stability matters
 
     // Atomic voice mask written by the audio thread (processBlock), read by UI thread
     // (getActiveVoiceMask). No lock required — relaxed atomics suffice for a status display.
     std::atomic<uint8_t> voiceMaskAtomic_{0};
 
+    juce::AudioParameterChoice* voiceStealParam = nullptr;
+
     struct Voice {
         int note = -1;
         bool active = false;
-        juce::int64 lastUsedTime = 0;
+        juce::int64 lastUsedSample = 0;
         float currentFreq = 0.0f; // Store freq to hold it on NoteOff
         juce::SmoothedValue<float> smoothedGate;
         juce::SmoothedValue<float> smoothedFreq;
     };
     Voice voices[MAX_VOICES];
+
+    juce::int64 sampleCounter_ = 0; // samples elapsed since prepareToPlay
+    juce::int64 lastStamp_ = 0;     // last stamp handed out — keeps ages strictly increasing
+    int roundRobinCursor_ = 0;      // next voice StealMode::RoundRobin will take
+    juce::Random stealRandom_{kStealSeed};
 
     // Helper to render state to buffer
     void renderChunk(juce::AudioBuffer<float>& buffer, int startSample, int endSample) {
@@ -146,15 +179,15 @@ private:
         }
     }
 
-    void handleNoteOn(int note, float velocity) {
+    void handleNoteOn(int note, float velocity, juce::int64 eventSample) {
         juce::ignoreUnused(velocity);
-        juce::int64 now = juce::Time::getMillisecondCounter();
+        const juce::int64 now = stampFor(eventSample);
         float freq = juce::MidiMessage::getMidiNoteInHertz(note);
 
         // Try to find existing note to re-trigger
         for (int i = 0; i < MAX_VOICES; ++i) {
             if (voices[i].active && voices[i].note == note) {
-                voices[i].lastUsedTime = now;
+                voices[i].lastUsedSample = now;
                 voices[i].currentFreq = freq;
                 return;
             }
@@ -165,18 +198,44 @@ private:
             if (!voices[i].active) {
                 voices[i].note = note;
                 voices[i].active = true;
-                voices[i].lastUsedTime = now;
+                voices[i].lastUsedSample = now;
                 voices[i].currentFreq = freq;
                 return;
             }
         }
 
-        // Steal least recently used voice
-        int oldestIdx = findOldestVoiceIndex();
-        voices[oldestIdx].note = note;
-        voices[oldestIdx].active = true;
-        voices[oldestIdx].lastUsedTime = now;
-        voices[oldestIdx].currentFreq = freq;
+        // All eight voices are busy — the Voice Steal parameter decides which one loses its note.
+        int stealIdx = selectVoiceToSteal();
+        voices[stealIdx].note = note;
+        voices[stealIdx].active = true;
+        voices[stealIdx].lastUsedSample = now;
+        voices[stealIdx].currentFreq = freq;
+    }
+
+    // Voice ages must be strictly increasing, not merely non-decreasing: a chord whose notes share
+    // one sample offset would otherwise hand out equal stamps, and "least recently used" would
+    // collapse to "voice 0" for every note in it — the degenerate case from issue #198. Clamping to
+    // lastStamp_ + 1 keeps the ordering exact while staying deterministic.
+    juce::int64 stampFor(juce::int64 eventSample) noexcept {
+        lastStamp_ = std::max(eventSample, lastStamp_ + 1);
+        return lastStamp_;
+    }
+
+    int selectVoiceToSteal() noexcept {
+        switch (getStealMode()) {
+        case StealMode::RoundRobin: {
+            const int idx = roundRobinCursor_;
+            roundRobinCursor_ = (roundRobinCursor_ + 1) % MAX_VOICES;
+            return idx;
+        }
+        case StealMode::Random:
+            // Module-owned, fixed-seed PRNG advanced only here: the choice sounds random, but two
+            // renders of the same input steal identically.
+            return stealRandom_.nextInt(MAX_VOICES);
+        case StealMode::Oldest:
+        default:
+            return findOldestVoiceIndex();
+        }
     }
 
     void handleNoteOff(int note) {
@@ -196,11 +255,11 @@ private:
 
     int findOldestVoiceIndex() const {
         int oldestIdx = 0;
-        juce::int64 oldestTime = voices[0].lastUsedTime;
+        juce::int64 oldestTime = voices[0].lastUsedSample;
 
         for (int i = 1; i < MAX_VOICES; ++i) {
-            if (voices[i].lastUsedTime < oldestTime) {
-                oldestTime = voices[i].lastUsedTime;
+            if (voices[i].lastUsedSample < oldestTime) {
+                oldestTime = voices[i].lastUsedSample;
                 oldestIdx = i;
             }
         }

--- a/Source/PresetManager.cpp
+++ b/Source/PresetManager.cpp
@@ -51,7 +51,7 @@ juce::String PresetManager::getPresetJSON(int index) {
     //   Attenuverter:  40 x 40   (not a ModuleComponent; excluded from overlap check)
     //   Sequencer:   560 x 380   ← DOUBLE-wide (kDoubleWidth = 2 × kSingleWidth = 560)
     //   MIDI Keyboard: 560 x 150 ← DOUBLE-wide
-    //   Poly MIDI:   280 x 123
+    //   Poly MIDI:   280 x 171   ← +48 (one combo row) from the issue #198 Voice Steal selector
     //   Distortion:  280 x 355
     //   Delay:       280 x 269   ← +76 (one knob row) from the issue #122 Level knob
     //   Reverb:      280 x 269

--- a/Source/UI/GraphEditor.cpp
+++ b/Source/UI/GraphEditor.cpp
@@ -62,7 +62,7 @@ juce::Point<int> GraphEditor::estimateModuleSize(const juce::String& typeName) {
         typeName.containsIgnoreCase("MIDI Keyboard"))
         return {synth::LayoutUtil::kDoubleWidth, 150};
     if (typeName == "Poly MIDI" || typeName == "PolyMidi")
-        return {280, 123};
+        return {280, 171}; // +48 (one combo row) from the issue #198 Voice Steal selector
     if (typeName == "Distortion")
         return {280, 355};
     if (typeName == "Delay")

--- a/Tests/AIStateMapperTests.cpp
+++ b/Tests/AIStateMapperTests.cpp
@@ -1088,7 +1088,7 @@ TEST(AIStateMapperTest, ParamIdsGolden) {
                           "outputGain"},
         {"Phaser", "bypassed, centreFreq, depth, feedback, mix, muted, outputLevel, rate"},
         {"Pitch Shifter", "bypassed, feedback, fine, mix, muted, outputLevel, pitch, shiftHz, shiftMode, window"},
-        {"Poly MIDI", "bypassed"},
+        {"Poly MIDI", "bypassed, voiceSteal"},
         {"Poly Sequencer", "Gate 1, Gate 2, Gate 3, Gate 4, Gate 5, Gate 6, Gate 7, Gate 8, Step 1 Chord, Step 1 Root, "
                            "Step 2 Chord, Step 2 Root, Step 3 Chord, Step 3 Root, Step 4 Chord, Step 4 Root, "
                            "Step 5 Chord, Step 5 Root, Step 6 Chord, Step 6 Root, Step 7 Chord, Step 7 Root, "

--- a/Tests/AudioRenderingTests.cpp
+++ b/Tests/AudioRenderingTests.cpp
@@ -526,6 +526,59 @@ TEST_F(AudioRenderingTest, AllPresetsRenderNonSilent) {
 }
 
 // ===========================================================================
+// Test 8b: the "Poly Pad" preset renders identically twice (issue #198)
+//
+// Pushes an over-full chord through the real preset graph (MIDI Keyboard -> Poly MIDI -> 8-voice
+// Oscillator -> Filter -> VCA -> Reverb) — the path an offline bounce or a golden-render regression
+// would take — and requires the whole chain to be bit-reproducible.
+//
+// Scope, deliberately: this is a *forward* guard, not a detector for the original bug. Checked by
+// experiment — with voice age restored to juce::Time::getMillisecondCounter() this test still
+// passes 8/8, because every note here lands at one sample offset, so the buggy code degenerates
+// *consistently* (always voice 0) and both runs agree. What actually catches wall-clock stamping
+// is PolyMidiModuleTest.SameBlockNotesStealInArrivalOrder / OverfullChordInOneBlock…, which pin
+// *which* voice is stolen. This test's job is to fail if anything in the poly chain later
+// introduces nondeterminism (an unseeded PRNG, a clock read, uninitialised state).
+// ===========================================================================
+juce::AudioBuffer<float> renderPolyPadChord(int numNotes, int numBlocks) {
+    AudioEngine engine; // do NOT initialise() — that would open a real audio device
+    auto& graph = engine.getGraph();
+    graph.setPlayConfigDetails(0, 2, kSampleRate, kBlockSize);
+    synth::PresetManager::loadPreset(6, graph);
+    graph.prepareToPlay(kSampleRate, kBlockSize);
+
+    for (auto* node : graph.getNodes())
+        if (auto* kb = dynamic_cast<MidiKeyboardModule*>(node->getProcessor()))
+            for (int i = 0; i < numNotes; ++i)
+                kb->getKeyboardState().noteOn(1, 60 + i, 1.0f);
+
+    juce::AudioBuffer<float> result(2, numBlocks * kBlockSize);
+    result.clear();
+    for (int b = 0; b < numBlocks; ++b) {
+        juce::AudioBuffer<float> block(2, kBlockSize);
+        block.clear();
+        juce::MidiBuffer emptyMidi;
+        graph.processBlock(block, emptyMidi);
+        for (int ch = 0; ch < 2; ++ch)
+            result.copyFrom(ch, b * kBlockSize, block, ch, 0, kBlockSize);
+    }
+    return result;
+}
+
+TEST_F(AudioRenderingTest, PolyPadPresetRendersIdenticallyTwice) {
+    ASSERT_EQ(synth::PresetManager::getPresetNames()[6], "Poly Pad") << "preset index 6 moved";
+
+    const auto first = renderPolyPadChord(12, 20); // 12 notes into 8 voices — 4 steals
+    juce::Thread::sleep(3);                        // a wall-clock stamp would tick over here
+    const auto second = renderPolyPadChord(12, 20);
+
+    ASSERT_EQ(first.getNumSamples(), second.getNumSamples());
+    EXPECT_FALSE(TestAudioHelpers::isSilent(first, 0)) << "nothing was rendered, so nothing is proven";
+    EXPECT_EQ(TestAudioHelpers::compareBuffers(first, second), 0.0f)
+        << "the same chord must render bit-identically — voice stealing may not depend on wall-clock time";
+}
+
+// ===========================================================================
 // Test 9: ADSR envelope shape (attack/sustain/release phases)
 // ===========================================================================
 TEST_F(AudioRenderingTest, ADSREnvelopeShape) {

--- a/Tests/PolyMidiModuleTests.cpp
+++ b/Tests/PolyMidiModuleTests.cpp
@@ -1,5 +1,68 @@
 #include "Modules/PolyMidiModule.h"
 #include <gtest/gtest.h>
+#include <vector>
+
+namespace {
+
+constexpr int kBlockSize = 512;
+constexpr int kNumChannels = 16;
+
+float noteHz(int note) { return static_cast<float>(juce::MidiMessage::getMidiNoteInHertz(note)); }
+
+// The pitch/gate a voice is holding at the end of the last rendered block. Both are 5 ms-smoothed,
+// so reading the final sample of a 512-sample block gives the settled value.
+float voicePitch(const juce::AudioBuffer<float>& b, int voice) { return b.getSample(voice, b.getNumSamples() - 1); }
+
+// One MIDI event inside a block.
+struct Event {
+    int note;
+    int offset; // sample offset within the block
+    bool on;
+};
+
+void setStealMode(PolyMidiModule& m, PolyMidiModule::StealMode mode) {
+    auto* p = dynamic_cast<juce::AudioParameterChoice*>(findParameterByID(&m, "voiceSteal"));
+    ASSERT_NE(p, nullptr);
+    p->setValueNotifyingHost(p->convertTo0to1(static_cast<float>(static_cast<int>(mode))));
+}
+
+void pushBlock(PolyMidiModule& m, juce::AudioBuffer<float>& buffer, const std::vector<Event>& events) {
+    juce::MidiBuffer midi;
+    for (const auto& e : events)
+        midi.addEvent(e.on ? juce::MidiMessage::noteOn(1, e.note, 0.8f) : juce::MidiMessage::noteOff(1, e.note),
+                      e.offset);
+    m.processBlock(buffer, midi);
+}
+
+// Renders a fixed MIDI script through a freshly prepared module and returns every sample it
+// produced, so two runs of the same script can be compared sample for sample.
+std::vector<float> render(PolyMidiModule::StealMode mode, const std::vector<std::vector<Event>>& blocks) {
+    PolyMidiModule m;
+    m.prepareToPlay(44100.0, kBlockSize);
+    setStealMode(m, mode);
+
+    std::vector<float> out;
+    juce::AudioBuffer<float> buffer(kNumChannels, kBlockSize);
+    for (const auto& block : blocks) {
+        pushBlock(m, buffer, block);
+        for (int ch = 0; ch < kNumChannels; ++ch)
+            out.insert(out.end(), buffer.getReadPointer(ch), buffer.getReadPointer(ch) + kBlockSize);
+    }
+    return out;
+}
+
+// A >8-note chord (so voices get stolen) followed by more notes and some releases.
+std::vector<std::vector<Event>> stealScript() {
+    std::vector<Event> chord;
+    for (int i = 0; i < 12; ++i)
+        chord.push_back({60 + i, i * 8, true}); // 12 notes into 8 voices — 4 steals inside one block
+    return {chord,
+            {{72, 0, true}, {73, 64, true}, {74, 128, true}},
+            {{60, 0, false}, {61, 32, false}},
+            {{80, 0, true}, {81, 100, true}, {82, 200, true}, {83, 300, true}}};
+}
+
+} // namespace
 
 class PolyMidiModuleTest : public ::testing::Test {
 protected:
@@ -45,24 +108,121 @@ TEST_F(PolyMidiModuleTest, NoteOffDeactivatesVoice) {
 TEST_F(PolyMidiModuleTest, VoiceStealingLRU) {
     juce::AudioBuffer<float> buffer(16, 512);
 
-    // Switch on 8 voices
-    for (int i = 0; i < 8; ++i) {
-        juce::MidiBuffer midi;
-        midi.addEvent(juce::MidiMessage::noteOn(1, 60 + i, 0.8f), 0);
-        module->processBlock(buffer, midi);
-        juce::Thread::sleep(2); // Ensure timestamps differ
+    // Switch on 8 voices, one per block. No sleep needed: voice age is a sample counter, not the
+    // wall clock (issue #198).
+    for (int i = 0; i < 8; ++i)
+        pushBlock(*module, buffer, {{60 + i, 0, true}});
+
+    EXPECT_EQ(module->getActiveVoiceMask(), 0xFF);
+
+    // 9th note steals the least recently used voice — voice 0, which holds note 60.
+    pushBlock(*module, buffer, {{72, 0, true}});
+
+    EXPECT_EQ(module->getActiveVoiceMask(), 0xFF);
+    EXPECT_NEAR(voicePitch(buffer, 0), noteHz(72), 1.0f);
+    EXPECT_NEAR(voicePitch(buffer, 1), noteHz(61), 1.0f) << "only the oldest voice should be stolen";
+}
+
+// The parameter must default to the pre-#198 behaviour so patches saved without it load unchanged.
+TEST_F(PolyMidiModuleTest, VoiceStealDefaultsToOldest) {
+    EXPECT_EQ(module->getStealMode(), PolyMidiModule::StealMode::Oldest);
+
+    auto* p = dynamic_cast<juce::AudioParameterChoice*>(findParameterByID(module.get(), "voiceSteal"));
+    ASSERT_NE(p, nullptr);
+    EXPECT_EQ(p->choices, juce::StringArray({"Oldest", "Round-Robin", "Random"}));
+    EXPECT_EQ(p->getIndex(), 0);
+}
+
+// Issue #198's degenerate case: notes arriving inside a single block used to share one millisecond
+// stamp, so every steal in a chord hit voice 0. Sample-offset stamps order them correctly.
+TEST_F(PolyMidiModuleTest, SameBlockNotesStealInArrivalOrder) {
+    juce::AudioBuffer<float> buffer(16, 512);
+
+    for (int i = 0; i < 8; ++i)
+        pushBlock(*module, buffer, {{60 + i, 0, true}});
+    ASSERT_EQ(module->getActiveVoiceMask(), 0xFF);
+
+    // Three steals inside one block, at distinct sample offsets.
+    pushBlock(*module, buffer, {{72, 0, true}, {73, 64, true}, {74, 128, true}});
+
+    EXPECT_EQ(module->getActiveVoiceMask(), 0xFF);
+    EXPECT_NEAR(voicePitch(buffer, 0), noteHz(72), 1.0f);
+    EXPECT_NEAR(voicePitch(buffer, 1), noteHz(73), 1.0f);
+    EXPECT_NEAR(voicePitch(buffer, 2), noteHz(74), 1.0f);
+    EXPECT_NEAR(voicePitch(buffer, 3), noteHz(63), 1.0f) << "voice 3 was not old enough to be stolen";
+}
+
+// A chord larger than the voice count, delivered in one block, must also steal in arrival order.
+TEST_F(PolyMidiModuleTest, OverfullChordInOneBlockStealsInArrivalOrder) {
+    juce::AudioBuffer<float> buffer(16, 512);
+
+    std::vector<Event> chord;
+    for (int i = 0; i < 11; ++i)
+        chord.push_back({60 + i, i * 8, true}); // 11 notes, 8 voices → notes 60-62 get stolen
+
+    pushBlock(*module, buffer, chord);
+
+    EXPECT_EQ(module->getActiveVoiceMask(), 0xFF);
+    EXPECT_NEAR(voicePitch(buffer, 0), noteHz(68), 1.0f);
+    EXPECT_NEAR(voicePitch(buffer, 1), noteHz(69), 1.0f);
+    EXPECT_NEAR(voicePitch(buffer, 2), noteHz(70), 1.0f);
+    EXPECT_NEAR(voicePitch(buffer, 3), noteHz(63), 1.0f);
+}
+
+// The regression test for issue #198: identical input renders identically, every time.
+TEST_F(PolyMidiModuleTest, RenderIsDeterministicAcrossRuns) {
+    for (auto mode : {PolyMidiModule::StealMode::Oldest, PolyMidiModule::StealMode::RoundRobin,
+                      PolyMidiModule::StealMode::Random}) {
+        const auto first = render(mode, stealScript());
+        juce::Thread::sleep(3); // a wall-clock stamp would land in a different millisecond here
+        const auto second = render(mode, stealScript());
+
+        ASSERT_EQ(first.size(), second.size());
+        EXPECT_EQ(first, second) << "voice stealing must not depend on when the render happens";
     }
+}
 
-    EXPECT_EQ(module->getActiveVoiceMask(), 0xFF);
+TEST_F(PolyMidiModuleTest, RoundRobinCyclesVoicesInOrder) {
+    juce::AudioBuffer<float> buffer(16, 512);
+    setStealMode(*module, PolyMidiModule::StealMode::RoundRobin);
 
-    // Add 9th voice - should steal the first one (note 60)
-    juce::MidiBuffer midi;
-    midi.addEvent(juce::MidiMessage::noteOn(1, 72, 0.8f), 0);
-    module->processBlock(buffer, midi);
+    for (int i = 0; i < 8; ++i)
+        pushBlock(*module, buffer, {{60 + i, 0, true}});
 
-    // We can't easily check which one was stolen without exposing voices,
-    // but we can check if it stays at 8 active voices
-    EXPECT_EQ(module->getActiveVoiceMask(), 0xFF);
+    // Re-trigger note 60 so voice 0 is the *newest*: LRU would now steal voice 1 first, round-robin
+    // still starts at voice 0.
+    pushBlock(*module, buffer, {{60, 0, true}});
+    pushBlock(*module, buffer, {{80, 0, true}, {81, 64, true}, {82, 128, true}});
+
+    EXPECT_NEAR(voicePitch(buffer, 0), noteHz(80), 1.0f);
+    EXPECT_NEAR(voicePitch(buffer, 1), noteHz(81), 1.0f);
+    EXPECT_NEAR(voicePitch(buffer, 2), noteHz(82), 1.0f);
+
+    // The cursor keeps walking rather than restarting at the oldest voice.
+    pushBlock(*module, buffer, {{83, 0, true}});
+    EXPECT_NEAR(voicePitch(buffer, 3), noteHz(83), 1.0f);
+}
+
+// Random stealing is reproducible (asserted above for the render) *and* actually random: a
+// least-recently-used or round-robin walk visits each of the 8 voices exactly once over 8 steals,
+// so the eight stealing notes would all survive. A PRNG repeats and skips voices.
+TEST_F(PolyMidiModuleTest, RandomStealIsReproducibleButNotSequential) {
+    juce::AudioBuffer<float> buffer(16, 512);
+    setStealMode(*module, PolyMidiModule::StealMode::Random);
+
+    for (int i = 0; i < 8; ++i)
+        pushBlock(*module, buffer, {{60 + i, 0, true}});
+    for (int i = 0; i < 8; ++i)
+        pushBlock(*module, buffer, {{80 + i, 0, true}});
+
+    int survivingStealers = 0;
+    for (int v = 0; v < 8; ++v)
+        for (int n = 80; n < 88; ++n)
+            if (std::abs(voicePitch(buffer, v) - noteHz(n)) < 1.0f)
+                ++survivingStealers;
+
+    EXPECT_LT(survivingStealers, 8) << "random stealing should revisit some voices, unlike LRU/round-robin";
+    EXPECT_GT(survivingStealers, 0);
 }
 
 TEST_F(PolyMidiModuleTest, AllNotesOff) {

--- a/Tests/PolyMidiModuleTests.cpp
+++ b/Tests/PolyMidiModuleTests.cpp
@@ -169,7 +169,10 @@ TEST_F(PolyMidiModuleTest, OverfullChordInOneBlockStealsInArrivalOrder) {
     EXPECT_NEAR(voicePitch(buffer, 3), noteHz(63), 1.0f);
 }
 
-// The regression test for issue #198: identical input renders identically, every time.
+// Issue #198's headline property: identical input renders identically, every time. Note this alone
+// is a weak detector — wall-clock stamping fails it only when a millisecond boundary happens to
+// fall between the two runs. The tests above are the deterministic ones, because they pin *which*
+// voice gets stolen.
 TEST_F(PolyMidiModuleTest, RenderIsDeterministicAcrossRuns) {
     for (auto mode : {PolyMidiModule::StealMode::Oldest, PolyMidiModule::StealMode::RoundRobin,
                       PolyMidiModule::StealMode::Random}) {

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -216,7 +216,17 @@ Loads an audio file from disk and plays it back one of two ways.
 
 ## Poly MIDI Module
 - **Capacity**: 8 simultaneous voices.
-- **Allocation**: Least Recently Used (LRU) algorithm.
+- **Allocation**: a note-on re-uses the voice already holding that note, else the first free voice, else steals one per the **Voice Steal** parameter.
+- **Parameter**: `voiceSteal` — `Oldest` (default) | `Round-Robin` | `Random`.
+
+| Mode | Which voice loses its note |
+|---|---|
+| `Oldest` | Least recently used — the voice whose last note-on is furthest in the past. |
+| `Round-Robin` | The next voice in a 0→7 cycle, regardless of age. The cursor advances only on a steal. |
+| `Random` | A voice picked by a module-owned PRNG. |
+
+- **Voice ages are sample counts, never wall-clock time** (issue #198). `processBlock` advances a monotonic `sampleCounter_` (before the bypass check, so ages stay ordered across a bypass toggle) and each note-on is stamped with `blockStartSample + its MIDI sample offset`. Two consequences the module depends on: a chord delivered inside one block steals in arrival order rather than collapsing onto voice 0, and offline renders are reproducible. Stamps are additionally clamped to `lastStamp_ + 1` so notes sharing one sample offset still order strictly. `Random` seeds its `juce::Random` from a fixed constant in `prepareToPlay` and advances it only on a steal, so it too renders identically every run — **never** reintroduce `juce::Time`, `std::random_device`, or an unseeded PRNG on this path.
+- **Not yet handled** (tracked separately): note velocity is ignored, and a same-pitch retrigger updates the held frequency without producing a new gate edge, so back-to-back repeated notes don't re-articulate a downstream ADSR.
 - **Outputs**: 16 total channels — ch0-7 = per-voice pitch (Hz), ch8-15 = per-voice gate (0/1).
 - **Visible ports**: 1 output jack ("Poly Out") representing the entire poly bus.
 - **Voice mask atomic**: `voiceMaskAtomic_` (`std::atomic<uint8_t>`) is written at the end of every `processBlock` with `std::memory_order_relaxed` — one bit per voice (bit 0 = voice 0, … bit 7 = voice 7), set when `voices[i].active` is true. `AudioEngine::getDisplayVoiceCount()` reads it lock-free and counts set bits via `std::popcount` (C++20 `<bit>`).


### PR DESCRIPTION
## Summary

Fixes #198. `PolyMidiModule` stamped voices with `juce::Time::getMillisecondCounter()` on the audio thread, so voice stealing depended on *when* a render happened — and a chord arriving inside one block got identical millisecond stamps, collapsing "least recently used" onto voice 0. Voice age is now a monotonic sample counter, and the steal strategy is selectable.

## Changes

- **Sample-counter voice age.** `processBlock` advances a monotonic `sampleCounter_` (before the bypass check, so ages stay ordered across a bypass toggle) and each note-on is stamped with `blockStartSample + its MIDI sample offset`. Stamps are clamped to `lastStamp_ + 1` so notes sharing one sample offset still order strictly rather than tying on voice 0. No `juce::Time` / `std::random_device` anywhere on the audio path.
- **New `voiceSteal` parameter** (`juce::AudioParameterChoice`, "Voice Steal"): `Oldest` (default) | `Round-Robin` | `Random`.
  - `Oldest` is the pre-existing LRU behaviour, now deterministic. A patch saved before this parameter existed loads as `Oldest`, so existing patches are unchanged.
  - `Round-Robin` walks a 0→7 cursor, advanced only on a steal.
  - `Random` uses a module-owned `juce::Random` re-seeded from a fixed constant in `prepareToPlay` and advanced only on a steal — it sounds random, but two renders of the same input steal identically.
- **Card height 123 → 171** — the Voice Steal combo adds one row, so `GraphEditor::estimateModuleSize()` and the `PresetManager` size table were updated (pinned by `ModuleComponentTest.EstimatedModuleSizesMatchTheRealComponents`; preset layouts stay overlap-free, verified by `E2EWorkflowTest.AllPresetsLoadWithoutOverlapAsAuthored`).
- **`AIStateMapperTest.ParamIdsGolden`** row updated to `{"Poly MIDI", "bypassed, voiceSteal"}` after rebasing onto #199.
- **Docs**: `docs/modules.md` Poly MIDI section documents the parameter, the sample-counter rule, and the determinism requirement.

### Behaviour, measured

Holding notes 60–67, re-pressing 60 (so voice 0 is the *newest*), then adding notes 80–85 one at a time:

| after | v0 | v1 | v2 | v3 | v4 | v5 | v6 | v7 |
|---|---|---|---|---|---|---|---|---|
| 8 held | 60 | 61 | 62 | 63 | 64 | 65 | 66 | 67 |
| `Oldest` + 80 | 60 | **80** | 62 | 63 | 64 | 65 | 66 | 67 |
| `Round-Robin` + 80 | **80** | 61 | 62 | 63 | 64 | 65 | 66 | 67 |
| `Random` + 80…85 | 83 | 61 | 62 | 82 | 80 | 84 | 85 | 67 |

`Oldest` honours the re-press and spares voice 0; `Round-Robin` ignores age; `Random` revisits voices (v3 twice) and skips others (v7 untouched), identically on every run.

### Out of scope (agreed, tracked separately)

Velocity handling and same-pitch-retrigger gate edges — both listed in #198 as related gaps. Both audibly change existing patches, so they stay in the "poly note contract" follow-up.

## Test Plan

- [x] All existing tests pass — **1536/1536 green** (`./build/Tests/Tests`, run outside the sandbox), rebased onto #199
- [x] New tests added for new functionality:
  - `PolyMidiModuleTest.SameBlockNotesStealInArrivalOrder` — notes at offsets 0/64/128 in one block steal voices 0, 1, 2 in order
  - `PolyMidiModuleTest.OverfullChordInOneBlockStealsInArrivalOrder` — an 11-note chord in a single block steals in arrival order
  - `PolyMidiModuleTest.RoundRobinCyclesVoicesInOrder` — cursor order, set up so LRU would pick differently
  - `PolyMidiModuleTest.RandomStealIsReproducibleButNotSequential` — reproducible under a fixed seed, and demonstrably not an LRU/round-robin walk
  - `PolyMidiModuleTest.RenderIsDeterministicAcrossRuns` — the same script rendered twice is sample-identical, for all three modes
  - `PolyMidiModuleTest.VoiceStealDefaultsToOldest` — default index/choices pinned for patch compatibility
  - `AudioRenderingTest.PolyPadPresetRendersIdenticallyTwice` — a 12-note chord through the real "Poly Pad" preset graph (MIDI Keyboard → Poly MIDI → Oscillator → Filter → VCA → Reverb) renders bit-identically twice
  - `VoiceStealingLRU` — the old test's `Thread::sleep(2)` is gone (age no longer depends on wall time) and it now asserts *which* voice was stolen
- [x] Verified the tests actually catch the bug — reverting `stampFor()` to `getMillisecondCounter()` fails the two same-block ordering tests deterministically. Worth knowing about the other two: `RenderIsDeterministicAcrossRuns` fails only intermittently under wall-clock (it needs a millisecond boundary to fall between the runs), and `PolyPadPresetRendersIdenticallyTwice` passed 8/8 against the buggy code, because every note there lands at one sample offset so the bug degenerates *consistently*. Both are forward guards against future nondeterminism; the ordering tests are the real detectors. That reasoning is written into the test comments so nobody mistakes their scope later.
- [x] Tested locally (build + run) — full `cmake --build build` including the `AgentSynth` GUI target; `clang-format` (pinned 22.1.2) clean
- [x] Documentation updated — `docs/modules.md`

Manually confirmed in the app: the Voice Steal selector renders on the Poly MIDI card and survives a save/load round-trip. Not confirmed by ear through an audio device — that needs MIDI input hardware we didn't have to hand.

## Screenshots

n/a — the Voice Steal selector uses the generic `AudioParameterChoice` combo path; the card's real height is pinned by test.
