### PR TITLE
feat(ai): quota-error upgrade bubble + usage indicator (P4-4)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -291,6 +291,8 @@ target_sources(AgentSynth PRIVATE
     Source/UI/AIChatComponent.cpp
     Source/UI/AccountRow.cpp
     Source/UI/AccountRow.h
+    Source/UI/PlanBadge.cpp
+    Source/UI/PlanBadge.h
     Source/UI/SignInDialog.cpp
     Source/UI/SignInDialog.h
     Source/UI/GraphEditor.cpp

--- a/Source/AI/AccountService.cpp
+++ b/Source/AI/AccountService.cpp
@@ -115,6 +115,13 @@ void AccountService::signOut() {
         startJob(PendingJob::Kind::revoke, refreshTokenToRevoke);
 }
 
+void AccountService::refreshEntitlement() {
+    const juce::String token = getAccessToken();
+    if (token.isEmpty())
+        return; // signed out — nothing to refresh
+    startJob(PendingJob::Kind::refreshEntitlement, token);
+}
+
 void AccountService::startJob(PendingJob::Kind kind, juce::String arg) {
     bool mustStart = false;
     {
@@ -197,6 +204,9 @@ void AccountService::run() {
                 break;
             case PendingJob::Kind::revoke:
                 runRevokeFlow(job.arg);
+                break;
+            case PendingJob::Kind::refreshEntitlement:
+                runRefreshEntitlementFlow(job.arg);
                 break;
             case PendingJob::Kind::none:
                 break;
@@ -328,6 +338,32 @@ void AccountService::runRevokeFlow(const juce::String& token) {
     authClient.revoke(token, cancelRequested);
 }
 
+void AccountService::runRefreshEntitlementFlow(const juce::String& accessTokenForRefresh) {
+    if (threadShouldExit() || cancelRequested.load())
+        return;
+
+    const auto entitlement = authClient.fetchEntitlement(accessTokenForRefresh, cancelRequested);
+    if (!entitlement.ok) {
+        juce::Logger::writeToLog("AccountService: refreshEntitlement failed (non-fatal): " +
+                                 entitlement.transportError);
+        return;
+    }
+
+    // Merge onto the currently published snapshot rather than a fresh AccountSnapshot{} — this
+    // job only ever touches entitlement fields, never sign-in state. If a sign-out raced this job
+    // (the snapshot is no longer SignedIn by the time the fetch returns), publishing entitlement
+    // data on top of it would resurrect a stale plan for a moment, so just drop the result.
+    AccountSnapshot s = getSnapshot();
+    if (s.state != AccountState::SignedIn)
+        return;
+
+    s.plan = entitlement.plan;
+    s.monthlyRequestLimit = entitlement.monthlyRequestLimit;
+    s.requestsUsed = entitlement.requestsUsed;
+    s.entitlementKnown = true;
+    publishSnapshot(s);
+}
+
 void AccountService::completeSignIn(const juce::String& newAccessToken, const juce::String& newRefreshToken) {
     // Guards the window between "the network round trip that produced this token pair completed"
     // and "it's persisted and published": without this check, a cancelSignIn() or signOut() that
@@ -362,11 +398,32 @@ void AccountService::completeSignIn(const juce::String& newAccessToken, const ju
         juce::Logger::writeToLog("AccountService: fetchMe after sign-in failed (non-fatal): " + me.transportError);
     }
 
+    // Same non-fatal contract as fetchMe() above: entitlement is cosmetic (a usage indicator, an
+    // upgrade path), never a reason to fail an otherwise-successful sign-in.
+    juce::String plan;
+    int monthlyRequestLimit = 0;
+    int requestsUsed = 0;
+    bool entitlementKnown = false;
+    const auto entitlement = authClient.fetchEntitlement(newAccessToken, cancelRequested);
+    if (entitlement.ok) {
+        plan = entitlement.plan;
+        monthlyRequestLimit = entitlement.monthlyRequestLimit;
+        requestsUsed = entitlement.requestsUsed;
+        entitlementKnown = true;
+    } else {
+        juce::Logger::writeToLog("AccountService: fetchEntitlement after sign-in failed (non-fatal): " +
+                                 entitlement.transportError);
+    }
+
     setAccessTokenFromWorker(newAccessToken);
 
     AccountSnapshot s;
     s.state = AccountState::SignedIn;
     s.email = email;
+    s.plan = plan;
+    s.monthlyRequestLimit = monthlyRequestLimit;
+    s.requestsUsed = requestsUsed;
+    s.entitlementKnown = entitlementKnown;
     publishSnapshot(s);
 
     juce::Logger::writeToLog("AccountService: sign-in succeeded (" + maskEmail(email) + ").");

--- a/Source/AI/AccountService.h
+++ b/Source/AI/AccountService.h
@@ -18,6 +18,17 @@ struct AccountSnapshot {
     juce::String verificationUriComplete;
     juce::String email;
     juce::String lastError;
+
+    // P4-4: entitlement, fetched alongside fetchMe() on sign-in (see completeSignIn()) and
+    // refreshable on demand (see refreshEntitlement()). entitlementKnown is false until the first
+    // successful fetch — a fetch failure is non-fatal (mirrors how a failed fetchMe() leaves
+    // `email` empty rather than failing sign-in), so callers must check it before trusting
+    // plan/monthlyRequestLimit/requestsUsed rather than treating a default-constructed plan as
+    // "Free".
+    juce::String plan;
+    int monthlyRequestLimit = 0;
+    int requestsUsed = 0;
+    bool entitlementKnown = false;
 };
 
 /**
@@ -68,6 +79,13 @@ public:
         on the worker thread; its result is ignored either way. */
     void signOut();
 
+    /** Re-fetches entitlement only (plan/limit/usage), leaving sign-in state untouched. No-op if
+        signed out. Fire-and-forget — publishes an updated snapshot via onStateChanged on success,
+        silent (logged, non-fatal) on failure, same contract as the entitlement fetch inside
+        completeSignIn(). Intended for "the user may have just paid — check again" moments (P4-4:
+        AIChatComponent calls this right after a Quota error). */
+    void refreshEntitlement();
+
     // Called (via MessageManager::callAsync when it originates from the worker thread) whenever
     // getSnapshot() would return something different.
     std::function<void()> onStateChanged;
@@ -77,9 +95,11 @@ public:
 
 private:
     struct PendingJob {
-        enum class Kind { none, deviceSignIn, silentSignIn, revoke };
+        enum class Kind { none, deviceSignIn, silentSignIn, revoke, refreshEntitlement };
         Kind kind = Kind::none;
-        juce::String arg; // stored refresh token (silentSignIn) or token to revoke (revoke)
+        // stored refresh token (silentSignIn), token to revoke (revoke), or the access token to
+        // refresh entitlement for (refreshEntitlement)
+        juce::String arg;
     };
 
     AuthClient authClient;
@@ -105,6 +125,7 @@ private:
     void runDeviceSignInFlow();
     void runSilentSignInFlow(const juce::String& storedRefreshToken);
     void runRevokeFlow(const juce::String& token);
+    void runRefreshEntitlementFlow(const juce::String& accessTokenForRefresh);
 
     /** Rotation-before-use invariant lives here: called by both flows once a fresh access/refresh
         token pair is in hand. */

--- a/Source/AI/AuthClient.cpp
+++ b/Source/AI/AuthClient.cpp
@@ -299,6 +299,51 @@ AuthClient::MeResult AuthClient::fetchMe(const juce::String& accessToken, const 
     return result;
 }
 
+AuthClient::EntitlementResult AuthClient::fetchEntitlement(const juce::String& accessToken,
+                                                           const std::atomic<bool>& cancelled) const {
+    EntitlementResult result;
+
+    juce::StringPairArray headers;
+    headers.set("Authorization", "Bearer " + accessToken);
+
+    const auto http = performHttp("GET", host + "/v1/entitlement", headers, {}, kRequestTimeoutMs, cancelled);
+
+    if (http.transportFailed || http.timedOut) {
+        result.transportError = http.errorMessage.isNotEmpty() ? http.errorMessage : "Error: request failed.";
+        return result;
+    }
+
+    if (http.httpStatus != 200) {
+        result.transportError = "Error: /v1/entitlement failed (HTTP " + juce::String(http.httpStatus) + ").";
+        return result;
+    }
+
+    const auto parsed = juce::JSON::parse(http.body);
+    auto* obj = parsed.getDynamicObject();
+    if (obj == nullptr) {
+        result.transportError = "Error: could not parse /v1/entitlement response.";
+        return result;
+    }
+
+    result.plan = obj->getProperty("plan").toString();
+    result.status = obj->getProperty("status").toString();
+    result.periodEndIso = obj->getProperty("period_end").toString();
+    result.cancelAtPeriodEnd = static_cast<bool>(obj->getProperty("cancel_at_period_end"));
+
+    if (auto* limits = obj->getProperty("limits").getDynamicObject())
+        result.monthlyRequestLimit = static_cast<int>(limits->getProperty("monthly_requests"));
+
+    // `usage` is a P4-4 addition to the response; absent against an older server is not a parse
+    // failure — the client just shows 0 used rather than failing the whole entitlement fetch.
+    if (auto* usage = obj->getProperty("usage").getDynamicObject()) {
+        result.requestsUsed = static_cast<int>(usage->getProperty("requests_used"));
+        result.usagePeriodStartIso = usage->getProperty("period_start").toString();
+    }
+
+    result.ok = true;
+    return result;
+}
+
 bool AuthClient::revoke(const juce::String& token, const std::atomic<bool>& cancelled) const {
     juce::StringPairArray headers;
     headers.set("Content-Type", "application/x-www-form-urlencoded");

--- a/Source/AI/AuthClient.h
+++ b/Source/AI/AuthClient.h
@@ -76,6 +76,21 @@ public:
         juce::String transportError;
     };
 
+    /** Result of GET /v1/entitlement (P4-2/P4-3/P4-4). `requestsUsed`/`usagePeriodStartIso` come
+        from the response's `usage` object; both stay at their defaults (0 / empty) against a
+        server that doesn't send it yet — see docs/billing.md for the full response shape. */
+    struct EntitlementResult {
+        bool ok = false;
+        juce::String plan;
+        juce::String status;
+        juce::String periodEndIso;
+        bool cancelAtPeriodEnd = false;
+        int monthlyRequestLimit = 0;
+        int requestsUsed = 0;
+        juce::String usagePeriodStartIso;
+        juce::String transportError;
+    };
+
     explicit AuthClient(juce::String host = "http://localhost:8787", juce::String clientId = "synth-desktop",
                         juce::String deviceId = "");
 
@@ -95,6 +110,9 @@ public:
 
     /** GET /v1/auth/me with `Authorization: Bearer <accessToken>`. */
     MeResult fetchMe(const juce::String& accessToken, const std::atomic<bool>& cancelled) const;
+
+    /** GET /v1/entitlement with `Authorization: Bearer <accessToken>`. */
+    EntitlementResult fetchEntitlement(const juce::String& accessToken, const std::atomic<bool>& cancelled) const;
 
     /** POST /v1/auth/revoke. Fire-and-forget: the endpoint always answers 200 with an empty body,
         so the return value only reflects whether the transport succeeded — callers are not

--- a/Source/AI/RemoteProvider.cpp
+++ b/Source/AI/RemoteProvider.cpp
@@ -557,6 +557,19 @@ void RemoteProvider::processRequest(const Request& req) {
     }
 
     if (httpStatus == 429) {
+        // P4-3's monthly quota (enforce-quota.ts) answers 429 QUOTA_EXCEEDED, not the 402 the
+        // Quota mapping below was originally written for — without this check, the real
+        // paid-plan quota-exceeded response is silently misclassified as a generic rate limit and
+        // the upgrade-bubble UI (P4-4) never fires. Any other/no code on a 429 keeps the
+        // pre-existing generic RateLimit mapping — nothing else currently returns 429 to
+        // /v1/capability/*, so this is defensive.
+        if (extractErrorCode(result.body) == "QUOTA_EXCEEDED") {
+            const auto detail = extractErrorDetail(result.body);
+            deliverErr(AIErrorKind::Quota,
+                       detail.isNotEmpty() ? detail : "Error: Your monthly request quota is used up.");
+            return;
+        }
+
         const int retryAfterSeconds = result.headers.getValue("Retry-After", "").getIntValue();
         deliverErr(AIErrorKind::RateLimit,
                    withErrorDetail("Error: Remote provider at " + remoteHost + " rate-limited the request (HTTP 429)",

--- a/Source/Branding.h
+++ b/Source/Branding.h
@@ -42,4 +42,10 @@ constexpr const char* kWebsiteUrl = "https://agentsynth.app";
 // Support contact address, for the About box / support links. Not yet referenced anywhere.
 constexpr const char* kSupportEmail = "support@agentsynth.app";
 
+// Static Polar checkout link (covers both the monthly and yearly Pro products) opened by the
+// "Upgrade to Pro" button on a Quota-kind AI error (P4-4, Source/UI/AIChatComponent.cpp).
+// Deliberately static rather than a dynamically-created checkout session — see docs/billing.md's
+// "what this deliberately does not do" for why P4-4 doesn't create checkout sessions.
+constexpr const char* kUpgradeUrl = "https://buy.polar.sh/polar_cl_DkiJlmel2CXVtpl236TvS52omgYaZM26HGe1U0rbD75";
+
 } // namespace synth::branding

--- a/Source/UI/AIChatComponent.cpp
+++ b/Source/UI/AIChatComponent.cpp
@@ -1,4 +1,5 @@
 #include "AIChatComponent.h"
+#include "../Branding.h"
 
 namespace synth {
 
@@ -94,7 +95,8 @@ private:
 //==============================================================================
 class AIChatComponent::MessageBubble : public juce::Component {
 public:
-    MessageBubble(const MessageData& data, std::function<void(const juce::String&)> applyPatch, bool isMerge) {
+    MessageBubble(const MessageData& data, std::function<void(const juce::String&)> applyPatch, bool isMerge,
+                  std::function<void(const juce::URL&)> urlOpener) {
         role = data.role;
         text = data.text;
 
@@ -107,6 +109,14 @@ public:
             patchCard = std::make_unique<PatchCard>(
                 data.jsonPatch, [applyPatch, json = data.jsonPatch]() { applyPatch(json); }, isMerge);
             addAndMakeVisible(*patchCard);
+        }
+
+        if (data.showUpgradeAction) {
+            upgradeButton = std::make_unique<juce::TextButton>();
+            upgradeButton->setButtonText("Upgrade to Pro");
+            upgradeButton->setColour(juce::TextButton::buttonColourId, juce::Colour(0xFF6B4FBB));
+            upgradeButton->onClick = [urlOpener] { urlOpener(juce::URL(synth::branding::kUpgradeUrl)); };
+            addAndMakeVisible(*upgradeButton);
         }
     }
 
@@ -138,6 +148,11 @@ public:
             b.removeFromBottom(5);
         }
 
+        if (upgradeButton) {
+            upgradeButton->setBounds(b.removeFromBottom(kUpgradeButtonHeight));
+            b.removeFromBottom(5);
+        }
+
         textLabel.setBounds(b);
     }
 
@@ -155,14 +170,21 @@ public:
             height += 10 + patchCard->getRequiredHeight();
         }
 
+        if (upgradeButton) {
+            height += 5 + kUpgradeButtonHeight;
+        }
+
         return juce::jmax(40, height);
     }
 
 private:
+    static constexpr int kUpgradeButtonHeight = 28;
+
     juce::String role;
     juce::String text;
     juce::Label textLabel;
     std::unique_ptr<PatchCard> patchCard;
+    std::unique_ptr<juce::TextButton> upgradeButton;
 };
 
 //==============================================================================
@@ -201,6 +223,11 @@ AIChatComponent::AIChatComponent(AIIntegrationService& service, juce::Applicatio
     // so it plays correctly with AIChatComponent's own top-level setVisible() calls from
     // MainComponent.
     addChildComponent(accountRow);
+
+    // Same addChildComponent (not addAndMakeVisible) rationale as accountRow just above: starts
+    // invisible/zero-height and stays that way until setAccountService() attaches a real
+    // AccountService with a known entitlement.
+    addChildComponent(planBadge);
 
     addAndMakeVisible(viewport);
     viewport.setScrollBarsShown(true, false);
@@ -272,6 +299,8 @@ AIChatComponent::AIChatComponent(AIIntegrationService& service, juce::Applicatio
                 cleanText = msg.content.substring(0, start) + msg.content.substring(end + 3);
             }
         }
+        // showUpgradeAction deliberately left at its default false: a replayed history turn never
+        // resurrects the Upgrade button, same as Cancel-button/spinner state being session-only.
         messages.push_back({msg.role, cleanText.trim(), json});
     }
 
@@ -300,6 +329,7 @@ AIChatComponent::~AIChatComponent() {
 void AIChatComponent::setAccountService(AccountService* service) {
     accountServicePtr = service;
     accountRow.setAccountService(service);
+    planBadge.setAccountService(service);
 
     if (service == nullptr)
         return;
@@ -310,8 +340,10 @@ void AIChatComponent::setAccountService(AccountService* service) {
     // this is what actually makes such a call safe.
     juce::Component::SafePointer<AIChatComponent> safeThis(this);
     service->onStateChanged = [safeThis] {
-        if (auto* self = safeThis.getComponent())
+        if (auto* self = safeThis.getComponent()) {
             self->accountRow.refresh();
+            self->planBadge.refresh();
+        }
     };
     service->onAccessTokenChanged = [safeThis](juce::String token) {
         if (auto* self = safeThis.getComponent())
@@ -382,7 +414,15 @@ void AIChatComponent::resized() {
     // never calls setAccountService() sees byte-identical layout to before this feature.
     const int accountRowHeight = accountRow.getPreferredHeight();
     const int accountRowGap = accountRowHeight > 0 ? 5 : 0;
-    auto bottomArea = b.removeFromBottom(70 + accountRowHeight + accountRowGap); // Increased height for both rows
+
+    // Plan badge: same zero-height-when-absent contract as accountRow — reserved only once an
+    // AccountService is attached AND its entitlement is known (SignedOut/SigningIn/unknown all
+    // collapse to 0, same as accountRow collapsing to 0 with no service).
+    const int planBadgeHeight = planBadge.getPreferredHeight();
+    const int planBadgeGap = planBadgeHeight > 0 ? 5 : 0;
+
+    auto bottomArea = b.removeFromBottom(70 + accountRowHeight + accountRowGap + planBadgeHeight +
+                                         planBadgeGap); // Increased height for all three rows
 
     // Bottom row: Input + Send (+ Cancel when waiting + spinner dot)
     auto inputRow = bottomArea.removeFromBottom(40);
@@ -409,6 +449,11 @@ void AIChatComponent::resized() {
 #ifndef NDEBUG
     toggleDebugButton.setBounds(modelRow.removeFromRight(60));
 #endif
+
+    if (planBadgeHeight > 0) {
+        bottomArea.removeFromBottom(planBadgeGap);
+        planBadge.setBounds(bottomArea.removeFromBottom(planBadgeHeight));
+    }
 
     if (accountRowHeight > 0) {
         bottomArea.removeFromBottom(accountRowGap);
@@ -535,6 +580,16 @@ void AIChatComponent::sendButtonClicked() {
                     }
 
                     self->messages.push_back({"assistant", cleanText.trim(), json});
+                } else if (aiResponse.error.kind == AIProvider::AIErrorKind::Quota) {
+                    // The server's message is already a complete, user-facing sentence — no
+                    // "Error: " prefix, same precedent as TrialExhausted/ServiceCapacityExceeded.
+                    // showUpgradeAction=true adds the Upgrade-to-Pro button (see MessageBubble).
+                    self->messages.push_back({"assistant", aiResponse.error.message, "", false,
+                                              /*showUpgradeAction=*/true});
+                    // The user may have just paid mid-session — check again so a retry right after
+                    // upgrading reflects the new plan without restarting the app.
+                    if (self->accountServicePtr != nullptr)
+                        self->accountServicePtr->refreshEntitlement();
                 } else {
                     self->messages.push_back({"assistant", "Error: " + aiResponse.error.message, ""});
                 }
@@ -650,7 +705,7 @@ void AIChatComponent::updateChatDisplay() {
                         refreshLater();
                     });
             },
