### PR TITLE
Node-preserving structural undo/redo

### DIFF
--- a/Source/AI/AIStateMapper.cpp
+++ b/Source/AI/AIStateMapper.cpp
@@ -35,8 +35,10 @@
 #include <functional> // For std::function
 #include <limits>
 #include <map>
+#include <optional>
 #include <set>
 #include <unordered_map> // For the factory map
+#include <vector>
 
 namespace synth {
 
@@ -890,7 +892,19 @@ int AIStateMapper::findChoiceIndex(juce::AudioParameterChoice* p, const juce::St
 }
 
 void AIStateMapper::applyParamsToProcessor(juce::AudioProcessor* processor, const juce::DynamicObject* paramsObj,
-                                           bool trusted) {
+                                           bool trusted, bool skipUnchanged) {
+    // Writing a parameter that already holds the target value is not a no-op: setValueNotifyingHost
+    // notifies its listeners unconditionally, and one of ours re-anchors a module's cables when
+    // "poly" changes — i.e. it mutates the graph. A snapshot restore re-applies every parameter of
+    // every surviving node, so for that caller the redundant writes are the overwhelming majority.
+    // The tolerance only has to absorb the float round-trip through the JSON's denormalized value;
+    // it is orders of magnitude below any parameter step a user or a model can express.
+    auto setNormalised = [skipUnchanged](juce::RangedAudioParameter* p, float normalised) {
+        if (skipUnchanged && std::abs(p->getValue() - normalised) <= 1.0e-6f)
+            return;
+        p->setValueNotifyingHost(normalised);
+    };
+
     for (auto* param : processor->getParameters()) {
         if (auto* p = dynamic_cast<juce::RangedAudioParameter*>(param)) {
             if (paramsObj->hasProperty(p->paramID)) {
@@ -900,15 +914,15 @@ void AIStateMapper::applyParamsToProcessor(juce::AudioProcessor* processor, cons
                     if (jsonValue.isString()) {
                         int index = findChoiceIndex(choice, jsonValue.toString());
                         if (index >= 0) {
-                            p->setValueNotifyingHost(p->getNormalisableRange().convertTo0to1((float)index));
+                            setNormalised(p, p->getNormalisableRange().convertTo0to1((float)index));
                         }
                     } else {
                         auto choiceRange = p->getNormalisableRange();
                         float val = choiceRange.snapToLegalValue((float)jsonValue);
-                        p->setValueNotifyingHost(choiceRange.convertTo0to1(val));
+                        setNormalised(p, choiceRange.convertTo0to1(val));
                     }
                 } else if (auto* b = dynamic_cast<juce::AudioParameterBool*>(p)) {
-                    b->setValueNotifyingHost((bool)jsonValue ? 1.0f : 0.0f);
+                    setNormalised(b, (bool)jsonValue ? 1.0f : 0.0f);
                 } else {
                     float val = (float)jsonValue;
                     auto range = p->getNormalisableRange();
@@ -925,8 +939,7 @@ void AIStateMapper::applyParamsToProcessor(juce::AudioProcessor* processor, cons
                     }
 
                     val = range.snapToLegalValue(val);
-                    float normalizedValue = range.convertTo0to1(val);
-                    p->setValueNotifyingHost(normalizedValue);
+                    setNormalised(p, range.convertTo0to1(val));
                 }
             }
         }
@@ -1323,6 +1336,299 @@ bool AIStateMapper::applyJSONToGraph(const juce::var& json, juce::AudioProcessor
                 }
             }
         }
+    }
+
+    return true;
+}
+
+namespace {
+
+/**
+ * One node of a snapshot, resolved far enough that the whole restore can be planned before the
+ * graph is touched at all. After planning, either `kept`/`liveId` names the live node this entry
+ * updates in place, or `created` holds the processor waiting to be added.
+ */
+struct SnapshotTargetNode {
+    const juce::DynamicObject* obj = nullptr;
+    juce::uint32 id = 0;
+    juce::String uuid;
+    juce::String type;
+    bool kept = false;
+    // Node IDENTITY, never a cached Node*: applying a parameter to a node that is already in the
+    // graph runs its listeners synchronously, and one of them re-anchors the module's cables — so
+    // any Node* held across that call can dangle. Everything below re-resolves through the graph.
+    bool hasLiveId = false;
+    juce::AudioProcessorGraph::NodeID liveId;
+    std::unique_ptr<juce::AudioProcessor> created;
+};
+
+/** A snapshot connection with both endpoints resolved to indices into the target-node vector. */
+struct SnapshotTargetConnection {
+    size_t srcIndex = 0;
+    size_t dstIndex = 0;
+    int srcPort = 0;
+    int dstPort = 0;
+};
+
+// Re-applies a node's non-parameter state ONLY when it differs from what the module already holds.
+// setExtraState is not a cheap setter — SamplerModule and WavetableOscillatorModule read a file off
+// disk from it — so a restore that re-applied it unconditionally would reload every sample and every
+// wavetable on every single Cmd+Z.
+void applyExtraStateIfChanged(juce::AudioProcessor* processor, const juce::DynamicObject* nObj) {
+    if (!nObj->hasProperty("state"))
+        return;
+    auto* mb = dynamic_cast<ModuleBase*>(processor);
+    if (mb == nullptr)
+        return;
+
+    const juce::var target = nObj->getProperty("state");
+    if (juce::JSON::toString(mb->getExtraState()) == juce::JSON::toString(target))
+        return;
+
+    mb->setExtraState(target);
+}
+
+// Copies the snapshot's stored canvas position onto a live node, if it carries one.
+void applyPositionToNode(juce::AudioProcessorGraph::Node* node, const juce::DynamicObject* nObj) {
+    if (auto* posObj = nObj->getProperty("position").getDynamicObject()) {
+        node->properties.set("x", posObj->getProperty("x"));
+        node->properties.set("y", posObj->getProperty("y"));
+    }
+}
+
+} // namespace
+
+bool AIStateMapper::applySnapshotPreservingNodes(const juce::var& snapshot, juce::AudioProcessorGraph& graph,
+                                                 std::function<void()> beforeNodeRemoval) {
+    auto* rootObj = snapshot.isObject() ? snapshot.getDynamicObject() : nullptr;
+    if (rootObj == nullptr)
+        return false;
+
+    // A merge delta describes a CHANGE, not a target state: there is nothing to diff a live graph
+    // against, so it is not something this entry point can restore.
+    if (rootObj->hasProperty("remove") || rootObj->hasProperty("removeModulations"))
+        return false;
+
+    const auto* nodesList = rootObj->hasProperty("nodes") ? rootObj->getProperty("nodes").getArray() : nullptr;
+    const auto* connList =
+        rootObj->hasProperty("connections") ? rootObj->getProperty("connections").getArray() : nullptr;
+    if (nodesList == nullptr || connList == nullptr)
+        return false;
+
+    // ---------------------------------------------------------------------------------------
+    // Plan. Nothing below this block mutates the graph, so every rejection here leaves the graph
+    // exactly as it was and the caller's full-rebuild fallback starts from a clean slate.
+    // ---------------------------------------------------------------------------------------
+
+    // Live nodes, indexed by identity. A node with no uuid, or a uuid two nodes share, means
+    // identity cannot be decided — give up rather than guess which node the snapshot meant.
+    std::map<juce::String, juce::AudioProcessorGraph::Node*> liveByUuid;
+    for (auto* node : graph.getNodes()) {
+        if (node->getProcessor() == nullptr)
+            return false;
+        const juce::String uuid = node->properties["uuid"].toString();
+        if (uuid.isEmpty() || !liveByUuid.emplace(uuid, node).second)
+            return false;
+    }
+
+    std::vector<SnapshotTargetNode> targets;
+    targets.reserve(static_cast<size_t>(nodesList->size()));
+    std::set<juce::String> targetUuids;
+    std::set<juce::uint32> targetIds;
+    std::map<juce::uint32, size_t> targetIndexById;
+
+    for (const auto& nVar : *nodesList) {
+        const auto* nObj = nVar.getDynamicObject();
+        if (nObj == nullptr)
+            return false;
+
+        SnapshotTargetNode t;
+        t.obj = nObj;
+        if (!extractUnsignedInt(nObj->getProperty("id"), t.id))
+            return false;
+
+        t.uuid = nObj->getProperty("uuid").toString();
+        t.type = nObj->getProperty("type").toString();
+        if (t.uuid.isEmpty() || t.type.isEmpty())
+            return false;
+        if (!targetUuids.insert(t.uuid).second || !targetIds.insert(t.id).second)
+            return false;
+
+        const auto liveEntry = liveByUuid.find(t.uuid);
+        if (liveEntry != liveByUuid.end()) {
+            // The same identity must still name the same module. A uuid whose type changed is a
+            // corrupt snapshot, not an update-in-place — and patchTypeMatchesProcessor is what
+            // knows that an "Amp Env" processor legitimately serializes as type "ADSR".
+            if (!patchTypeMatchesProcessor(liveEntry->second->getProcessor(), t.type))
+                return false;
+            t.kept = true;
+            t.hasLiveId = true;
+            t.liveId = liveEntry->second->nodeID;
+        } else {
+            t.created = createModule(t.type);
+            if (t.created == nullptr)
+                return false;
+        }
+
+        targetIndexById[t.id] = targets.size();
+        targets.push_back(std::move(t));
+    }
+
+    std::vector<SnapshotTargetConnection> targetConnections;
+    targetConnections.reserve(static_cast<size_t>(connList->size()));
+
+    for (const auto& cVar : *connList) {
+        const auto* cObj = cVar.getDynamicObject();
+        if (cObj == nullptr)
+            return false;
+        if (!cObj->hasProperty("srcPort") || !cObj->hasProperty("dstPort"))
+            return false;
+
+        juce::uint32 srcId = 0, dstId = 0;
+        if (!extractUnsignedInt(cObj->getProperty("src"), srcId) ||
+            !extractUnsignedInt(cObj->getProperty("dst"), dstId))
+            return false;
+
+        const auto srcEntry = targetIndexById.find(srcId);
+        const auto dstEntry = targetIndexById.find(dstId);
+        if (srcEntry == targetIndexById.end() || dstEntry == targetIndexById.end())
+            return false;
+
+        SnapshotTargetConnection c;
+        c.srcIndex = srcEntry->second;
+        c.dstIndex = dstEntry->second;
+        c.srcPort = static_cast<int>(cObj->getProperty("srcPort"));
+        c.dstPort = static_cast<int>(cObj->getProperty("dstPort"));
+        if (c.srcPort == -1)
+            c.srcPort = juce::AudioProcessorGraph::midiChannelIndex;
+        if (c.dstPort == -1)
+            c.dstPort = juce::AudioProcessorGraph::midiChannelIndex;
+        targetConnections.push_back(c);
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Execute. Every topology op is issued with UpdateKind::none and the render sequence is
+    // rebuilt exactly once at the end, so a mixed restore pays for the rebuild once instead of
+    // once per node and per wire — and a restore that changes no topology pays nothing at all.
+    // No graph callback lock is taken: parameter stores are atomic, and JUCE's graph publishes
+    // topology to the audio thread through its own render-sequence exchange.
+    //
+    // Parameters go FIRST and all structure is reconciled after them, because a parameter write
+    // can re-enter and change the graph (ModuleComponent re-anchors a module's cables when "poly"
+    // flips). Reconciling afterwards means such a rewire is just more state for the diff to
+    // correct, instead of a hazard the plan has to anticipate.
+    // ---------------------------------------------------------------------------------------
+    bool topologyChanged = false;
+    bool teardownNotified = false;
+    auto notifyBeforeNodeRemoval = [&beforeNodeRemoval, &teardownNotified] {
+        if (teardownNotified)
+            return;
+        teardownNotified = true;
+        if (beforeNodeRemoval)
+            beforeNodeRemoval();
+    };
+    auto resolve = [&graph](const SnapshotTargetNode& t) {
+        return t.hasLiveId ? graph.getNodeForId(t.liveId) : nullptr;
+    };
+
+    // 1. Kept nodes: parameters, extra state and position updated in place. No lock is held across
+    //    this loop, so the audio callback keeps running through it.
+    for (auto& t : targets) {
+        if (!t.kept)
+            continue;
+
+        if (auto* live = resolve(t))
+            if (auto* pObj = t.obj->getProperty("params").getDynamicObject())
+                applyParamsToProcessor(live->getProcessor(), pObj, /*trusted=*/true, /*skipUnchanged=*/true);
+        if (auto* live = resolve(t))
+            applyExtraStateIfChanged(live->getProcessor(), t.obj);
+        if (auto* live = resolve(t))
+            applyPositionToNode(live, t.obj);
+    }
+
+    // 2. Drop every live node the snapshot does not contain. Their processors — and every UI object
+    //    reading them — die here, which is why the caller gets its one chance to detach first. The
+    //    set is recomputed from the live graph rather than taken from the plan, so a node that a
+    //    re-entrant rewire created above (it has no uuid) is swept up too.
+    std::vector<juce::AudioProcessorGraph::NodeID> doomed;
+    for (auto* node : graph.getNodes())
+        if (targetUuids.count(node->properties["uuid"].toString()) == 0)
+            doomed.push_back(node->nodeID);
+
+    if (!doomed.empty()) {
+        notifyBeforeNodeRemoval();
+        for (auto nodeId : doomed)
+            graph.removeNode(nodeId, juce::AudioProcessorGraph::UpdateKind::none);
+        topologyChanged = true;
+    }
+
+    // 3. Create every snapshot node the graph now lacks, re-adopting the snapshot's node id when it
+    //    is free so ids stay stable across the restore (a merge-mode patch card addresses existing
+    //    nodes by uid). Removals ran first precisely so those ids are available. Identity is
+    //    re-derived from the live graph, so a node destroyed by a re-entrant rewire is rebuilt here.
+    std::map<juce::String, juce::AudioProcessorGraph::NodeID> liveIdByUuid;
+    for (auto* node : graph.getNodes())
+        liveIdByUuid[node->properties["uuid"].toString()] = node->nodeID;
+
+    for (auto& t : targets) {
+        const auto liveEntry = liveIdByUuid.find(t.uuid);
+        if (liveEntry != liveIdByUuid.end()) {
+            t.hasLiveId = true;
+            t.liveId = liveEntry->second;
+            continue;
+        }
+
+        t.hasLiveId = false;
+        auto processor = t.created != nullptr ? std::move(t.created) : createModule(t.type);
+        if (processor == nullptr)
+            continue;
+
+        if (auto* pObj = t.obj->getProperty("params").getDynamicObject())
+            applyParamsToProcessor(processor.get(), pObj, /*trusted=*/true);
+        applyExtraStateToProcessor(processor.get(), t.obj, /*trusted=*/true);
+
+        std::optional<juce::AudioProcessorGraph::NodeID> preservedId;
+        const juce::AudioProcessorGraph::NodeID wantedId(t.id);
+        if (t.id > 0 && graph.getNodeForId(wantedId) == nullptr)
+            preservedId = wantedId;
+
+        auto node = graph.addNode(std::move(processor), preservedId, juce::AudioProcessorGraph::UpdateKind::none);
+        topologyChanged = true;
+        if (node == nullptr)
+            continue; // Unreachable in practice (the id was checked free); wires to it are skipped below.
+
+        t.hasLiveId = true;
+        t.liveId = node->nodeID;
+        node->properties.set("uuid", t.uuid);
+        applyPositionToNode(node.get(), t.obj);
+    }
+
+    // 4. Connections: apply the delta only. A restore that changed no wiring issues no graph
+    //    topology call here, which is what keeps a parameter-only undo free of any rebuild.
+    std::set<juce::AudioProcessorGraph::Connection> wanted;
+    for (const auto& c : targetConnections) {
+        auto* src = resolve(targets[c.srcIndex]);
+        auto* dst = resolve(targets[c.dstIndex]);
+        if (src == nullptr || dst == nullptr)
+            continue;
+        wanted.insert({{src->nodeID, c.srcPort}, {dst->nodeID, c.dstPort}});
+    }
+
+    for (const auto& conn : graph.getConnections()) {
+        if (wanted.count(conn) == 0) {
+            graph.removeConnection(conn, juce::AudioProcessorGraph::UpdateKind::none);
+            topologyChanged = true;
+        }
+    }
+
+    for (const auto& conn : wanted) {
+        if (!graph.isConnected(conn) && graph.addConnection(conn, juce::AudioProcessorGraph::UpdateKind::none))
+            topologyChanged = true;
+    }
+
+    if (topologyChanged) {
+        graph.rebuild();
+        graph.sendChangeMessage(); // Suppressed per-op above; announced once here instead.
     }
 
     return true;

--- a/Source/AI/AIStateMapper.h
+++ b/Source/AI/AIStateMapper.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <functional>
 #include <juce_audio_processors/juce_audio_processors.h>
 #include <juce_core/juce_core.h>
 #include <memory>
@@ -123,6 +124,45 @@ public:
                                  bool trusted = false, bool autoConnectNewNodes = true);
 
     /**
+     * @brief Restores one of OUR OWN graphToJSON snapshots by diffing it against the live graph.
+     *
+     * The undo/redo path only. applyJSONToGraph(clearExisting=true) reaches the same end state by
+     * destroying and re-creating every node, which throws away all module runtime state (sequencer
+     * step, envelope stage, sounding voices), and does it while holding the graph callback lock.
+     * This entry point instead computes the difference and touches only what actually changed:
+     * an undo of a parameter-only edit performs ZERO topology operations, so JUCE never rebuilds
+     * its render sequence and the audio callback never blocks.
+     *
+     * Node identity is the per-node "uuid" (see graphToJSON) — NOT the integer "id", which merge
+     * mode renumbers. A live node whose uuid appears in the snapshot is KEPT and updated in place;
+     * one whose uuid is absent is removed; a snapshot node with no live match is created (adopting
+     * both its uuid and, when free, its original id).
+     *
+     * Everything is planned before anything is mutated, and the function returns false WITHOUT
+     * having touched the graph whenever identity cannot be established with certainty — a live or
+     * snapshot node with no uuid, a duplicate uuid or id, a uuid whose type no longer matches the
+     * live processor, an unknown module type, a connection naming a node the snapshot does not
+     * define, or a merge delta ("remove"/"removeModulations") rather than a full snapshot. The
+     * caller must then fall back to applyJSONToGraph(..., clearExisting=true, trusted=true), which
+     * is always correct.
+     *
+     * The snapshot's "modulations" array is ignored on purpose: in a graphToJSON snapshot it is
+     * derived from the attenuverter nodes and their wires, both of which are already carried
+     * verbatim by "nodes" and "connections". For the same reason no auto-promotion, auto-connect
+     * or value rescaling happens here — a snapshot is reproduced exactly, not interpreted.
+     *
+     * @param beforeNodeRemoval Invoked at most once, immediately before the first node is removed,
+     *        i.e. before any processor is freed. This is the caller's only chance to detach UI that
+     *        points into those processors (GraphEditor::detachAllModuleComponents). It is NOT
+     *        called when the restore removes no nodes, which is exactly when the UI has nothing to
+     *        detach from and can keep its components.
+     *
+     * @return true if the snapshot was applied; false if the caller must fall back (graph untouched).
+     */
+    static bool applySnapshotPreservingNodes(const juce::var& snapshot, juce::AudioProcessorGraph& graph,
+                                             std::function<void()> beforeNodeRemoval = {});
+
+    /**
      * @brief Validates a patch JSON without applying it, returning a reason on failure.
      *
      * @param graph existing graph the patch would be applied to — used in merge mode
@@ -174,8 +214,12 @@ private:
      */
     static int findChoiceIndex(juce::AudioParameterChoice* p, const juce::String& choiceText);
 
+    // skipUnchanged suppresses writes to parameters that already hold the target value. Only for
+    // processors that are already IN the graph: setValueNotifyingHost notifies unconditionally, and
+    // some listeners mutate the graph (ModuleComponent re-anchors a module's cables when "poly"
+    // changes), so re-applying a whole snapshot's worth of no-op writes is not free.
     static void applyParamsToProcessor(juce::AudioProcessor* processor, const juce::DynamicObject* paramsObj,
-                                       bool trusted = false);
+                                       bool trusted = false, bool skipUnchanged = false);
 
     // Feeds a node's "state" property back into ModuleBase::setExtraState — trusted callers only.
     static void applyExtraStateToProcessor(juce::AudioProcessor* processor, const juce::DynamicObject* nodeObj,

--- a/Source/AppUndoManager.cpp
+++ b/Source/AppUndoManager.cpp
@@ -22,22 +22,10 @@ public:
             return true;
         }
 