-            isMerge);
+            isMerge, urlOpener);
         messageList.addAndMakeVisible(bubble);
     }
 

--- a/Source/UI/AIChatComponent.h
+++ b/Source/UI/AIChatComponent.h
@@ -3,6 +3,7 @@
 #include "../AI/AIIntegrationService.h"
 #include "../AI/AccountService.h"
 #include "AccountRow.h"
+#include "PlanBadge.h"
 #include "Theme/AppLookAndFeel.h"
 #include "UIAnimation.h"
 #include <atomic>
@@ -72,6 +73,10 @@ public:
 
     // Testing hook: returns the current isWaitingForResponse flag.
     bool isWaiting() const { return isWaitingForResponse; }
+
+    // Testing hook: replaces the real "open in default browser" action a Quota error's Upgrade
+    // button invokes, so tests can assert on the URL without ever launching a real browser.
+    void setUrlOpenerForTesting(std::function<void(const juce::URL&)> opener) { urlOpener = std::move(opener); }
 
 private:
     void timerCallback() override;
@@ -151,6 +156,7 @@ private:
     // setAccountService()'s comment for the single-owner contract those slots are under.
     AccountService* accountServicePtr = nullptr;
     AccountRow accountRow;
+    PlanBadge planBadge;
 
     // Handle for the request currently in flight, so cancelRequest() can tell the provider to
     // actually abandon it. Default (value 0) whenever nothing is outstanding — cleared by the