-        if (preRestore)
-            preRestore();
-        synth::AIStateMapper::applyJSONToGraph(afterState, graph, true, true);
-        if (postRestore)
-            postRestore();
-        return true;
+        return restore(afterState);
     }
 
-    bool undo() override {
-        if (preRestore)
-            preRestore();
-        synth::AIStateMapper::applyJSONToGraph(beforeState, graph, true, true);
-        if (postRestore)
-            postRestore();
-        return true;
-    }
+    bool undo() override { return restore(beforeState); }
 
     int getSizeInUnits() override {
         return static_cast<int>(
@@ -45,6 +33,42 @@ public:
     }
 
 private:
+    /**
+     * Restores one snapshot, keeping every node the target state still contains.
+     *
+     * The node-preserving apply is tried first: it reaches the same state by diffing, so modules
+     * that survive the edit keep their processor instance and all its runtime state (sequencer
+     * position, envelope stage, sounding voices) and an undo of a parameter-only change performs
+     * no topology operation at all. It refuses — without touching the graph — any snapshot whose
+     * node identities it cannot establish, and then the original destroy-and-rebuild apply runs,
+     * which is always correct.
+     *
+     * preRestore is what detaches graph-referencing UI before processors are freed, so it fires
+     * lazily: on the fallback (which frees everything) and, on the preserving path, only if a node
+     * is actually being removed. When nothing is freed there is nothing to detach from, and
+     * GraphEditor::updateComponents reconciles the rest — so a parameter-only undo no longer
+     * destroys and re-creates every ModuleComponent either.
+     */
+    bool restore(const juce::var& state) {
+        bool preRestoreFired = false;
+        auto firePreRestore = [this, &preRestoreFired] {
+            if (preRestoreFired)
+                return;
+            preRestoreFired = true;
+            if (preRestore)
+                preRestore();
+        };
+
+        if (!synth::AIStateMapper::applySnapshotPreservingNodes(state, graph, firePreRestore)) {
+            firePreRestore();
+            synth::AIStateMapper::applyJSONToGraph(state, graph, true, true);
+        }
+
+        if (postRestore)
+            postRestore();
+        return true;
+    }
+
     juce::var beforeState;
     juce::var afterState;
     juce::AudioProcessorGraph& graph;

--- a/Tests/UndoRedoTests.cpp
+++ b/Tests/UndoRedoTests.cpp
@@ -3,6 +3,7 @@
 #include "../Source/Modules/ADSRModule.h"
 #include "../Source/Modules/AttenuverterModule.h"
 #include "../Source/Modules/FilterModule.h"
+#include "../Source/Modules/ModuleBase.h"
 #include "../Source/Modules/OscillatorModule.h"
 #include "../Source/Modules/VCAModule.h"
 #include "../Source/PresetManager.h"
@@ -12,6 +13,8 @@
 #include <juce_audio_processors/juce_audio_processors.h>
 #include <juce_gui_basics/juce_gui_basics.h>
 #include <map>
+#include <set>
+#include <vector>
 
 class UndoRedoTest : public ::testing::Test {
 protected:
@@ -20,6 +23,411 @@ protected:
 
     void SetUp() override { graph.clear(); }
 };
+
+// =============================================================================
+// Node-preserving (diffing) restore — see AIStateMapper::applySnapshotPreservingNodes.
+//
+// A structural undo used to destroy and re-create EVERY node, losing all module runtime state and
+// blocking the audio callback while it did so. The restore now diffs the snapshot against the live
+// graph, so the tests below are about IDENTITY, not just about the graph ending up the right shape.
+// =============================================================================
+
+namespace {
+
+/** Property no snapshot carries, so it survives a kept node and vanishes with a re-created one. */
+const juce::Identifier kSurvivorTag("undoRedoTestSurvivorTag");
+
+void tagLiveNodes(juce::AudioProcessorGraph& g) {
+    for (auto* node : g.getNodes())
+        node->properties.set(kSurvivorTag, 1);
+}
+
+int countTaggedNodes(juce::AudioProcessorGraph& g) {
+    int n = 0;
+    for (auto* node : g.getNodes())
+        if (node->properties.contains(kSurvivorTag))
+            ++n;
+    return n;
+}
+
+/**
+ * Address-reuse-proof fingerprint of who is in the graph. Pointer sets alone can lie — a freed
+ * node can be replaced at the same address — so the tag set is compared alongside them.
+ */
+struct GraphIdentity {
+    std::set<const void*> nodes;
+    std::set<const void*> processors;
+    std::set<juce::uint32> ids;
+    std::set<juce::String> uuids;
+    std::set<juce::AudioProcessorGraph::Connection> connections;
+
+    bool operator==(const GraphIdentity& o) const {
+        return nodes == o.nodes && processors == o.processors && ids == o.ids && uuids == o.uuids &&
+               connections == o.connections;
+    }
+};
+
+GraphIdentity captureIdentity(juce::AudioProcessorGraph& g) {
+    GraphIdentity id;
+    for (auto* node : g.getNodes()) {
+        id.nodes.insert(node);
+        id.processors.insert(node->getProcessor());
+        id.ids.insert(node->nodeID.uid);
+        id.uuids.insert(node->properties["uuid"].toString());
+    }
+    for (const auto& c : g.getConnections())
+        id.connections.insert(c);
+    return id;
+}
+
+juce::String uuidOf(juce::AudioProcessorGraph::Node* node) { return node->properties["uuid"].toString(); }
+
+/**
+ * Stamps a uuid onto every live node. graphToJSON generates them lazily and writes them back, so
+ * in the app the snapshot AppUndoManager takes before a mutation is what does this; a test that
+ * wants to fingerprint identity before the first snapshot has to ask for it explicitly.
+ */
+void stampUuids(juce::AudioProcessorGraph& g) { synth::AIStateMapper::graphToJSON(g); }
+
+juce::RangedAudioParameter* findParam(juce::AudioProcessor* processor, const juce::String& paramId) {
+    for (auto* param : processor->getParameters())
+        if (auto* p = dynamic_cast<juce::AudioProcessorParameterWithID*>(param))
+            if (p->paramID == paramId)
+                return dynamic_cast<juce::RangedAudioParameter*>(param);
+    return nullptr;
+}
+
+/** Counts how many times the graph announced a topology change. */
+class TopologyChangeCounter : public juce::ChangeListener {
+public:
+    void changeListenerCallback(juce::ChangeBroadcaster*) override { ++count; }
+    int count = 0;
+};
+
+void pumpMessageLoop(int ms = 30) { juce::MessageManager::getInstance()->runDispatchLoopUntil(ms); }
+
+/** ModuleBase stand-in that records how often its non-parameter state is written. */
+class ExtraStateProbeModule : public ModuleBase {
+public:
+    ExtraStateProbeModule()
+        : ModuleBase("Oscillator", 1, 1) {}
+
+    void prepareToPlay(double, int) override {}
+    void processBlock(juce::AudioBuffer<float>&, juce::MidiBuffer&) override {}
+    ModuleType getModuleType() const override { return ModuleType::Oscillator; }
+
+    juce::var getExtraState() const override {
+        juce::DynamicObject::Ptr state = new juce::DynamicObject();
+        state->setProperty("token", token);
+        return juce::var(state.get());
+    }
+
+    void setExtraState(const juce::var& state) override {
+        ++setExtraStateCalls;
+        if (auto* obj = state.getDynamicObject())
+            token = obj->getProperty("token").toString();
+    }
+
+    juce::String token{"a"};
+    int setExtraStateCalls = 0;
+};
+
+} // namespace
+
+/**
+ * A parameter-only undo must keep every module instance alive. This is the whole point of the
+ * diffing restore: a re-created Sequencer forgets its step, a re-created ADSR forgets its stage,
+ * and a re-created hosted plugin would have to be re-instantiated from its binary.
+ */
+TEST_F(UndoRedoTest, ParamOnlyUndoPreservesNodeInstances) {
+    auto* osc = graph.addNode(std::make_unique<OscillatorModule>()).get();
+    auto* filter = graph.addNode(std::make_unique<FilterModule>()).get();
+    graph.addConnection({{osc->nodeID, 0}, {filter->nodeID, 0}});
+
+    auto* fine = findParam(osc->getProcessor(), "fine");
+    ASSERT_NE(fine, nullptr);
+    const float originalNormalised = fine->getValue();
+
+    undoManager.captureBeforeState(graph); // Assigns uuids to every live node.
+    tagLiveNodes(graph);
+    const auto before = captureIdentity(graph);
+
+    fine->setValueNotifyingHost(0.75f);
+    undoManager.pushSnapshotFromCapture(graph);
+    ASSERT_TRUE(undoManager.canUndo());
+
+    ASSERT_TRUE(undoManager.undo());
+    EXPECT_NEAR(fine->getValue(), originalNormalised, 0.001f);
+    EXPECT_EQ(countTaggedNodes(graph), 2) << "a parameter undo must not destroy and re-create any node";
+    EXPECT_TRUE(captureIdentity(graph) == before) << "node instances, ids, uuids and wiring must all survive";
+
+    ASSERT_TRUE(undoManager.redo());
+    EXPECT_NEAR(fine->getValue(), 0.75f, 0.001f);
+    EXPECT_EQ(countTaggedNodes(graph), 2) << "a parameter redo must not destroy and re-create any node either";
+    EXPECT_TRUE(captureIdentity(graph) == before);
+}
+
+/**
+ * The acceptance criterion behind issue #197: a parameter-only undo performs ZERO topology
+ * operations, so JUCE never rebuilds its render sequence and the audio callback never blocks.
+ * The graph announces every topology change to its ChangeBroadcaster, so a silent restore is
+ * observable as zero change messages.
+ */
+TEST_F(UndoRedoTest, ParamOnlyUndoPerformsNoTopologyOperations) {
+    auto* osc = graph.addNode(std::make_unique<OscillatorModule>()).get();
+    auto* filter = graph.addNode(std::make_unique<FilterModule>()).get();
+    graph.addConnection({{osc->nodeID, 0}, {filter->nodeID, 0}});
+    graph.addConnection({{osc->nodeID, 1}, {filter->nodeID, 1}});
+
+    auto* fine = findParam(osc->getProcessor(), "fine");
+    ASSERT_NE(fine, nullptr);
+
+    undoManager.captureBeforeState(graph);
+    fine->setValueNotifyingHost(0.75f);
+    undoManager.pushSnapshotFromCapture(graph);
+
+    const auto connectionsBefore = captureIdentity(graph).connections;
+
+    // Drain anything the setup queued, then start listening.
+    pumpMessageLoop();
+    TopologyChangeCounter counter;
+    graph.addChangeListener(&counter);
+
+    ASSERT_TRUE(undoManager.undo());
+    pumpMessageLoop();
+    EXPECT_EQ(counter.count, 0) << "a parameter-only undo must not touch graph topology";
+
+    ASSERT_TRUE(undoManager.redo());
+    pumpMessageLoop();
+    EXPECT_EQ(counter.count, 0) << "a parameter-only redo must not touch graph topology";
+
+    EXPECT_EQ(graph.getNumNodes(), 2);
+    EXPECT_TRUE(captureIdentity(graph).connections == connectionsBefore);
+
+    graph.removeChangeListener(&counter);
+}
+
+/** Undoing an add removes exactly the added node and leaves every other instance untouched. */
+TEST_F(UndoRedoTest, NodeAddUndoRemovesOnlyThatNode) {
+    graph.addNode(std::make_unique<OscillatorModule>());
+    graph.addNode(std::make_unique<FilterModule>());
+
+    stampUuids(graph);
+    tagLiveNodes(graph);
+    const auto before = captureIdentity(graph);
+
+    undoManager.recordStructuralChange(graph, [this] { graph.addNode(std::make_unique<VCAModule>()); });
+    ASSERT_EQ(graph.getNumNodes(), 3);
+
+    ASSERT_TRUE(undoManager.undo());
+    EXPECT_EQ(graph.getNumNodes(), 2);
+    EXPECT_EQ(countTaggedNodes(graph), 2) << "the two survivors must be the original instances";
+    EXPECT_TRUE(captureIdentity(graph) == before);
+
+    // Redo re-adds the VCA without disturbing the survivors.
+    ASSERT_TRUE(undoManager.redo());
+    EXPECT_EQ(graph.getNumNodes(), 3);
+    EXPECT_EQ(countTaggedNodes(graph), 2);
+}
+
+/** Undoing a delete re-creates only the deleted node, and restores its uuid from the snapshot. */
+TEST_F(UndoRedoTest, NodeDeleteUndoRecreatesOnlyDeletedNode) {
+    auto* osc = graph.addNode(std::make_unique<OscillatorModule>()).get();
+    auto* filter = graph.addNode(std::make_unique<FilterModule>()).get();
+    auto* vca = graph.addNode(std::make_unique<VCAModule>()).get();
+    graph.addConnection({{osc->nodeID, 0}, {filter->nodeID, 0}});
+    graph.addConnection({{filter->nodeID, 0}, {vca->nodeID, 0}});
+
+    stampUuids(graph);
+    tagLiveNodes(graph);
+
+    const auto filterId = filter->nodeID;
+    const juce::String filterUuid = uuidOf(filter);
+    const juce::String oscUuid = uuidOf(osc);
+    ASSERT_TRUE(filterUuid.isNotEmpty());
+
+    undoManager.recordStructuralChange(graph, [this, filterId] { graph.removeNode(filterId); });
+    ASSERT_EQ(graph.getNumNodes(), 2);
+
+    ASSERT_TRUE(undoManager.undo());
+    ASSERT_EQ(graph.getNumNodes(), 3);
+    EXPECT_EQ(countTaggedNodes(graph), 2) << "only the deleted node should have been re-created";
+
+    auto* restored = graph.getNodeForId(filterId);
+    ASSERT_NE(restored, nullptr) << "the re-created node must reclaim its original node id";
+    EXPECT_EQ(uuidOf(restored), filterUuid) << "identity must be restored from the snapshot, not regenerated";
+    EXPECT_FALSE(restored->properties.contains(kSurvivorTag));
+    EXPECT_EQ(restored->getProcessor()->getName(), juce::String("Filter"));
+
+    // The survivors kept their identity, and the wiring around the restored node is back.
+    EXPECT_EQ(uuidOf(graph.getNodeForId(osc->nodeID)), oscUuid);
+    EXPECT_EQ(graph.getConnections().size(), 2u);
+}
+
+/** A connection edit applies as a delta: no node is added, removed or re-created. */
+TEST_F(UndoRedoTest, ConnectionUndoPreservesAllNodeInstances) {
+    auto* osc = graph.addNode(std::make_unique<OscillatorModule>()).get();
+    auto* filter = graph.addNode(std::make_unique<FilterModule>()).get();
+
+    stampUuids(graph);
+    tagLiveNodes(graph);
+    const auto before = captureIdentity(graph);
+    ASSERT_TRUE(before.connections.empty());
+
+    undoManager.recordStructuralChange(
+        graph, [this, osc, filter] { graph.addConnection({{osc->nodeID, 0}, {filter->nodeID, 0}}); });
+    ASSERT_EQ(graph.getConnections().size(), 1u);
+
+    ASSERT_TRUE(undoManager.undo());
+    EXPECT_EQ(countTaggedNodes(graph), 2);
+    EXPECT_TRUE(captureIdentity(graph) == before) << "undoing a wire must only remove the wire";
+
+    ASSERT_TRUE(undoManager.redo());
+    EXPECT_EQ(countTaggedNodes(graph), 2) << "redoing a wire must not re-create the nodes it joins";
+    EXPECT_EQ(graph.getConnections().size(), 1u);
+}
+
+/**
+ * An AI merge patch renumbers the ids it was given, so undoing one is the case most likely to
+ * confuse an identity-based restore. The graph must come back exactly as it was.
+ */
+TEST_F(UndoRedoTest, AiMergePatchUndoRestoresGraphExactly) {
+    auto* osc = graph.addNode(std::make_unique<OscillatorModule>()).get();
+    auto* filter = graph.addNode(std::make_unique<FilterModule>()).get();
+    graph.addConnection({{osc->nodeID, 0}, {filter->nodeID, 0}});
+
+    auto* cutoff = findParam(filter->getProcessor(), "cutoff");
+    ASSERT_NE(cutoff, nullptr);
+    const float cutoffBefore = cutoff->getNormalisableRange().convertFrom0to1(cutoff->getValue());
+
+    stampUuids(graph);
+    tagLiveNodes(graph);
+    const auto before = captureIdentity(graph);
+    const juce::String jsonBefore = juce::JSON::toString(synth::AIStateMapper::graphToJSON(graph));
+
+    // Untrusted merge: the ids in the patch are renumbered as the nodes are created.
+    const juce::var patch = juce::JSON::parse(R"({"nodes":[{"id":77,"type":"Delay","params":{}}],
+                                                  "connections":[]})");
+    ASSERT_TRUE(patch.isObject());
+    undoManager.recordStructuralChange(graph, [this, &patch] {
+        synth::AIStateMapper::applyJSONToGraph(patch, graph, /*clearExisting=*/false, /*trusted=*/false);
+    });
+    ASSERT_EQ(graph.getNumNodes(), 3) << "the merge patch should have added a node";
+
+    ASSERT_TRUE(undoManager.undo());
+    EXPECT_EQ(graph.getNumNodes(), 2);
+    EXPECT_EQ(countTaggedNodes(graph), 2) << "the pre-merge modules must be the same instances";
+    EXPECT_TRUE(captureIdentity(graph) == before);
+    EXPECT_EQ(juce::JSON::toString(synth::AIStateMapper::graphToJSON(graph)), jsonBefore)
+        << "the restored graph must serialize identically to the pre-merge graph";
+    EXPECT_NEAR(cutoff->getNormalisableRange().convertFrom0to1(cutoff->getValue()), cutoffBefore, 0.01f);
+}
+
+/** Non-parameter module state is re-applied only when it actually differs. */
+TEST_F(UndoRedoTest, ExtraStateIsReappliedOnlyWhenItChanged) {
+    auto* probeNode = graph.addNode(std::make_unique<ExtraStateProbeModule>()).get();
+    auto* probe = dynamic_cast<ExtraStateProbeModule*>(probeNode->getProcessor());
+    ASSERT_NE(probe, nullptr);
+    graph.addNode(std::make_unique<FilterModule>());
+
+    // (a) An undo that leaves this module's state alone must not write it back — setExtraState
+    //     reloads a sample/wavetable from disk in the real modules.
+    undoManager.recordStructuralChange(graph, [this] { graph.addNode(std::make_unique<VCAModule>()); });
+    probe->setExtraStateCalls = 0;
+    ASSERT_TRUE(undoManager.undo());
+    EXPECT_EQ(probe->setExtraStateCalls, 0) << "unchanged extra state must not be re-applied on every undo";
+    EXPECT_EQ(probe->token, juce::String("a"));
+
+    // (b) An undo that does change it must write it back, exactly once.
+    undoManager.captureBeforeState(graph);
+    probe->token = "b";
+    undoManager.pushSnapshotFromCapture(graph);
+    probe->setExtraStateCalls = 0;
+
+    ASSERT_TRUE(undoManager.undo());
+    EXPECT_EQ(probe->setExtraStateCalls, 1);
+    EXPECT_EQ(probe->token, juce::String("a"));
+}
+
+/**
+ * Fallback: a live node with no uuid makes identity undecidable, so the restore must give up and
+ * let the original destroy-and-rebuild apply run. The graph still ends up correct — it is only the
+ * node instances that are lost, which is what the missing tags prove.
+ */
+TEST_F(UndoRedoTest, RestoreFallsBackToFullRebuildWhenIdentityIsUnusable) {
+    auto* osc = graph.addNode(std::make_unique<OscillatorModule>()).get();
+    auto* filter = graph.addNode(std::make_unique<FilterModule>()).get();
+    graph.addConnection({{osc->nodeID, 0}, {filter->nodeID, 0}});
+
+    stampUuids(graph);
+    tagLiveNodes(graph);
+    ASSERT_EQ(countTaggedNodes(graph), 2);
+
+    undoManager.recordStructuralChange(graph, [this] { graph.addNode(std::make_unique<VCAModule>()); });
+    ASSERT_EQ(graph.getNumNodes(), 3);
+
+    // Corrupt identity on a live node the snapshot still contains.
+    graph.getNodes().getFirst()->properties.remove(juce::Identifier("uuid"));
+
+    ASSERT_TRUE(undoManager.undo());
+
+    // Correct end state...
+    EXPECT_EQ(graph.getNumNodes(), 2);
+    EXPECT_EQ(graph.getConnections().size(), 1u);
+    // ...reached the expensive way: every node was destroyed and re-created.
+    EXPECT_EQ(countTaggedNodes(graph), 0) << "the full-rebuild fallback should have run";
+}
+
+/** A snapshot whose identities are ambiguous is refused outright, with the graph left untouched. */
+TEST_F(UndoRedoTest, PreservingApplyRefusesAmbiguousSnapshotWithoutMutating) {
+    graph.addNode(std::make_unique<OscillatorModule>());
+    graph.addNode(std::make_unique<FilterModule>());
+
+    const juce::var snapshot = synth::AIStateMapper::graphToJSON(graph);
+    const auto before = captureIdentity(graph);
+
+    auto duplicateUuid = [](const juce::var& source) {
+        const juce::var copy = juce::JSON::parse(juce::JSON::toString(source));
+        auto* nodes = copy.getDynamicObject()->getProperty("nodes").getArray();
+        (*nodes)[1].getDynamicObject()->setProperty("uuid", (*nodes)[0].getDynamicObject()->getProperty("uuid"));
+        return copy;
+    };
+
+    EXPECT_FALSE(synth::AIStateMapper::applySnapshotPreservingNodes(duplicateUuid(snapshot), graph))
+        << "two nodes claiming one identity must be refused";
+    EXPECT_TRUE(captureIdentity(graph) == before) << "a refused snapshot must leave the graph untouched";
+
+    auto retypeFirstNode = [](const juce::var& source) {
+        const juce::var copy = juce::JSON::parse(juce::JSON::toString(source));
+        auto* nodes = copy.getDynamicObject()->getProperty("nodes").getArray();
+        (*nodes)[0].getDynamicObject()->setProperty("type", "Reverb");
+        return copy;
+    };
+
+    EXPECT_FALSE(synth::AIStateMapper::applySnapshotPreservingNodes(retypeFirstNode(snapshot), graph))
+        << "a uuid whose module type changed must be refused";
+    EXPECT_TRUE(captureIdentity(graph) == before);
+
+    auto dropUuid = [](const juce::var& source) {
+        const juce::var copy = juce::JSON::parse(juce::JSON::toString(source));
+        auto* nodes = copy.getDynamicObject()->getProperty("nodes").getArray();
+        (*nodes)[0].getDynamicObject()->removeProperty("uuid");
+        return copy;
+    };
+
+    EXPECT_FALSE(synth::AIStateMapper::applySnapshotPreservingNodes(dropUuid(snapshot), graph))
+        << "a snapshot node with no identity must be refused";
+    EXPECT_TRUE(captureIdentity(graph) == before);
+
+    // A merge delta is a change, not a target state — there is nothing to diff against.
+    EXPECT_FALSE(synth::AIStateMapper::applySnapshotPreservingNodes(
+        juce::JSON::parse(R"({"nodes":[],"connections":[],"remove":[1]})"), graph));
+    EXPECT_TRUE(captureIdentity(graph) == before);
+
+    // The unmodified snapshot, by contrast, applies and changes nothing.
+    EXPECT_TRUE(synth::AIStateMapper::applySnapshotPreservingNodes(snapshot, graph));
+    EXPECT_TRUE(captureIdentity(graph) == before);
+}
 
 /**
  * Test 1: UndoAddModule

--- a/docs/AI_Engine.md
+++ b/docs/AI_Engine.md
@@ -110,6 +110,15 @@ Per-node `uuid` is honoured on the trusted path only (`applyJSONToGraph` with `t
 untrusted input gets fresh identities regenerated on the next `graphToJSON`. This ensures a model
 cannot hand two nodes the same identity or claim one that something else already points at.
 
+That uuid is also what makes undo/redo node-preserving: `AIStateMapper::applySnapshotPreservingNodes`
+(the third apply path, used **only** by `AppUndoManager::SnapshotAction`) diffs one of our own
+`graphToJSON` snapshots against the live graph and keeps every node whose uuid still matches,
+instead of replaying it through `applyJSONToGraph` and re-creating everything. It refuses anything
+whose identity is ambiguous — leaving the graph untouched — and the caller then falls back to
+`applyJSONToGraph(..., clearExisting=true, trusted=true)`. `applyJSONToGraph` itself is unchanged;
+presets, snippets and AI apply all keep their existing semantics. See
+[`docs/architecture.md`](architecture.md#appundomanager).
+
 None of `schemaVersion`, `uuid` or `"timeline"` appears in `getPatchSchema()` — every property there
 is an invitation to emit it, and all three are ours to write. Pinned by
 `AIStateMapperTest.SchemaOmitsReservedFields`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -88,7 +88,7 @@ Guards poly-mode CV inputs from being auto-wrapped in an `AttenuverterModule` by
 
 For state that has to survive a graph rebuild but is not expressible as a `juce::AudioProcessorParameter` — today only `SamplerModule`'s loaded file path. `AIStateMapper::graphToJSON` writes whatever `getExtraState()` returns as the node's `"state"` property, and `applyJSONToGraph` feeds it back through `setExtraState()`. Return a **void** `var` when there is nothing to persist, so modules that do not use the hook add no JSON.
 
-This matters because undo/redo and preset load both go through `graphToJSON` → `applyJSONToGraph`, which rebuilds processors from scratch: anything not in that JSON is silently lost on the next undo.
+This matters because preset load — and any undo that has to fall back to a full rebuild — goes through `graphToJSON` → `applyJSONToGraph`, which rebuilds processors from scratch: anything not in that JSON is silently lost. (An ordinary undo restores by diffing and keeps the processor, so it re-applies `"state"` only when it actually changed — see [AppUndoManager](#appundomanager).)
 
 `setExtraState` is only ever called on the **trusted** path (our own snapshots and presets). A module may legitimately read this as a filename, so honouring it for untrusted model output would turn a patch suggestion into an arbitrary file read.
 
@@ -174,6 +174,16 @@ Intermediary inserted between a modulation source and its destination to scale C
 `Source/AppUndoManager.h/.cpp`
 
 Snapshot-based undo/redo wrapping `juce::UndoManager`. Structural graph changes (add/remove module, connect/disconnect) are captured as JSON before/after snapshots via `SnapshotAction`. Parameter and position changes have dedicated action types. Safe detach/reattach lifecycle — `setGraphEditor(nullptr)` before graph teardown.
+
+#### Restoring a snapshot is a diff, not a rebuild
+
+`SnapshotAction` restores through `AIStateMapper::applySnapshotPreservingNodes`, which compares the target snapshot against the live graph and touches only what differs. It does **not** replay the snapshot through `applyJSONToGraph`, which reaches the same end state by destroying and re-creating every node.
+
+- **Identity is the per-node `uuid`**, not the integer `id` (merge mode renumbers ids). A live node whose uuid appears in the snapshot is **kept** and updated in place — parameters via the trusted param path, position from `"position"`, and `"state"` re-applied through `setExtraState` **only when it changed** (it reloads a sample/wavetable off disk, so an unconditional re-apply would hit the filesystem on every Cmd+Z). A live node whose uuid is absent from the snapshot is removed; a snapshot node with no live match is created, re-adopting both its uuid and its original id when that id is free.
+- **A parameter-only undo performs zero topology operations.** No node and no connection is added or removed, so JUCE never rebuilds its render sequence and the audio callback never blocks. Mixed restores batch their topology ops (`UpdateKind::none`) and rebuild exactly once at the end. No graph callback lock is taken at any point.
+- **Module runtime state survives.** Sequencer position, envelope stage and sounding voices belong to the processor instance, which is no longer thrown away. This is also what makes hosted plugins and timeline-driven MIDI sources viable: neither can afford to be re-instantiated on every Cmd+Z.
+- **Any doubt falls back to the old full rebuild.** `applySnapshotPreservingNodes` plans the whole restore before mutating anything and returns `false` — graph untouched — on a live or snapshot node with no uuid, a duplicate uuid or id, a uuid whose module type no longer matches, an unknown type, a connection naming an undefined node, or a merge delta (`"remove"` / `"removeModulations"`) rather than a full snapshot. `SnapshotAction` then runs `applyJSONToGraph(..., clearExisting=true, trusted=true)`, which is always correct. Correctness beats preservation.
+- **UI teardown is now conditional.** The action's `preRestore` hook (`GraphEditor::detachAllModuleComponents`, and the AI service's `aiPatchAboutToApply`) exists to detach UI from processors that are about to be freed, so it fires only when a node is actually being removed — or on the fallback, which frees everything. When nothing is freed there is nothing to detach, and `updateComponents()` (the `postRestore` hook) reconciles additively, so a parameter-only undo no longer destroys and re-creates every `ModuleComponent` either.
 
 ### AppLookAndFeel + ThemeManager
 


### PR DESCRIPTION
## Summary

Fixes #197. Undo/redo no longer destroys and re-creates every graph node under the audio callback lock — `SnapshotAction` now restores through a diffing apply (`AIStateMapper::applySnapshotPreservingNodes`) that keeps every node the target state still contains. Module runtime state (sequencer positions, envelope stages, sounding voices) survives undo, a param-only undo triggers no render-sequence rebuild at all, and the hard blocker for hosted plugins / timeline nodes is gone. `applyJSONToGraph` semantics are byte-for-byte unchanged for presets, snippets, and AI apply.

## Changes

- Identity = per-node `uuid` (from #199), never the integer id. Matching live nodes are kept and updated in place: params via the trusted path with a new opt-in `skipUnchanged`, position properties, and the `"state"` extra-state blob re-applied **only on change** (no more Sampler file reloads on every undo).
- Zero topology operations for a param-only undo (verified by a topology-change-counting test). Mixed restores batch all ops with `UpdateKind::none` and call `graph.rebuild()` exactly once; no graph callback lock is taken.
- Plan-then-execute: the whole restore is resolved before anything is mutated. Missing/duplicate uuids, uuid-with-type-mismatch, unknown types, dangling connections, or merge deltas → refuse **without touching the graph** and fall back to the original full rebuild (always correct; covered by tests).
- `preRestore` UI teardown fires lazily — only when a node is actually about to be freed — so param-only undos keep all `ModuleComponent`s alive too.
- Re-entrancy fix found during implementation: applying a param can rewire the graph inline (`parameterValueChanged` → poly-state rewire), which segfaulted a dangling `Node*`. The executor holds `NodeID`s only and reconciles structure after the param pass.

Behaviour note: the preserving path reproduces the snapshot *exactly* — the old rebuild path could add auto-promoted attenuverter chains that weren't in the snapshot. No test depended on the old behaviour.

Follow-ups (out of scope): structural undos still detach all module components (`detachAllModuleComponents` is all-or-nothing); `PresetManager`/snippets intentionally keep the full-rebuild apply.

## Test Plan

- [x] All existing tests pass — full suite 1538/1538 (baseline 1529), two independent runs
- [x] New tests added for new functionality — 9 cases in `UndoRedoTests` incl. pointer-identity preservation, zero-topology assertion, exact-restore after an AI merge patch, and fallback-on-ambiguous-identity
- [x] Tested locally (build + run) — full build clean; clang-format clean on touched files
- [x] Documentation updated (CLAUDE.md, docs/) — docs/architecture.md UndoManager section, docs/AI_Engine.md apply-path note

## Screenshots

n/a (no UI changes)