@@ -170,6 +176,10 @@ private:
     juce::VBlankAnimatorUpdater vblankUpdater{this};
     SpinnerDot spinnerDot;
 
+    // Opens a Quota error's "Upgrade to Pro" button target. Real default; overridden in tests via
+    // setUrlOpenerForTesting() so no test ever launches a real browser.
+    std::function<void(const juce::URL&)> urlOpener = [](const juce::URL& u) { u.launchInDefaultBrowser(); };
+
     void updateChatDisplay();
     void scrollToBottom();
 
@@ -178,6 +188,11 @@ private:
         juce::String text;
         juce::String jsonPatch;
         bool isExpanded = false;
+        // P4-4: true only for a live Quota-error response — renders an "Upgrade to Pro" button on
+        // the bubble. Deliberately NOT reconstructed by the history-replay loop in the
+        // constructor, so a New Chat or app restart drops it along with the rest of that turn's
+        // transient UI state (mirrors how Cancel-button/spinner state is session-only).
+        bool showUpgradeAction = false;
     };
     std::vector<MessageData> messages;
 

--- a/Source/UI/PlanBadge.cpp
+++ b/Source/UI/PlanBadge.cpp
@@ -1,0 +1,76 @@
+#include "PlanBadge.h"
+
+namespace synth {
+
+PlanBadge::PlanBadge() {
+    addChildComponent(textLabel);
+    textLabel.setJustificationType(juce::Justification::centredLeft);
+    textLabel.setMinimumHorizontalScale(1.0f);
+    textLabel.setFont(juce::Font(12.0f));
+
+    // Invisible/zero-height until setAccountService() attaches a real service with a known
+    // entitlement — mirrors AccountRow's default state for every existing caller/test.
+    setVisible(false);
+}
+
+PlanBadge::~PlanBadge() = default;
+
+void PlanBadge::setAccountService(AccountService* service) {
+    accountService = service;
+
+    if (accountService == nullptr) {
+        hasContent = false;
+        setVisible(false);
+        return;
+    }
+
+    // Synchronous, not routed through onStateChanged — this badge does not own that callback slot
+    // (AIChatComponent does, same as AccountRow) — see the class comment.
+    updateFromSnapshot(accountService->getSnapshot());
+}
+
+void PlanBadge::refresh() {
+    if (accountService == nullptr)
+        return;
+
+    updateFromSnapshot(accountService->getSnapshot());
+}
+
+int PlanBadge::getPreferredHeight() const { return hasContent ? 18 : 0; }
+
+void PlanBadge::updateFromSnapshot(const AccountSnapshot& snapshot) {
+    hasContent = snapshot.state == AccountState::SignedIn && snapshot.entitlementKnown;
+    setVisible(hasContent);
+    textLabel.setVisible(hasContent);
+
+    if (!hasContent) {
+        if (auto* parent = getParentComponent())
+            parent->resized();
+        return;
+    }
+
+    auto* lf = dynamic_cast<synth::theme::AppLookAndFeel*>(&getLookAndFeel());
+    const bool isPro = snapshot.plan.equalsIgnoreCase("pro");
+    const juce::Colour textColour = lf != nullptr
+                                        ? (isPro ? lf->getTheme().colors.accent : lf->getTheme().colors.textMuted)
+                                        : (isPro ? juce::Colours::lightblue : juce::Colours::grey);
+    textLabel.setColour(juce::Label::textColourId, textColour);
+
+    const juce::String planLabel = isPro ? "Pro" : "Free";
+    textLabel.setText(planLabel + " \xc2\xb7 " + juce::String(snapshot.requestsUsed) + " / " +
+                          juce::String(snapshot.monthlyRequestLimit) + " this month",
+                      juce::dontSendNotification);
+
+    resized();
+    if (auto* parent = getParentComponent())
+        parent->resized();
+}
+
+void PlanBadge::paint(juce::Graphics&) {
+    // No background of its own — sits directly on AIChatComponent's already-painted panel, same
+    // as AccountRow.
+}
+
+void PlanBadge::resized() { textLabel.setBounds(getLocalBounds()); }
+
+} // namespace synth

--- a/Source/UI/PlanBadge.h
+++ b/Source/UI/PlanBadge.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include "../AI/AccountService.h"
+#include "Theme/AppLookAndFeel.h"
+#include <juce_gui_basics/juce_gui_basics.h>
+
+namespace synth {
+
+/**
+ * @class PlanBadge
+ * @brief Slim usage indicator shown near the model picker: "Free · 240 / 1000 this month" or
+ *        "Pro · 1,203 / 10,000 this month", sourced from AccountService's entitlement fields
+ *        (P4-4).
+ *
+ * Driven entirely by setAccountService()/refresh() — same contract as AccountRow (see its class
+ * comment): with no AccountService attached, or one attached but not yet SignedIn with a known
+ * entitlement, this stays invisible with zero preferred height, so it can be added unconditionally
+ * to AIChatComponent's layout with no behavior change for callers that never opt in.
+ *
+ * Like AccountRow, this class does NOT set AccountService::onStateChanged itself — that slot is
+ * single-owner and AIChatComponent already claims it (see its setAccountService() comment).
+ * refresh() is the one entry point a caller uses to tell this badge the snapshot changed.
+ */
+class PlanBadge : public juce::Component {
+public:
+    PlanBadge();
+    ~PlanBadge() override;
+
+    void resized() override;
+    void paint(juce::Graphics& g) override;
+
+    // Non-owning, nullable. Pass nullptr to detach — the badge goes invisible again.
+    void setAccountService(AccountService* service);
+
+    // Re-reads accountService->getSnapshot() and updates this badge's text/visibility. Called by
+    // AIChatComponent from the single AccountService::onStateChanged callback it owns.
+    void refresh();
+
+    // 0 when no AccountService is attached, or entitlement isn't known yet (not signed in, or the
+    // entitlement fetch hasn't completed/failed) — badge invisible, contributes nothing to
+    // layout. AIChatComponent::resized() uses this to reserve space only when there is something
+    // to show.
+    int getPreferredHeight() const;
+
+private:
+    void updateFromSnapshot(const AccountSnapshot& snapshot);
+
+    AccountService* accountService = nullptr;
+    bool hasContent = false;
+
+    juce::Label textLabel;
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(PlanBadge)
+};
+
+} // namespace synth

--- a/Tests/AIChatComponentTests.cpp
+++ b/Tests/AIChatComponentTests.cpp
@@ -3,6 +3,7 @@
 #include "../Source/AI/AccountService.h"
 #include "../Source/AudioEngine.h"
 #include "../Source/Auth/InMemoryTokenStore.h"
+#include "../Source/Branding.h"
 #include "../Source/UI/AIChatComponent.h"
 #include "../Source/UI/AccountRow.h"
 #include <gtest/gtest.h>
@@ -74,6 +75,75 @@ private:
     std::function<void(const juce::StringArray&, bool)> pendingCallback;
     juce::String currentModel;
 };
+
+// Synchronously delivers a failed AIResponse with a caller-chosen error kind/message — used to
+// exercise AIChatComponent's failure-branch UI (P4-4: the Quota error's upgrade bubble, and the
+// regression lock that every other kind keeps the old flat bubble).
+class ErrorProvider : public synth::AIProvider {
+public:
+    ErrorProvider(AIErrorKind kind, juce::String message)
+        : kind(kind)
+        , message(std::move(message)) {}
+
+    juce::String getProviderName() const override { return "ErrorProvider"; }
+
+    void fetchAvailableModels(std::function<void(const juce::StringArray&, bool)> callback) override {
+        callback({"MockModel1"}, true);
+    }
+
+    RequestId sendPrompt(const std::vector<synth::AIProvider::Message>&, CompletionCallback callback,
+                         const juce::var& = juce::var(), std::function<void(const juce::String&)> = {}) override {
+        AIResponse response;
+        response.success = false;
+        response.error.kind = kind;
+        response.error.message = message;
+        callback(response);
+        return {};
+    }
+
+    void cancel(RequestId) override {}
+
+    void setModel(const juce::String& name) override { currentModel = name; }
+    juce::String getCurrentModel() const override { return currentModel; }
+
+private:
+    AIErrorKind kind;
+    juce::String message;
+    juce::String currentModel;
+};
+
+// Finds the juce::Viewport AIChatComponent adds as a direct child and returns its viewed
+// component (messageList) — the parent of every rendered MessageBubble. MessageBubble itself is a
+// private nested type, but its base juce::Component* children (labels, buttons) are inspectable
+// without knowing the concrete type.
+juce::Component* findMessageList(synth::AIChatComponent& chatComponent) {
+    for (auto* child : chatComponent.getChildren()) {
+        if (auto* viewport = dynamic_cast<juce::Viewport*>(child))
+            return viewport->getViewedComponent();
+    }
+    return nullptr;
+}
+
+// Depth-first search for a descendant of the given kind (Label or TextButton) whose text matches.
+template <typename ComponentType>
+ComponentType* findDescendantWithText(juce::Component* root, const juce::String& text) {
+    if (root == nullptr)
+        return nullptr;
+    for (auto* child : root->getChildren()) {
+        if (auto* match = dynamic_cast<ComponentType*>(child)) {
+            if constexpr (std::is_same_v<ComponentType, juce::Label>) {
+                if (match->getText() == text)
+                    return match;
+            } else if constexpr (std::is_same_v<ComponentType, juce::TextButton>) {
+                if (match->getButtonText() == text)
+                    return match;
+            }
+        }
+        if (auto* nested = findDescendantWithText<ComponentType>(child, text))
+            return nested;
+    }
+    return nullptr;
+}
 
 class AIChatComponentTest : public ::testing::Test {
 protected:
@@ -310,4 +380,143 @@ TEST_F(AIChatComponentTest, SetAccountServiceMakesAccountRowVisibleAndReflectsSn
     EXPECT_TRUE(accountRow->isVisible());
     EXPECT_GT(accountRow->getPreferredHeight(), 0);
     EXPECT_EQ(accountService.getSnapshot().state, synth::AccountState::SignedOut);
+}
+
+// ============================================================================
+// Quota error -> upgrade bubble (P4-4)
+// ============================================================================
+
+TEST_F(AIChatComponentTest, QuotaErrorRendersUpgradeButtonWithServerMessageVerbatim) {
+    AudioEngine engine;
+    synth::AIIntegrationService service(engine.getGraph());
+    service.setProvider(std::make_unique<ErrorProvider>(
+        synth::AIProvider::AIErrorKind::Quota, "Your monthly request quota is used up. Upgrading to Pro raises it."));
+
+    juce::ApplicationProperties props;
+    juce::PropertiesFile::Options options;
+    options.applicationName = "Test";
+    options.filenameSuffix = "test";
+    options.storageFormat = juce::PropertiesFile::storeAsXML;
+    props.setStorageParameters(options);
+
+    synth::AIChatComponent chatComponent(service, props);
+    chatComponent.setSize(400, 600);
+
+    juce::TextEditor* inputField = nullptr;
+    for (auto* child : chatComponent.getChildren()) {
+        if (auto* editor = dynamic_cast<juce::TextEditor*>(child))
+            inputField = editor;
+    }
+    ASSERT_NE(inputField, nullptr);
+
+    // Set BEFORE triggerSend(): ErrorProvider answers synchronously, so the MessageBubble (and
+    // the upgrade button's onClick, which captures urlOpener by value at construction time) is
+    // built during triggerSend() itself — setting the fake opener afterward would miss it.
+    juce::URL openedUrl;
+    bool opened = false;
+    chatComponent.setUrlOpenerForTesting([&](const juce::URL& url) {
+        openedUrl = url;
+        opened = true;
+    });
+
+    inputField->setText("hello");
+    chatComponent.triggerSend();
+    juce::MessageManager::getInstance()->runDispatchLoopUntil(100);
+
+    auto* messageList = findMessageList(chatComponent);
+    ASSERT_NE(messageList, nullptr);
+
+    // No "Error: " prefix — the server's message is already a complete sentence.
+    auto* messageLabel = findDescendantWithText<juce::Label>(
+        messageList, "Your monthly request quota is used up. Upgrading to Pro raises it.");
+    EXPECT_NE(messageLabel, nullptr) << "quota error message not rendered verbatim (no 'Error: ' prefix expected)";
+
+    auto* upgradeButton = findDescendantWithText<juce::TextButton>(messageList, "Upgrade to Pro");
+    ASSERT_NE(upgradeButton, nullptr) << "Quota error did not render an Upgrade to Pro button";
+
+    ASSERT_NE(upgradeButton->onClick, nullptr);
+    upgradeButton->onClick();
+
+    EXPECT_TRUE(opened) << "clicking Upgrade to Pro never invoked the injected urlOpener";
+    EXPECT_EQ(openedUrl.toString(false), juce::String(synth::branding::kUpgradeUrl));
+}
+
+TEST_F(AIChatComponentTest, NonQuotaErrorKeepsFlatErrorBubbleWithNoUpgradeButton) {
+    AudioEngine engine;
+    synth::AIIntegrationService service(engine.getGraph());
+    service.setProvider(
+        std::make_unique<ErrorProvider>(synth::AIProvider::AIErrorKind::Network, "Could not reach the server."));
+
+    juce::ApplicationProperties props;
+    juce::PropertiesFile::Options options;
+    options.applicationName = "Test";
+    options.filenameSuffix = "test";
+    options.storageFormat = juce::PropertiesFile::storeAsXML;
+    props.setStorageParameters(options);
+
+    synth::AIChatComponent chatComponent(service, props);
+    chatComponent.setSize(400, 600);
+
+    juce::TextEditor* inputField = nullptr;
+    for (auto* child : chatComponent.getChildren()) {
+        if (auto* editor = dynamic_cast<juce::TextEditor*>(child))
+            inputField = editor;
+    }
+    ASSERT_NE(inputField, nullptr);
+    inputField->setText("hello");
+    chatComponent.triggerSend();
+    juce::MessageManager::getInstance()->runDispatchLoopUntil(100);
+
+    auto* messageList = findMessageList(chatComponent);
+    ASSERT_NE(messageList, nullptr);
+
+    auto* messageLabel = findDescendantWithText<juce::Label>(messageList, "Error: Could not reach the server.");
+    EXPECT_NE(messageLabel, nullptr) << "non-Quota errors must keep the flat 'Error: ' bubble unchanged";
+
+    auto* upgradeButton = findDescendantWithText<juce::TextButton>(messageList, "Upgrade to Pro");
+    EXPECT_EQ(upgradeButton, nullptr) << "a non-Quota error must not render an Upgrade to Pro button";
+}
+
+// Confirms the deliberate non-persistence documented on MessageData::showUpgradeAction: a fresh
+// updateChatDisplay() (as New Chat triggers) never resurrects the button, and doesn't crash doing
+// so, even though it's driven by the same history-replay path a real New Chat/reload uses.
+TEST_F(AIChatComponentTest, UpgradeButtonDoesNotSurviveNewChat) {
+    AudioEngine engine;
+    synth::AIIntegrationService service(engine.getGraph());
+    service.setProvider(std::make_unique<ErrorProvider>(synth::AIProvider::AIErrorKind::Quota, "Quota used up."));
+
+    juce::ApplicationProperties props;
+    juce::PropertiesFile::Options options;
+    options.applicationName = "Test";
+    options.filenameSuffix = "test";
+    options.storageFormat = juce::PropertiesFile::storeAsXML;
+    props.setStorageParameters(options);
+
+    synth::AIChatComponent chatComponent(service, props);
+    chatComponent.setSize(400, 600);
+
+    juce::TextEditor* inputField = nullptr;
+    juce::TextButton* newChatButton = nullptr;
+    for (auto* child : chatComponent.getChildren()) {
+        if (auto* editor = dynamic_cast<juce::TextEditor*>(child))
+            inputField = editor;
+        else if (auto* button = dynamic_cast<juce::TextButton*>(child)) {
+            if (button->getButtonText() == "New Chat")
+                newChatButton = button;
+        }
+    }
+    ASSERT_NE(inputField, nullptr);
+    ASSERT_NE(newChatButton, nullptr);
+
+    inputField->setText("hello");
+    chatComponent.triggerSend();
+    juce::MessageManager::getInstance()->runDispatchLoopUntil(100);
+
+    ASSERT_NE(findDescendantWithText<juce::TextButton>(findMessageList(chatComponent), "Upgrade to Pro"), nullptr)
+        << "setup failed: the upgrade button never appeared";
+
+    EXPECT_NO_THROW(newChatButton->onClick());
+
+    EXPECT_EQ(findDescendantWithText<juce::TextButton>(findMessageList(chatComponent), "Upgrade to Pro"), nullptr)
+        << "New Chat must not resurrect the upgrade button";
 }

--- a/Tests/AccountServiceTests.cpp
+++ b/Tests/AccountServiceTests.cpp
@@ -59,6 +59,10 @@ public:
     AuthClient::HttpResult deviceCodeResponse = makeTransportFailure();
     AuthClient::HttpResult meResponse = makeStatus(200, R"({"id":"","email":"","display_name":"","created_at":""})");
     AuthClient::HttpResult revokeResponse = makeStatus(200, "");
+    // Defaults to a transport failure, same as every other unset canned response here — tests that
+    // don't care about entitlement get the same "fetchEntitlement failed, non-fatal" path
+    // completeSignIn() already tolerates for fetchMe(), so they don't need to set this explicitly.
+    AuthClient::HttpResult entitlementResponse = makeTransportFailure();
     // Consumed FIFO by /v1/auth/token calls (covers both the device-code poll and refreshToken());
     // the last entry repeats once exhausted, so a test that only cares about the first N calls
     // doesn't need to size this exactly.
@@ -69,6 +73,7 @@ public:
     int tokenCallCount = 0;
     int meCallCount = 0;
     int revokeCallCount = 0;
+    int entitlementCallCount = 0;
     std::vector<std::chrono::steady_clock::time_point> tokenCallTimes;
 
     AuthClient::HttpPerformer performer() {
@@ -98,8 +103,17 @@ public:
                 ++revokeCallCount;
                 return revokeResponse;
             }
+            if (url.endsWith("/v1/entitlement")) {
+                ++entitlementCallCount;
+                return entitlementResponse;
+            }
             return makeTransportFailure();
         };
+    }
+
+    int entitlementCalls() const {
+        const std::lock_guard<std::mutex> lock(mutex);
+        return entitlementCallCount;
     }
 
     int tokenCalls() const {
@@ -146,6 +160,24 @@ AuthClient::HttpResult makeMeSuccess(const juce::String& email) {
     obj->setProperty("email", email);
     obj->setProperty("display_name", "Test User");
     obj->setProperty("created_at", "2024-01-01");
+    return makeStatus(200, juce::JSON::toString(juce::var(obj.get())));
+}
+
+AuthClient::HttpResult makeEntitlementSuccess(const juce::String& plan, int limit, int used) {
+    juce::DynamicObject::Ptr usage = new juce::DynamicObject();
+    usage->setProperty("requests_used", used);
+    usage->setProperty("period_start", "2026-08-01");
+
+    juce::DynamicObject::Ptr limits = new juce::DynamicObject();
+    limits->setProperty("monthly_requests", limit);
+
+    juce::DynamicObject::Ptr obj = new juce::DynamicObject();
+    obj->setProperty("plan", plan);
+    obj->setProperty("status", "active");
+    obj->setProperty("period_end", juce::var());
+    obj->setProperty("cancel_at_period_end", false);
+    obj->setProperty("limits", juce::var(limits.get()));
+    obj->setProperty("usage", juce::var(usage.get()));
     return makeStatus(200, juce::JSON::toString(juce::var(obj.get())));
 }
 
@@ -437,6 +469,91 @@ TEST(AccountServiceTest, AttemptSilentSignInWithNoStoredTokenStaysSignedOutWitho
     juce::Thread::sleep(200);
     EXPECT_EQ(service.getSnapshot().state, AccountState::SignedOut);
     EXPECT_EQ(server.tokenCalls(), 0);
+}
+
+// ============================================================================
+// entitlement (P4-4)
+// ============================================================================
+
+TEST(AccountServiceTest, CompleteSignInPopulatesEntitlementFromSuccessfulFetch) {
+    FakeAuthServer server;
+    server.deviceCodeResponse = makeDeviceCodeResponse(0);
+    server.tokenResponses = {makeTokenSuccess("at1", "rt1")};
+    server.meResponse = makeMeSuccess("jane@example.com");
+    server.entitlementResponse = makeEntitlementSuccess("pro", 10000, 743);
+
+    AccountService service{kHost, server.performer(), std::make_unique<InMemoryTokenStore>()};
+    service.beginSignIn();
+
+    ASSERT_TRUE(waitUntil([&] { return service.getSnapshot().state == AccountState::SignedIn; }));
+    ASSERT_TRUE(waitUntil([&] { return service.getSnapshot().entitlementKnown; })) << "entitlement was never populated";
+
+    const auto snapshot = service.getSnapshot();
+    EXPECT_EQ(snapshot.plan, juce::String("pro"));
+    EXPECT_EQ(snapshot.monthlyRequestLimit, 10000);
+    EXPECT_EQ(snapshot.requestsUsed, 743);
+}
+
+TEST(AccountServiceTest, CompleteSignInLeavesEntitlementAtDefaultsWhenFetchFails) {
+    FakeAuthServer server;
+    server.deviceCodeResponse = makeDeviceCodeResponse(0);
+    server.tokenResponses = {makeTokenSuccess("at1", "rt1")};
+    server.meResponse = makeMeSuccess("jane@example.com");
+    // entitlementResponse left at its default transport failure.
+
+    AccountService service{kHost, server.performer(), std::make_unique<InMemoryTokenStore>()};
+    service.beginSignIn();
+
+    ASSERT_TRUE(waitUntil([&] { return service.getSnapshot().state == AccountState::SignedIn; }));
+    // Sign-in must not have been blocked by the entitlement failure — give the (failed) fetch a
+    // moment to have definitely run, then assert it left no trace.
+    juce::Thread::sleep(200);
+
+    const auto snapshot = service.getSnapshot();
+    EXPECT_FALSE(snapshot.entitlementKnown);
+    EXPECT_TRUE(snapshot.plan.isEmpty());
+    EXPECT_EQ(snapshot.monthlyRequestLimit, 0);
+    EXPECT_EQ(snapshot.requestsUsed, 0);
+}
+
+TEST(AccountServiceTest, RefreshEntitlementUpdatesSnapshotWithoutChangingSignInState) {
+    FakeAuthServer server;
+    server.deviceCodeResponse = makeDeviceCodeResponse(0);
+    server.tokenResponses = {makeTokenSuccess("at1", "rt1")};
+    server.meResponse = makeMeSuccess("jane@example.com");
+    server.entitlementResponse = makeEntitlementSuccess("free", 1000, 100);
+
+    AccountService service{kHost, server.performer(), std::make_unique<InMemoryTokenStore>()};
+    service.beginSignIn();
+    ASSERT_TRUE(waitUntil([&] { return service.getSnapshot().entitlementKnown; }));
+    ASSERT_EQ(service.getSnapshot().plan, juce::String("free"));
+    const int entitlementCallsAfterSignIn = server.entitlementCalls();
+
+    // Simulate "the user upgraded mid-session": the server now reports Pro.
+    server.entitlementResponse = makeEntitlementSuccess("pro", 10000, 101);
+    service.refreshEntitlement();
+
+    ASSERT_TRUE(waitUntil([&] { return server.entitlementCalls() > entitlementCallsAfterSignIn; }))
+        << "refreshEntitlement() never hit the network";
+    ASSERT_TRUE(waitUntil([&] { return service.getSnapshot().plan == juce::String("pro"); }));
+
+    const auto snapshot = service.getSnapshot();
+    EXPECT_EQ(snapshot.state, AccountState::SignedIn) << "refreshEntitlement() must not touch sign-in state";
+    EXPECT_EQ(snapshot.email, juce::String("jane@example.com")) << "refreshEntitlement() must not touch email";
+    EXPECT_EQ(snapshot.monthlyRequestLimit, 10000);
+    EXPECT_EQ(snapshot.requestsUsed, 101);
+}
+
+TEST(AccountServiceTest, RefreshEntitlementIsNoOpWhenSignedOut) {
+    FakeAuthServer server;
+
+    AccountService service{kHost, server.performer(), std::make_unique<InMemoryTokenStore>()};
+    ASSERT_EQ(service.getSnapshot().state, AccountState::SignedOut);
+
+    service.refreshEntitlement();
+
+    juce::Thread::sleep(200);
+    EXPECT_EQ(server.entitlementCalls(), 0);
 }
 
 // ============================================================================

--- a/Tests/AuthClientTests.cpp
+++ b/Tests/AuthClientTests.cpp
@@ -355,6 +355,85 @@ TEST(AuthClientTest, FetchMeUnauthorized) {
 }
 
 // ============================================================================
+// fetchEntitlement
+// ============================================================================
+
+TEST(AuthClientTest, FetchEntitlementSuccessParsesFieldsIncludingUsage) {
+    juce::String capturedMethod;
+    juce::StringPairArray capturedHeaders;
+
+    auto performer = [&](const juce::String& method, const juce::String& url, const juce::StringPairArray& headers,
+                         const juce::String&, int, const std::atomic<bool>&) -> synth::AuthClient::HttpResult {
+        capturedMethod = method;
+        capturedHeaders = headers;
+        EXPECT_EQ(url, kHost + "/v1/entitlement");
+        return makeStatus(200, R"({"plan":"pro","status":"active","period_end":"2026-09-11T09:14:00.000Z",)"
+                               R"("cancel_at_period_end":false,"limits":{"monthly_requests":10000},)"
+                               R"("usage":{"requests_used":743,"period_start":"2026-08-01"},)"
+                               R"("token":"eyJ...","expires_at":"2026-08-18T09:14:00.000Z",)"
+                               R"("refresh_after":"2026-08-11T10:14:00.000Z"})");
+    };
+
+    synth::AuthClient client{kHost, kClientId, performer};
+    const auto result = client.fetchEntitlement("access-token-123", kNeverCancelled);
+
+    ASSERT_TRUE(result.ok);
+    EXPECT_EQ(result.plan, juce::String("pro"));
+    EXPECT_EQ(result.status, juce::String("active"));
+    EXPECT_EQ(result.periodEndIso, juce::String("2026-09-11T09:14:00.000Z"));
+    EXPECT_FALSE(result.cancelAtPeriodEnd);
+    EXPECT_EQ(result.monthlyRequestLimit, 10000);
+    EXPECT_EQ(result.requestsUsed, 743);
+    EXPECT_EQ(result.usagePeriodStartIso, juce::String("2026-08-01"));
+
+    EXPECT_EQ(capturedMethod, juce::String("GET"));
+    EXPECT_EQ(capturedHeaders.getValue("Authorization", ""), juce::String("Bearer access-token-123"));
+}
+
+// Older/pre-P4-4 server: no `usage` key at all. The fetch must still succeed — the client
+// degrades to showing 0 used rather than failing the whole entitlement fetch.
+TEST(AuthClientTest, FetchEntitlementMissingUsageDefaultsToZero) {
+    auto performer = [](const juce::String&, const juce::String&, const juce::StringPairArray&, const juce::String&,
+                        int, const std::atomic<bool>&) -> synth::AuthClient::HttpResult {
+        return makeStatus(200, R"({"plan":"free","status":"active","period_end":null,)"
+                               R"("cancel_at_period_end":false,"limits":{"monthly_requests":1000}})");
+    };
+
+    synth::AuthClient client{kHost, kClientId, performer};
+    const auto result = client.fetchEntitlement("access-token-123", kNeverCancelled);
+
+    ASSERT_TRUE(result.ok);
+    EXPECT_EQ(result.plan, juce::String("free"));
+    EXPECT_EQ(result.requestsUsed, 0);
+    EXPECT_TRUE(result.usagePeriodStartIso.isEmpty());
+}
+
+TEST(AuthClientTest, FetchEntitlementUnauthorized) {
+    auto performer = [](const juce::String&, const juce::String&, const juce::StringPairArray&, const juce::String&,
+                        int, const std::atomic<bool>&) -> synth::AuthClient::HttpResult {
+        return makeStatus(401, R"({"error":{"code":"UNAUTHENTICATED"}})");
+    };
+
+    synth::AuthClient client{kHost, kClientId, performer};
+    const auto result = client.fetchEntitlement("bad-token", kNeverCancelled);
+
+    EXPECT_FALSE(result.ok);
+    EXPECT_TRUE(result.transportError.isNotEmpty());
+}
+
+TEST(AuthClientTest, FetchEntitlementTransportFailure) {
+    auto performer = [](const juce::String&, const juce::String&, const juce::StringPairArray&, const juce::String&,
+                        int,
+                        const std::atomic<bool>&) -> synth::AuthClient::HttpResult { return makeTransportFailure(); };
+
+    synth::AuthClient client{kHost, kClientId, performer};
+    const auto result = client.fetchEntitlement("access-token-123", kNeverCancelled);
+
+    EXPECT_FALSE(result.ok);
+    EXPECT_TRUE(result.transportError.isNotEmpty());
+}
+
+// ============================================================================
 // revoke / logout — fire-and-forget
 // ============================================================================
 

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -47,6 +47,7 @@ add_executable(Tests
     GraphEditorTests.cpp
     ModuleComponentTests.cpp
     AIChatComponentTests.cpp
+    PlanBadgeTests.cpp
     PolyMidiModuleTests.cpp
     PolySequencerModuleTests.cpp
     AIIntegrationServiceTests.cpp
@@ -104,6 +105,7 @@ add_executable(Tests
     ../Source/UI/ModMatrixComponent.cpp
     ../Source/UI/AIChatComponent.cpp
     ../Source/UI/AccountRow.cpp
+    ../Source/UI/PlanBadge.cpp
     ../Source/UI/SignInDialog.cpp
     ../Source/UI/ModuleComponent.cpp
     ../Source/UI/SettingsWindow.cpp

--- a/Tests/PlanBadgeTests.cpp
+++ b/Tests/PlanBadgeTests.cpp
@@ -1,0 +1,176 @@
+#include "../Source/AI/AccountService.h"
+#include "../Source/Auth/InMemoryTokenStore.h"
+#include "../Source/UI/PlanBadge.h"
+#include <gtest/gtest.h>
+#include <juce_gui_basics/juce_gui_basics.h>
+
+namespace {
+
+using synth::AccountService;
+using synth::AuthClient;
+using synth::InMemoryTokenStore;
+using synth::PlanBadge;
+
+const juce::String kHost = "http://mock-host:8787";
+
+AuthClient::HttpResult makeStatus(int status, const juce::String& body) {
+    AuthClient::HttpResult result;
+    result.httpStatus = status;
+    result.body = body;
+    return result;
+}
+
+AuthClient::HttpResult makeTransportFailure() {
+    AuthClient::HttpResult result;
+    result.transportFailed = true;
+    result.errorMessage = "offline";
+    return result;
+}
+
+AuthClient::HttpResult makeMeSuccess(const juce::String& email) {
+    juce::DynamicObject::Ptr obj = new juce::DynamicObject();
+    obj->setProperty("id", "user-1");
+    obj->setProperty("email", email);
+    obj->setProperty("display_name", "Test User");
+    obj->setProperty("created_at", "2024-01-01");
+    return makeStatus(200, juce::JSON::toString(juce::var(obj.get())));
+}
+
+AuthClient::HttpResult makeEntitlementSuccess(const juce::String& plan, int limit, int used) {
+    juce::DynamicObject::Ptr usage = new juce::DynamicObject();
+    usage->setProperty("requests_used", used);
+    usage->setProperty("period_start", "2026-08-01");
+
+    juce::DynamicObject::Ptr limits = new juce::DynamicObject();
+    limits->setProperty("monthly_requests", limit);
+
+    juce::DynamicObject::Ptr obj = new juce::DynamicObject();
+    obj->setProperty("plan", plan);
+    obj->setProperty("status", "active");
+    obj->setProperty("period_end", juce::var());
+    obj->setProperty("cancel_at_period_end", false);
+    obj->setProperty("limits", juce::var(limits.get()));
+    obj->setProperty("usage", juce::var(usage.get()));
+    return makeStatus(200, juce::JSON::toString(juce::var(obj.get())));
+}
+
+// Routes AuthClient's requests by URL suffix — same idiom as AccountServiceTests.cpp's
+// FakeAuthServer, trimmed to just what completeSignIn() needs (token/me/entitlement).
+AuthClient::HttpPerformer makeSignInPerformer(const AuthClient::HttpResult& tokenResponse,
+                                              const AuthClient::HttpResult& meResponse,
+                                              const AuthClient::HttpResult& entitlementResponse) {
+    return [=](const juce::String&, const juce::String& url, const juce::StringPairArray&, const juce::String&, int,
+               const std::atomic<bool>&) -> AuthClient::HttpResult {
+        if (url.endsWith("/v1/auth/token"))
+            return tokenResponse;
+        if (url.endsWith("/v1/auth/me"))
+            return meResponse;
+        if (url.endsWith("/v1/entitlement"))
+            return entitlementResponse;
+        return makeTransportFailure();
+    };
+}
+
+AuthClient::HttpResult makeTokenSuccess(const juce::String& accessToken, const juce::String& refreshToken) {
+    juce::DynamicObject::Ptr obj = new juce::DynamicObject();
+    obj->setProperty("access_token", accessToken);
+    obj->setProperty("token_type", "Bearer");
+    obj->setProperty("expires_in", 3600);
+    obj->setProperty("refresh_token", refreshToken);
+    return makeStatus(200, juce::JSON::toString(juce::var(obj.get())));
+}
+
+template <typename Predicate>
+bool waitUntil(Predicate predicate, std::chrono::milliseconds timeout = std::chrono::milliseconds{10000}) {
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    do {
+        if (predicate())
+            return true;
+        juce::MessageManager::getInstance()->runDispatchLoopUntil(10);
+    } while (std::chrono::steady_clock::now() < deadline);
+    return predicate();
+}
+
+} // namespace
+
+TEST(PlanBadgeTest, ZeroHeightAndInvisibleWithNoAccountService) {
+    PlanBadge badge;
+    EXPECT_EQ(badge.getPreferredHeight(), 0);
+    EXPECT_FALSE(badge.isVisible());
+}
+
+TEST(PlanBadgeTest, ZeroHeightWhenSignedOut) {
+    AccountService service{kHost,
+                           [](const juce::String&, const juce::String&, const juce::StringPairArray&,
+                              const juce::String&, int,
+                              const std::atomic<bool>&) -> AuthClient::HttpResult { return makeTransportFailure(); },
+                           std::make_unique<InMemoryTokenStore>()};
+
+    PlanBadge badge;
+    badge.setAccountService(&service);
+
+    EXPECT_EQ(badge.getPreferredHeight(), 0);
+    EXPECT_FALSE(badge.isVisible());
+
+    badge.setAccountService(nullptr);
+}
+
+TEST(PlanBadgeTest, RendersFreePlanTextOnceEntitlementIsKnown) {
+    auto performer = makeSignInPerformer(makeTokenSuccess("at1", "rt1"), makeMeSuccess("jane@example.com"),
+                                         makeEntitlementSuccess("free", 1000, 240));
+    // attemptSilentSignIn() (refreshToken()) rather than beginSignIn() (the device-code flow) —
+    // this test only needs to reach completeSignIn(), and refreshToken() hits the same
+    // /v1/auth/token endpoint makeSignInPerformer already answers, with no device-code step.
+    auto tokenStore = std::make_unique<InMemoryTokenStore>();
+    tokenStore->save("stored-refresh-token");
+    AccountService service{kHost, performer, std::move(tokenStore)};
+
+    PlanBadge badge;
+    badge.setAccountService(&service);
+
+    service.attemptSilentSignIn();
+    ASSERT_TRUE(waitUntil([&] { return service.getSnapshot().entitlementKnown; }));
+    badge.refresh();
+
+    EXPECT_TRUE(badge.isVisible());
+    EXPECT_GT(badge.getPreferredHeight(), 0);
+
+    juce::Label* label = nullptr;
+    for (auto* child : badge.getChildren()) {
+        if (auto* l = dynamic_cast<juce::Label*>(child))
+            label = l;
+    }
+    ASSERT_NE(label, nullptr);
+    EXPECT_TRUE(label->getText().contains("Free"));
+    EXPECT_TRUE(label->getText().contains("240"));
+    EXPECT_TRUE(label->getText().contains("1000"));
+
+    badge.setAccountService(nullptr);
+}
+
+TEST(PlanBadgeTest, RendersProPlanTextOnceEntitlementIsKnown) {
+    auto performer = makeSignInPerformer(makeTokenSuccess("at1", "rt1"), makeMeSuccess("jane@example.com"),
+                                         makeEntitlementSuccess("pro", 10000, 1203));
+    auto tokenStore = std::make_unique<InMemoryTokenStore>();
+    tokenStore->save("stored-refresh-token");
+    AccountService service{kHost, performer, std::move(tokenStore)};
+
+    PlanBadge badge;
+    badge.setAccountService(&service);
+
+    service.attemptSilentSignIn();
+    ASSERT_TRUE(waitUntil([&] { return service.getSnapshot().entitlementKnown; }));
+    badge.refresh();
+
+    juce::Label* label = nullptr;
+    for (auto* child : badge.getChildren()) {
+        if (auto* l = dynamic_cast<juce::Label*>(child))
+            label = l;
+    }
+    ASSERT_NE(label, nullptr);
+    EXPECT_TRUE(label->getText().contains("Pro"));
+    EXPECT_TRUE(label->getText().contains("1203"));
+    EXPECT_TRUE(label->getText().contains("10000"));
+
+    badge.setAccountService(nullptr);
+}

--- a/Tests/RemoteProviderTests.cpp
+++ b/Tests/RemoteProviderTests.cpp
@@ -373,6 +373,30 @@ TEST_F(RemoteProviderTest, MapsTooManyRequestsToRateLimitAndReadsRetryAfter) {
     EXPECT_EQ(result.error.retryAfterSeconds, 45);
 }
 
+// P4-3's monthly quota (enforce-quota.ts) answers 429 QUOTA_EXCEEDED — this must map to Quota
+// (the P4-4 upgrade-bubble UI keys off this kind), not the generic RateLimit above.
+TEST_F(RemoteProviderTest, MapsQuotaExceeded429ToQuotaError) {
+    auto performer = [](const juce::String&, const juce::StringPairArray&, const juce::String&, int,
+                        const std::atomic<bool>&) -> synth::RemoteProvider::HttpResult {
+        return makeStatus(429, R"({"error":{"code":"QUOTA_EXCEEDED",)"
+                               R"("message":"Your monthly request quota is used up. Upgrading to Pro raises it."}})");
+    };
+
+    synth::RemoteProvider provider{kMockHost, performer};
+    provider.setTestMode(true);
+
+    MockPromptCallback callback;
+    provider.sendPrompt(
+        {{"user", "hi"}}, [&callback](const synth::AIProvider::AIResponse& r) { callback(r); }, makeSchema());
+
+    auto result = callback.getResult();
+    provider.stopThread(5000);
+
+    EXPECT_FALSE(result.success);
+    EXPECT_EQ(result.error.kind, synth::AIProvider::AIErrorKind::Quota);
+    EXPECT_EQ(result.error.message, juce::String("Your monthly request quota is used up. Upgrading to Pro raises it."));
+}
+
 // ============================================================================
 // Success / malformed bodies
 // ============================================================================

--- a/docs/AI_Engine.md
+++ b/docs/AI_Engine.md
@@ -608,7 +608,8 @@ same as `OllamaProvider` checks `wasCancelled()` right after the network call re
 | `timedOut`                                    | `Timeout`                        |
 | `cancelled`                                   | `Cancelled`                      |
 | HTTP 401 / 403                                | `Auth`                            |
-| HTTP 429 (reads `Retry-After`)                | `RateLimit`                      |
+| HTTP 429, `error.code == "QUOTA_EXCEEDED"`    | `Quota` (P4-3's monthly quota — see "Quota UI and the Upgrade Path" below) |
+| HTTP 429, any other/no code                   | `RateLimit` (reads `Retry-After`) |
 | HTTP 402, `error.code == "TRIAL_EXHAUSTED"`   | `TrialExhausted` (see "Device Id and Anonymous Trial" below) |
 | HTTP 402, any other/no code                   | `Quota`                           |
 | HTTP 503, `error.code == "SERVICE_CAPACITY_EXCEEDED"` | `ServiceCapacityExceeded` (see below) |
@@ -619,10 +620,12 @@ same as `OllamaProvider` checks `wasCancelled()` right after the network call re
 Whenever the response body parses as JSON with a string `error.message`, it is appended to the
 delivered error message (mirrors the "name the specific failure" ethos on
 `AIIntegrationService::buildCorrectionPrompt`); otherwise the message just names the HTTP status.
-`TrialExhausted` and `ServiceCapacityExceeded` are the two exceptions to "appended": the server's
-`error.message` there is a complete, user-facing sentence on its own (see below), so it is
-delivered verbatim as `AIError::message` rather than tacked onto a generic "reported insufficient
-quota (HTTP 402)"-style prefix.
+`TrialExhausted`, `ServiceCapacityExceeded`, and `Quota` via the `QUOTA_EXCEEDED` 429 path are the
+exceptions to "appended": the server's `error.message` there is a complete, user-facing sentence on
+its own (see below and "Quota UI and the Upgrade Path"), so it is delivered verbatim as
+`AIError::message` rather than tacked onto a generic prefix. The pre-existing generic-402 `Quota`
+mapping (no recognised code) keeps the appended-prefix behaviour — only the `QUOTA_EXCEEDED` 429
+path is verbatim.
 
 **Cancellation, simplified vs `OllamaProvider`.** libcurl doesn't need the
 `StreamPublisher`/`activeStream`/`streamLock` machinery `OllamaProvider` uses to abort a
@@ -694,15 +697,58 @@ empty, field/header omitted) so unit tests never touch the real per-install file
 `AIErrorKind::TrialExhausted` with the server's `message` carried through unchanged (see the
 error-kind table above). That response reaches `AIChatComponent` through the same path every other
 provider error already does — appended to the conversation as an assistant bubble
-(`"Error: " + error.message`) — so no new UI surface is needed. When the caller is not signed in,
-the server's message text specifically invites signing in with Google to continue; the existing
+(`"Error: " + error.message`) — so no new UI surface is needed. This "no new UI surface" reasoning
+is specific to `TrialExhausted`: the caller isn't signed in yet, so "upgrade" isn't the right verb —
+the server's message text specifically invites signing in with Google to continue, and the existing
 `AccountRow` "Sign in" affordance (see "Account Sign-In Surface" above) is already visible
 immediately above the chat whenever an `AccountService` is attached, so the next step (opening
 `SignInDialog`) is always one click away without this feature needing to auto-launch it. A
 service-wide `503 {"error":{"code":"SERVICE_CAPACITY_EXCEEDED","message":"..."}}` is handled the
 same way but mapped to the distinct `AIErrorKind::ServiceCapacityExceeded` — it's a daily cap on
 the service as a whole, unrelated to the caller's own trial/quota, and gets its own message rather
-than being confused with either.
+than being confused with either. `AIErrorKind::Quota` (a signed-in account over its *paid* plan's
+allowance) is the one case that does get a new UI surface — see below.
+
+### Quota UI and the Upgrade Path (P4-4)
+
+Once a caller is signed in, P4-3's monthly request quota (`enforce-quota.ts`, `synth-platform`)
+answers `429 {"error":{"code":"QUOTA_EXCEEDED","message":"..."}}` when it's exhausted, mapped by
+`RemoteProvider` to `AIErrorKind::Quota` with the server's message carried through unchanged (see
+the error-kind table above). Unlike `TrialExhausted`, this *is* the "you're signed in, you're over
+your plan, upgrading raises it" moment, so `AIChatComponent` gives it a distinct treatment instead
+of the flat error bubble every other kind gets:
+
+- The assistant bubble carries the server's message verbatim (no `"Error: "` prefix, same as
+  `TrialExhausted`/`ServiceCapacityExceeded`) plus an **"Upgrade to Pro"** button, opening
+  `synth::branding::kUpgradeUrl` (`Source/Branding.h` — a static Polar checkout link; P4-4 does not
+  create checkout sessions dynamically, per `docs/billing.md`'s "what this deliberately does not
+  do") via the injected `urlOpener` (`AIChatComponent::setUrlOpenerForTesting()` swaps this for a
+  non-browser-launching fake in tests).
+- This button is carried on `MessageData::showUpgradeAction`, which is deliberately **not**
+  reconstructed by the history-replay loop in `AIChatComponent`'s constructor — a `New Chat` or app
+  restart drops it along with the rest of that turn's transient UI state (the same way
+  Cancel-button/spinner state never survives a reload).
+- A `Quota` error also triggers `AccountService::refreshEntitlement()` — a fire-and-forget re-fetch
+  of `GET /v1/entitlement` that updates the account's cached plan/limit/usage without touching
+  sign-in state, so a user who upgrades mid-session and immediately retries sees their new plan
+  reflected (in `PlanBadge`, below) without restarting the app.
+
+**`PlanBadge`** (`Source/UI/PlanBadge.h/.cpp`) is a small usage indicator placed in the same
+bottom-chrome stack as `AccountRow` and the model picker, showing `"Free · 240 / 1000 this month"`
+or `"Pro · 1,203 / 10,000 this month"`. It follows `AccountRow`'s exact zero-height-when-absent
+contract (`setAccountService()`/`refresh()`/`getPreferredHeight()`) — invisible and contributing
+nothing to layout until an `AccountService` is attached *and* has a known entitlement
+(`AccountSnapshot::entitlementKnown`), which `AccountService::completeSignIn()` populates alongside
+`fetchMe()` (same non-fatal contract: an entitlement-fetch failure never blocks sign-in) and
+`refreshEntitlement()` updates on demand. `usage.requests_used` is a P4-4 addition to the
+`GET /v1/entitlement` response (`docs/billing.md`) — `AuthClient::fetchEntitlement()` degrades to
+`requestsUsed = 0` rather than failing the whole parse if an older server doesn't send it.
+
+**Not yet end-to-end reachable.** `RemoteProvider` is still `hidden=true` (see "Ships hidden"
+above) — flipping the default to hosted is P4-6. This feature is fully built and unit-tested (the
+429→`Quota` mapping, `fetchEntitlement()`, `AccountService`'s entitlement fields, `PlanBadge`, and
+the upgrade bubble), but nothing in the shipped app can currently select the hosted provider that
+would ever produce a real `Quota` error.
 
 ## 6. Future Considerations
 


### PR DESCRIPTION
## Summary
- On a `Quota`-kind AI error (P4-3's monthly request quota), the assistant bubble now shows the server's message verbatim with an "Upgrade to Pro" button (opens `Branding::kUpgradeUrl`, a static Polar checkout link) instead of the flat `"Error: ..."` string.
- New `PlanBadge` component near the model picker shows `"Free · N / M this month"` / `"Pro · N / M this month"`, sourced from `AccountService`'s entitlement fields (fetched alongside `fetchMe()` on sign-in, refreshable via the new `refreshEntitlement()`).
- **Bug fix found while wiring this up**: `RemoteProvider` mapped every HTTP 429 to `RateLimit` unconditionally. The real P4-3 monthly-quota-exceeded response is `429 {"error":{"code":"QUOTA_EXCEEDED"}}`, not the `402` the pre-existing `Quota` mapping was written for — without this fix the real quota error was silently misclassified and the new upgrade UI would never fire.

## Dependency
Depends on https://github.com/Diabl0269/synth-platform/pull/40 for the `usage` field on `GET /v1/entitlement` (that PR is merged/done, backend tests 166/166 passing). This client degrades gracefully if `usage` is absent from the response — `AuthClient::fetchEntitlement()` just defaults `requestsUsed` to 0 rather than failing the parse — so merge order isn't strictly blocking.

## Not yet reachable end-to-end
`RemoteProvider` is still `hidden=true` (flipping the default to hosted is P4-6), so nothing in the shipped app can currently select the provider that would produce a real `Quota` error. This PR is fully unit-tested but the feature isn't user-visible yet.

## Test plan
- [x] `cmake -S . -B build -DENABLE_TESTS=ON && cmake --build build --target Tests && ./build/Tests/Tests` — 1525/1525 passing
- [x] New tests: `RemoteProviderTests` (429→Quota mapping), `AuthClientTests` (fetchEntitlement), `AccountServiceTests` (entitlement fetch + refreshEntitlement), `PlanBadgeTests`, `AIChatComponentTests` (upgrade bubble rendering/click/non-persistence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)