### PR TITLE
feat(ai): flip default AI provider to hosted (P4-6)

### DIFF
--- a/Source/AI/AIIntegrationService.h
+++ b/Source/AI/AIIntegrationService.h
@@ -180,6 +180,12 @@ public:
     juce::String getCurrentModel() const;
     void fetchAvailableModels(std::function<void(const juce::StringArray& models, bool success)> callback);
 
+    /**
+     * @brief True when the active provider sends the prompt/patch to a remote/hosted server
+     *        (RemoteProvider). False for a local provider (Ollama) or when none is installed yet.
+     */
+    bool isCurrentProviderHosted() const { return provider != nullptr && provider->isHosted(); }
+
 private:
     std::unique_ptr<AIProvider> provider;
     std::vector<AIProvider::Message> chatHistory;

--- a/Source/AI/AIProvider.h
+++ b/Source/AI/AIProvider.h
@@ -122,6 +122,14 @@ public:
      *        default, so providers with no notion of auth (e.g. local Ollama) are unaffected.
      */
     virtual void setAuthToken(const juce::String&) {}
+
+    /**
+     * @brief True when this provider sends the prompt and current patch to a remote/hosted
+     *        server for processing (RemoteProvider); false for a purely local provider (Ollama)
+     *        or any test double. Drives the hosted-mode privacy notice in AIChatComponent — see
+     *        AIIntegrationService::isCurrentProviderHosted().
+     */
+    virtual bool isHosted() const { return false; }
 };
 
 } // namespace synth

--- a/Source/AI/AIProviderRegistry.cpp
+++ b/Source/AI/AIProviderRegistry.cpp
@@ -1,4 +1,5 @@
 #include "AIProviderRegistry.h"
+#include "../Branding.h"
 #include "OllamaProvider.h"
 #include "RemoteProvider.h"
 
@@ -34,18 +35,20 @@ AIProviderRegistry AIProviderRegistry::createDefault() {
          }});
 
     // Registered AFTER "ollama" — order matters: AIProviderRegistry::create() falls back to
-    // descriptors.front() for an unknown/empty id, and that fallback must stay "ollama".
-    // hidden=true: ships wired up (constructible, registered, testable) but not yet offered in
-    // AISettingsTab's provider combo. Phase 4 is expected to flip this to false.
+    // descriptors.front() for an unknown/empty id, and that fallback must stay "ollama". This is
+    // deliberate even now that "remote" is the default (see MainComponent::resolveDefaultProviderId()):
+    // an unrecognised/corrupt persisted id fails safe to the provider that sends no data anywhere,
+    // never to the one that does.
+    // hidden=false as of P4-6: offered in AISettingsTab's provider combo alongside "ollama".
     registry.registerProvider({"remote", "Remote (hosted)", true, true,
                                [](const ProviderConfig& config) -> std::unique_ptr<AIProvider> {
                                    auto provider = std::make_unique<RemoteProvider>(
-                                       config.host.isNotEmpty() ? config.host : "http://localhost:8787");
+                                       config.host.isNotEmpty() ? config.host : synth::branding::kApiBaseUrl);
                                    if (config.authToken.isNotEmpty())
                                        provider->setAuthToken(config.authToken);
                                    return provider;
                                },
-                               /*hidden=*/true});
+                               /*hidden=*/false});
 
     return registry;
 }

--- a/Source/AI/RemoteProvider.h
+++ b/Source/AI/RemoteProvider.h
@@ -26,8 +26,8 @@ namespace synth {
  * Non-streaming: onDelta is accepted for interface compatibility but never invoked, because the
  * service's patch.generate endpoint is not streaming-capable (a single `c.json({data})`).
  *
- * Ships registered in AIProviderRegistry but hidden from the Settings UI
- * (ProviderDescriptor::hidden) until a later phase turns it on.
+ * Registered in AIProviderRegistry as "remote" and, as of P4-6, the default provider — see
+ * ProviderDescriptor::hidden and AIProviderRegistry::createDefault().
  */
 class RemoteProvider
     : public AIProvider
@@ -78,6 +78,7 @@ public:
     void cancel(RequestId requestId) override;
 
     juce::String getProviderName() const override { return "Remote"; }
+    bool isHosted() const override { return true; }
 
     using juce::Thread::stopThread; // Make stopThread public for testing purposes
 
@@ -89,6 +90,10 @@ public:
     void setAuthToken(const juce::String& token) override;
 
     void setTestMode(bool testMode) { isTestMode = testMode; }
+
+    // Test-only accessor so a test can confirm which host a provider ended up constructed with
+    // (e.g. AIProviderRegistry's empty-host fallback) without making a real HTTP call.
+    juce::String getHostForTesting() const { return remoteHost; }
 
 private:
     juce::String remoteHost;

--- a/Source/Branding.h
+++ b/Source/Branding.h
@@ -48,4 +48,12 @@ constexpr const char* kSupportEmail = "support@agentsynth.app";
 // "what this deliberately does not do" for why P4-4 doesn't create checkout sessions.
 constexpr const char* kUpgradeUrl = "https://buy.polar.sh/polar_cl_DkiJlmel2CXVtpl236TvS52omgYaZM26HGe1U0rbD75";
 
+// Production base URL for the synth-platform inference/auth/billing service (Cloud Run,
+// apps/infra/Pulumi.prod.yaml's authPublicBaseUrl in the synth-platform repo). Default host for
+// RemoteProvider, AuthClient and AccountService — see AIProviderRegistry.cpp and
+// MainComponent.h/.cpp. As of P4-6 the Cloud Run service still has no `allUsers` invoker binding
+// (tracked separately under P4-7), so requests here 403 at the IAM layer until that follow-up
+// infra step makes it public — expected, not a bug in this client.
+constexpr const char* kApiBaseUrl = "https://synth-api-6eft3t2kxq-uc.a.run.app";
+
 } // namespace synth::branding

--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -96,16 +96,47 @@ void MainComponent::initialiseCommon(std::unique_ptr<synth::AIProvider> provider
         appProperties.saveIfNeeded();
     };
 
-    // Load AI provider preference. "ollama" is the persisted id (see AIProviderRegistry),
-    // not a display name — registry.create() falls back to the first registered provider
-    // if the saved id is unknown (e.g. stale pre-registry value, or empty).
-    juce::String savedProviderId = appProperties.getUserSettings()->getValue("aiProvider", "ollama");
-    juce::String savedOllamaHost = appProperties.getUserSettings()->getValue("ollamaHost", "http://localhost:11434");
-
     if (provider) {
         aiService.setProvider(std::move(provider));
     } else {
-        aiService.setProvider(registry.create(savedProviderId, {savedOllamaHost, {}}));
+        // Load AI provider preference. The persisted id (see AIProviderRegistry) is not a
+        // display name — registry.create() falls back to the first registered provider ("ollama")
+        // if the saved id is unknown (e.g. stale pre-registry value, or empty).
+        //
+        // P4-6 migration: "aiProvider" is only ever WRITTEN by AISettingsTab::updateSettings(), so
+        // most existing installs have never persisted it, even after months of use — its absence
+        // alone can't distinguish "brand new install" from "existing user who never opened AI
+        // settings". existsAsFile() can: it reflects whether the settings file was already on disk
+        // before this launch touched anything (nothing above this point in initialiseCommon(), nor
+        // shortcutManager.loadFromProperties()/themeManager->initialise() in the constructor, writes
+        // to appProperties — all read-only). See resolveDefaultProviderId() for the pure decision.
+        const bool hasExistingSettingsFile = appProperties.getUserSettings()->getFile().existsAsFile();
+        const juce::String defaultProviderId = resolveDefaultProviderId(hasExistingSettingsFile);
+        juce::String savedProviderId = appProperties.getUserSettings()->getValue("aiProvider", defaultProviderId);
+
+        // Pin the resolved id so every other reader of "aiProvider" (AISettingsTab) agrees with
+        // what actually got constructed here, instead of independently re-deriving a default.
+        // saveIfNeeded() is required, not optional: without it, a fresh install that resolves to
+        // "remote" here only holds that in memory — if the process exits before some OTHER write
+        // flushes the file, launch 2 finds a settings file on disk (from this launch's theme/
+        // shortcut/panel-visibility writes) with no "aiProvider" key in it, resolves
+        // hasExistingSettingsFile=true, and silently reverts a brand new install to "ollama".
+        if (!appProperties.getUserSettings()->containsKey("aiProvider")) {
+            appProperties.getUserSettings()->setValue("aiProvider", savedProviderId);
+            appProperties.saveIfNeeded();
+        }
+
+        // Each provider persists its own host under its own key — "ollamaHost" and "remoteHost"
+        // must never collide, or switching providers in Settings silently points one of them at
+        // the other's address (see AISettingsTab::hostSettingsKeyFor()). An empty remoteHost
+        // default lets AIProviderRegistry::createDefault() fall back to
+        // synth::branding::kApiBaseUrl.
+        const juce::String hostKey = savedProviderId == "remote" ? "remoteHost" : "ollamaHost";
+        const juce::String hostDefault =
+            savedProviderId == "remote" ? juce::String() : juce::String("http://localhost:11434");
+        juce::String savedHost = appProperties.getUserSettings()->getValue(hostKey, hostDefault);
+
+        aiService.setProvider(registry.create(savedProviderId, {savedHost, {}}));
     }
 
     // ORDERING CONTRACT: aiChatComponent is a member, so its constructor (which calls

--- a/Source/MainComponent.h
+++ b/Source/MainComponent.h
@@ -5,6 +5,7 @@
 #include "AI/AccountService.h"
 #include "AppUndoManager.h"
 #include "AudioEngine.h"
+#include "Branding.h"
 #include "PresetManager.h"
 #include "ShortcutManager.h"
 #include "SnippetManager.h"
@@ -56,6 +57,18 @@ public:
 
     juce::ApplicationCommandManager& getCommandManager() { return commandManager; }
     void updateCommandShortcuts();
+
+    // P4-6: pure decision function for the AI provider id used when no "aiProvider" key is
+    // persisted yet. A brand new install (no pre-existing settings file at all) defaults to
+    // "remote" (hosted); an install that has launched before but never touched AI settings — the
+    // common case, since that key is only ever written by AISettingsTab::updateSettings() —
+    // keeps its working "ollama" default rather than being silently moved to hosted on upgrade.
+    // Extracted as a free function so this decision is unit-testable without touching a real
+    // properties file — see initialiseCommon() for the caller and the existsAsFile() check it's
+    // based on.
+    static juce::String resolveDefaultProviderId(bool hasExistingSettingsFile) {
+        return hasExistingSettingsFile ? juce::String("ollama") : juce::String("remote");
+    }
 
     // Testing Hooks
     bool isAiPanelConfiguredVisible() const { return isAiPanelVisible; }
@@ -189,7 +202,9 @@ private:
     // aiChatComponent (which installs AccountService::onStateChanged/onAccessTokenChanged in
     // setAccountService(), see its header comment) is torn down first, while accountService is
     // still alive to have those callback slots cleared.
-    synth::AccountService accountService;
+    // P4-6: explicit production host — the AccountService(host) default of localhost:8787 is a
+    // dev/test convenience only, and MainComponent is the real composition root.
+    synth::AccountService accountService{synth::branding::kApiBaseUrl};
     synth::AIChatComponent aiChatComponent;
     bool isAiPanelVisible = false;
     bool isLibraryVisible{true};

--- a/Source/UI/AIChatComponent.cpp
+++ b/Source/UI/AIChatComponent.cpp
@@ -282,6 +282,17 @@ AIChatComponent::AIChatComponent(AIIntegrationService& service, juce::Applicatio
         appProperties.getUserSettings()->saveIfNeeded();
     };
 
+    // Starts invisible (same contract as accountRow/planBadge) — updateHostedModeNotice(), called
+    // from refreshModels() below, sets its real visibility once a provider is known.
+    addChildComponent(hostedModeNotice);
+    hostedModeNotice.setJustificationType(juce::Justification::centredLeft);
+    hostedModeNotice.setMinimumHorizontalScale(1.0f);
+    hostedModeNotice.setFont(juce::Font(11.0f));
+    hostedModeNotice.setText("Hosted mode sends your prompt and current patch to Agent Synth's servers.",
+                             juce::dontSendNotification);
+    hostedModeNotice.setTooltip("Local (Ollama) mode keeps everything on this machine. See " +
+                                juce::String(synth::branding::kWebsiteUrl) + "/privacy for details.");
+
     refreshModels();
 
     // Populate history
@@ -421,8 +432,13 @@ void AIChatComponent::resized() {
     const int planBadgeHeight = planBadge.getPreferredHeight();
     const int planBadgeGap = planBadgeHeight > 0 ? 5 : 0;
 
-    auto bottomArea = b.removeFromBottom(70 + accountRowHeight + accountRowGap + planBadgeHeight +
-                                         planBadgeGap); // Increased height for all three rows
+    // Hosted-mode privacy notice: same zero-height-when-absent contract, reserved only while the
+    // active provider is hosted (see updateHostedModeNotice()).
+    const int hostedNoticeHeight = hostedModeNotice.isVisible() ? 18 : 0;
+    const int hostedNoticeGap = hostedNoticeHeight > 0 ? 5 : 0;
+
+    auto bottomArea = b.removeFromBottom(70 + accountRowHeight + accountRowGap + planBadgeHeight + planBadgeGap +
+                                         hostedNoticeHeight + hostedNoticeGap); // Increased height for all four rows
 
     // Bottom row: Input + Send (+ Cancel when waiting + spinner dot)
     auto inputRow = bottomArea.removeFromBottom(40);
@@ -449,6 +465,11 @@ void AIChatComponent::resized() {
 #ifndef NDEBUG
     toggleDebugButton.setBounds(modelRow.removeFromRight(60));
 #endif
+
+    if (hostedNoticeHeight > 0) {
+        bottomArea.removeFromBottom(hostedNoticeGap);
+        hostedModeNotice.setBounds(bottomArea.removeFromBottom(hostedNoticeHeight));
+    }
 
     if (planBadgeHeight > 0) {
         bottomArea.removeFromBottom(planBadgeGap);
@@ -723,6 +744,10 @@ void AIChatComponent::updateChatDisplay() {
 void AIChatComponent::scrollToBottom() { viewport.setViewPosition(0, messageList.getHeight()); }
 
 void AIChatComponent::refreshModels() {
+    // Provider identity (unlike its model list) is known synchronously right after
+    // setProvider() — no need to wait for the fetch below to resolve.
+    updateHostedModeNotice();
+
     // refreshModels() is called repeatedly over the component's lifetime (once at
     // construction with no provider yet, again after MainComponent installs one, and
     // again whenever Settings triggers a re-fetch) — never just once. Without this
@@ -761,11 +786,29 @@ void AIChatComponent::refreshModels() {
                 modelPicker.setSelectedId(1, juce::dontSendNotification);
                 aiService.setModel(models[0]);
             }
+        } else if (success) {
+            // Empty-but-successful is not a fetch failure — RemoteProvider's fetchAvailableModels()
+            // always resolves this way, because the hosted service picks its own model server-side
+            // (see RemoteProvider::fetchAvailableModels()'s doc comment). Showing "Error fetching
+            // models" here would be actively misleading to every hosted-mode user.
+            modelPicker.addItem("Model chosen automatically", 1);
+            modelPicker.setSelectedId(1, juce::dontSendNotification);
+            modelPicker.setEnabled(false);
         } else {
             modelPicker.addItem("Error fetching models", 1);
             modelPicker.setSelectedId(1, juce::dontSendNotification);
         }
     });
+}
+
+void AIChatComponent::updateHostedModeNotice() {
+    const bool hosted = aiService.isCurrentProviderHosted();
+    if (hosted) {
+        if (auto* lf = dynamic_cast<synth::theme::AppLookAndFeel*>(&getLookAndFeel()))
+            hostedModeNotice.setColour(juce::Label::textColourId, lf->getTheme().colors.textMuted);
+    }
+    hostedModeNotice.setVisible(hosted);
+    resized();
 }
 
 #ifndef NDEBUG

--- a/Source/UI/AIChatComponent.h
+++ b/Source/UI/AIChatComponent.h
@@ -171,6 +171,11 @@ private:
     juce::TextButton newChatButton;
     juce::ComboBox modelPicker;
 
+    // P4-6 privacy disclosure: visible only while the active provider is hosted (RemoteProvider).
+    // Zero-height/invisible otherwise, same contract as accountRow/planBadge below it in the
+    // bottom-chrome stack — see updateHostedModeNotice() and resized().
+    juce::Label hostedModeNotice;
+
     // Pulse animation for the "AI is thinking" state indicator.
     // VBlankAnimatorUpdater is attached to this Component.
     juce::VBlankAnimatorUpdater vblankUpdater{this};
@@ -182,6 +187,12 @@ private:
 
     void updateChatDisplay();
     void scrollToBottom();
+
+    // Syncs hostedModeNotice's visibility to aiService.isCurrentProviderHosted(). Called
+    // synchronously (provider identity is known immediately after setProvider(), no need to wait
+    // for the async model fetch) from refreshModels() — the same post-setProvider() resync point
+    // documented for model discovery (see CLAUDE.md "AI model discovery ordering").
+    void updateHostedModeNotice();
 
     struct MessageData {
         juce::String role;

--- a/Source/UI/SettingsWindow.cpp
+++ b/Source/UI/SettingsWindow.cpp
@@ -1,5 +1,6 @@
 #include "SettingsWindow.h"
 #include "../AI/AIProviderRegistry.h"
+#include "../Branding.h"
 #include "../ShortcutManager.h"
 #include "AppearanceSettingsTab.h"
 #include "ShortcutsSettingsTab.h"
@@ -19,6 +20,13 @@ public:
         providerLabel.setText("AI Provider:", juce::dontSendNotification);
 
         addAndMakeVisible(providerCombo);
+        // P4-6: hosted mode sends the prompt and current patch off this machine to Agent Synth's
+        // servers; local (Ollama) mode never leaves it. See also the same disclosure next to the
+        // model picker in AIChatComponent, which most users see far more often than this dialog.
+        providerCombo.setTooltip("Local (Ollama) processing stays on this machine. Hosted mode "
+                                 "sends your prompt and current patch to Agent Synth's servers "
+                                 "for processing \xe2\x80\x94 see " +
+                                 juce::String(synth::branding::kWebsiteUrl) + "/privacy.");
 
         // Built once and reused by selectedDescriptor() below: populating the combo from a
         // filtered view but then indexing selectedDescriptor() into the UNFILTERED
@@ -29,7 +37,7 @@ public:
             if (!descriptor.hidden)
                 visibleProviders.push_back(&descriptor);
 
-        juce::String savedProviderId = appProperties.getUserSettings()->getValue("aiProvider", "ollama");
+        juce::String savedProviderId = appProperties.getUserSettings()->getValue("aiProvider", "remote");
         int selectedItemId = 1;
         for (size_t i = 0; i < visibleProviders.size(); ++i) {
             int itemId = (int)i + 1;
@@ -38,11 +46,25 @@ public:
                 selectedItemId = itemId;
         }
         providerCombo.setSelectedId(selectedItemId, juce::dontSendNotification);
-        providerCombo.onChange = [this] { updateSettings(); };
+        providerCombo.onChange = [this] {
+            // Each provider persists its own host under its own key (see hostSettingsKeyFor()) —
+            // swap the field to the NEWLY selected provider's own saved value BEFORE
+            // updateSettings() persists anything, or the previous provider's host text gets
+            // written under the new provider's key.
+            const auto* descriptor = selectedDescriptor();
+            hostEditor.setText(
+                appProperties.getUserSettings()->getValue(hostSettingsKeyFor(descriptor), defaultHostFor(descriptor)),
+                juce::dontSendNotification);
+            updateSettings();
+        };
 
         addAndMakeVisible(hostLabel);
         addAndMakeVisible(hostEditor);
-        hostEditor.setText(appProperties.getUserSettings()->getValue("ollamaHost", "http://localhost:11434"));
+        {
+            const auto* initialDescriptor = selectedDescriptor();
+            hostEditor.setText(appProperties.getUserSettings()->getValue(hostSettingsKeyFor(initialDescriptor),
+                                                                         defaultHostFor(initialDescriptor)));
+        }
         hostEditor.onReturnKey = [this] { updateSettings(); };
         hostEditor.onFocusLost = [this] { updateSettings(); };
 
@@ -67,15 +89,16 @@ public:
     void updateSettings() {
         const auto* descriptor = selectedDescriptor();
         juce::String providerId = descriptor != nullptr ? descriptor->id : juce::String("ollama");
-        juce::String newOllamaHost = hostEditor.getText();
+        juce::String hostKey = hostSettingsKeyFor(descriptor);
+        juce::String newHost = hostEditor.getText();
 
         appProperties.getUserSettings()->setValue("aiProvider", providerId);
-        appProperties.getUserSettings()->setValue("ollamaHost", newOllamaHost);
+        appProperties.getUserSettings()->setValue(hostKey, newHost);
         appProperties.saveIfNeeded();
 
         updateHostFieldForSelectedProvider();
 
-        aiService.setProvider(providerRegistry.create(providerId, {newOllamaHost, {}}));
+        aiService.setProvider(providerRegistry.create(providerId, {newHost, {}}));
         aiChatComponent.refreshModels();
     }
 
@@ -85,6 +108,21 @@ private:
         if (selectedIndex >= 0 && (size_t)selectedIndex < visibleProviders.size())
             return visibleProviders[(size_t)selectedIndex];
         return nullptr;
+    }
+
+    // Each provider persists its own host under its own settings key — sharing one key (the
+    // pre-P4-6 behaviour) meant switching providers silently pointed the new one at whatever host
+    // string the previous provider had left behind (e.g. RemoteProvider constructed against
+    // Ollama's port). Mirrors MainComponent::initialiseCommon()'s equivalent lookup.
+    static juce::String hostSettingsKeyFor(const synth::ProviderDescriptor* descriptor) {
+        return (descriptor != nullptr && descriptor->id == "remote") ? "remoteHost" : "ollamaHost";
+    }
+
+    // Empty for "remote" so an unset value falls through to AIProviderRegistry::createDefault()'s
+    // synth::branding::kApiBaseUrl fallback, rather than duplicating that URL here.
+    static juce::String defaultHostFor(const synth::ProviderDescriptor* descriptor) {
+        return (descriptor != nullptr && descriptor->id == "remote") ? juce::String()
+                                                                     : juce::String("http://localhost:11434");
     }
 
     void updateHostFieldForSelectedProvider() {

--- a/Tests/AIChatComponentTests.cpp
+++ b/Tests/AIChatComponentTests.cpp
@@ -112,6 +112,32 @@ private:
     juce::String currentModel;
 };
 
+// P4-6: stands in for RemoteProvider without any network dependency — isHosted() true, and
+// fetchAvailableModels() resolves success=true with an empty list, mirroring RemoteProvider's own
+// "the service picks its own model server-side" contract (see its doc comment).
+class HostedMockProvider : public synth::AIProvider {
+public:
+    juce::String getProviderName() const override { return "HostedMockProvider"; }
+    bool isHosted() const override { return true; }
+
+    void fetchAvailableModels(std::function<void(const juce::StringArray&, bool)> callback) override {
+        callback({}, true);
+    }
+
+    RequestId sendPrompt(const std::vector<synth::AIProvider::Message>&, CompletionCallback callback,
+                         const juce::var& = juce::var(), std::function<void(const juce::String&)> = {}) override {
+        callback(AIResponse{});
+        return {};
+    }
+
+    void cancel(RequestId) override {}
+    void setModel(const juce::String& name) override { currentModel = name; }
+    juce::String getCurrentModel() const override { return currentModel; }
+
+private:
+    juce::String currentModel;
+};
+
 // Finds the juce::Viewport AIChatComponent adds as a direct child and returns its viewed
 // component (messageList) — the parent of every rendered MessageBubble. MessageBubble itself is a
 // private nested type, but its base juce::Component* children (labels, buttons) are inspectable
@@ -299,6 +325,112 @@ TEST_F(AIChatComponentTest, RefreshModelsClearsStaleItemsBeforeSecondFetchResolv
 
     provider->resolvePending({"MockModel1", "MockModel2", "MockModel3"}, true);
     EXPECT_EQ(modelPicker->getNumItems(), 3);
+}
+
+// P4-6: the privacy disclosure label is invisible for a local (non-hosted) provider — same
+// zero-height-when-absent contract as accountRow/planBadge.
+TEST_F(AIChatComponentTest, LocalProviderShowsNoHostedModeNotice) {
+    AudioEngine engine;
+    synth::AIIntegrationService service(engine.getGraph());
+    service.setProvider(std::make_unique<MockChatProvider>());
+
+    juce::ApplicationProperties props;
+    juce::PropertiesFile::Options options;
+    options.applicationName = "Test";
+    options.filenameSuffix = "test";
+    options.storageFormat = juce::PropertiesFile::storeAsXML;
+    props.setStorageParameters(options);
+
+    synth::AIChatComponent chatComponent(service, props);
+
+    // The label exists in the tree (added via addChildComponent, same as accountRow/planBadge)
+    // but must not be visible — findDescendantWithText() matches on text/type only, not
+    // visibility, so the assertion has to be on isVisible() explicitly.
+    auto* notice = findDescendantWithText<juce::Label>(
+        &chatComponent, "Hosted mode sends your prompt and current patch to Agent Synth's servers.");
+    ASSERT_NE(notice, nullptr);
+    EXPECT_FALSE(notice->isVisible());
+}
+
+// P4-6: a hosted provider (isHosted() == true) makes the privacy disclosure visible — this is the
+// "visible line near the model picker" the P4-6 acceptance criteria requires, since a tooltip
+// alone would not satisfy "should not be discoverable only by reading a policy page".
+TEST_F(AIChatComponentTest, HostedProviderShowsHostedModeNotice) {
+    AudioEngine engine;
+    synth::AIIntegrationService service(engine.getGraph());
+    service.setProvider(std::make_unique<HostedMockProvider>());
+
+    juce::ApplicationProperties props;
+    juce::PropertiesFile::Options options;
+    options.applicationName = "Test";
+    options.filenameSuffix = "test";
+    options.storageFormat = juce::PropertiesFile::storeAsXML;
+    props.setStorageParameters(options);
+
+    synth::AIChatComponent chatComponent(service, props);
+
+    auto* notice = findDescendantWithText<juce::Label>(
+        &chatComponent, "Hosted mode sends your prompt and current patch to Agent Synth's servers.");
+    ASSERT_NE(notice, nullptr);
+    EXPECT_TRUE(notice->isVisible());
+}
+
+// P4-6: switching FROM a hosted TO a local provider must hide the notice again — regression lock
+// for the resync happening in refreshModels() rather than only once at construction.
+TEST_F(AIChatComponentTest, HostedModeNoticeHidesAgainAfterSwitchingToLocalProvider) {
+    AudioEngine engine;
+    synth::AIIntegrationService service(engine.getGraph());
+    service.setProvider(std::make_unique<HostedMockProvider>());
+
+    juce::ApplicationProperties props;
+    juce::PropertiesFile::Options options;
+    options.applicationName = "Test";
+    options.filenameSuffix = "test";
+    options.storageFormat = juce::PropertiesFile::storeAsXML;
+    props.setStorageParameters(options);
+
+    synth::AIChatComponent chatComponent(service, props);
+    ASSERT_TRUE(findDescendantWithText<juce::Label>(
+                    &chatComponent, "Hosted mode sends your prompt and current patch to Agent Synth's servers.")
+                    ->isVisible());
+
+    service.setProvider(std::make_unique<MockChatProvider>());
+    chatComponent.refreshModels();
+
+    auto* notice = findDescendantWithText<juce::Label>(
+        &chatComponent, "Hosted mode sends your prompt and current patch to Agent Synth's servers.");
+    ASSERT_NE(notice, nullptr);
+    EXPECT_FALSE(notice->isVisible());
+}
+
+// P4-6: a hosted provider's empty-but-successful fetchAvailableModels() result (the service picks
+// its own model server-side — see RemoteProvider::fetchAvailableModels()'s doc comment) must not
+// render as "Error fetching models". That text is actively misleading once hosted is the default
+// provider: nothing failed.
+TEST_F(AIChatComponentTest, HostedProviderEmptyModelListShowsNoErrorText) {
+    AudioEngine engine;
+    synth::AIIntegrationService service(engine.getGraph());
+    service.setProvider(std::make_unique<HostedMockProvider>());
+
+    juce::ApplicationProperties props;
+    juce::PropertiesFile::Options options;
+    options.applicationName = "Test";
+    options.filenameSuffix = "test";
+    options.storageFormat = juce::PropertiesFile::storeAsXML;
+    props.setStorageParameters(options);
+
+    synth::AIChatComponent chatComponent(service, props);
+
+    juce::ComboBox* modelPicker = nullptr;
+    for (auto* child : chatComponent.getChildren()) {
+        if (auto* combo = dynamic_cast<juce::ComboBox*>(child)) {
+            modelPicker = combo;
+            break;
+        }
+    }
+    ASSERT_NE(modelPicker, nullptr);
+    ASSERT_EQ(modelPicker->getNumItems(), 1);
+    EXPECT_EQ(modelPicker->getItemText(0), "Model chosen automatically");
 }
 
 // REGRESSION LOCK: the 2-arg constructor used at 6+ call sites in this file (and by

--- a/Tests/AIProviderRegistryTests.cpp
+++ b/Tests/AIProviderRegistryTests.cpp
@@ -1,5 +1,7 @@
 #include "../Source/AI/AIProvider.h"
 #include "../Source/AI/AIProviderRegistry.h"
+#include "../Source/AI/RemoteProvider.h"
+#include "../Source/Branding.h"
 #include <gtest/gtest.h>
 
 namespace {
@@ -94,18 +96,45 @@ TEST(AIProviderRegistryTest, PersistedIdIsIndependentOfDisplayName) {
     ASSERT_NE(provider, nullptr);
 }
 
-TEST(AIProviderRegistryTest, CreateDefaultRegistersOllamaFirstAndRemoteHidden) {
+// P4-6: "remote" is no longer hidden — both providers are offered in AISettingsTab's combo.
+TEST(AIProviderRegistryTest, CreateDefaultRegistersOllamaFirstAndRemoteVisible) {
     auto registry = synth::AIProviderRegistry::createDefault();
 
     const auto& all = registry.listAll();
     ASSERT_EQ(all.size(), 2u);
 
     // "ollama" must stay first: AIProviderRegistry::create() falls back to descriptors.front()
-    // for an unknown/empty id, and that fallback must be unaffected by adding "remote".
+    // for an unknown/empty id, and that fallback must be unaffected by adding "remote". This is
+    // deliberate even though "remote" is now the default for a FRESH install (see
+    // MainComponent::resolveDefaultProviderId()) — an unrecognised/corrupt persisted id fails
+    // safe to the provider that sends no data anywhere, never to the one that does.
     EXPECT_EQ(all[0].id, "ollama");
     EXPECT_FALSE(all[0].hidden);
 
     const auto* remote = registry.find("remote");
     ASSERT_NE(remote, nullptr);
-    EXPECT_TRUE(remote->hidden);
+    EXPECT_FALSE(remote->hidden);
+}
+
+// Locks in the "ollama" fail-safe fallback described above, exercised through createDefault()
+// specifically (the generic version, UnknownIdFallsBackToFirstRegistered above, uses local stub
+// descriptors and wouldn't catch a registration-order regression in createDefault() itself).
+TEST(AIProviderRegistryTest, CreateDefaultUnknownIdFallsBackToOllamaNotRemote) {
+    auto registry = synth::AIProviderRegistry::createDefault();
+
+    auto provider = registry.create("some-corrupt-persisted-value", {});
+    ASSERT_NE(provider, nullptr);
+    EXPECT_EQ(provider->getProviderName(), "Ollama");
+}
+
+// AIProviderRegistry.cpp's "remote" descriptor falls back to synth::branding::kApiBaseUrl when
+// ProviderConfig::host is empty — the pre-P4-6 code hardcoded http://localhost:8787 here, which
+// would have silently pointed hosted mode at nothing in production.
+TEST(AIProviderRegistryTest, RemoteDescriptorDefaultsToProductionApiBaseUrlWhenHostEmpty) {
+    auto registry = synth::AIProviderRegistry::createDefault();
+
+    auto provider = registry.create("remote", {});
+    auto* remoteProvider = dynamic_cast<synth::RemoteProvider*>(provider.get());
+    ASSERT_NE(remoteProvider, nullptr);
+    EXPECT_EQ(remoteProvider->getHostForTesting(), juce::String(synth::branding::kApiBaseUrl));
 }

--- a/Tests/MainComponentTests.cpp
+++ b/Tests/MainComponentTests.cpp
@@ -470,6 +470,61 @@ TEST_F(MainComponentTest, StartupUsesRegistryAndStillSelectsAModel) {
     EXPECT_EQ(mc.getAiServiceForTest().getCurrentModel(), "mock-model-a");
 }
 
+// P4-6: resolveDefaultProviderId() is the pure decision MainComponent::initialiseCommon() bases
+// the migration on — a fresh install (no settings file at all) gets the new hosted-by-default,
+// an install that has already launched before keeps its working local Ollama default even though
+// it has never touched the "aiProvider" key specifically (see initialiseCommon()'s comment for
+// why key-absence alone can't tell those two cases apart). Tested directly, without touching a
+// real properties file, since MainComponent hardcodes its settings folder.
+TEST(MainComponentDefaultProviderIdTest, FreshInstallDefaultsToHosted) {
+    EXPECT_EQ(MainComponent::resolveDefaultProviderId(/*hasExistingSettingsFile=*/false), "remote");
+}
+
+TEST(MainComponentDefaultProviderIdTest, ExistingInstallKeepsLocalOllamaDefault) {
+    EXPECT_EQ(MainComponent::resolveDefaultProviderId(/*hasExistingSettingsFile=*/true), "ollama");
+}
+
+// Integration counterpart to the pure-function tests above: this fixture's shared "Agent Synth"
+// settings file already exists on disk by the time this test runs (resetPanelKeys() in SetUp()
+// writes it), so it stands in for "existing install, AI settings never touched" — the "aiProvider"
+// key itself is removed here to simulate a user who never opened the AI settings tab. Confirms the
+// migration reaches all the way through initialiseCommon() into which provider id the registry is
+// actually asked to construct, not just the pure decision function in isolation.
+TEST_F(MainComponentTest, ExistingInstallWithNoAiProviderKeyRequestsOllamaFromRegistry) {
+    {
+        juce::PropertiesFile::Options opts;
+        opts.applicationName = "Agent Synth";
+        opts.folderName = "Agent Synth";
+        opts.filenameSuffix = "settings";
+        opts.osxLibrarySubFolder = "Application Support";
+        opts.storageFormat = juce::PropertiesFile::storeAsXML;
+
+        juce::ApplicationProperties props;
+        props.setStorageParameters(opts);
+        if (auto* s = props.getUserSettings()) {
+            s->removeValue("aiProvider");
+            s->saveIfNeeded();
+        }
+    }
+
+    juce::String requestedId;
+    synth::AIProviderRegistry registry;
+    registry.registerProvider({"ollama", "Ollama (local)", true, false,
+                               [&requestedId](const synth::ProviderConfig&) -> std::unique_ptr<synth::AIProvider> {
+                                   requestedId = "ollama";
+                                   return std::make_unique<ModelTrackingMockProvider>();
+                               }});
+    registry.registerProvider({"remote", "Remote (hosted)", true, true,
+                               [&requestedId](const synth::ProviderConfig&) -> std::unique_ptr<synth::AIProvider> {
+                                   requestedId = "remote";
+                                   return std::make_unique<ModelTrackingMockProvider>();
+                               }});
+
+    MainComponent mc(nullptr, registry);
+
+    EXPECT_EQ(requestedId, "ollama");
+}
+
 // Regression: toolbar buttons must have non-zero bounds immediately after construction,
 // WITHOUT any additional manual resize or sidebar toggle. Pre-fix, setSize() fired
 // resized() -> layoutButtons() before setButtons() was called, leaving all button bounds

--- a/Tests/SettingsWindowTests.cpp
+++ b/Tests/SettingsWindowTests.cpp
@@ -126,6 +126,82 @@ TEST_F(SettingsWindowTest, AITabPersistsProviderSetting) {
     }
 }
 
+// P4-6: "remote" is no longer hidden, so both providers must be offered.
+TEST_F(SettingsWindowTest, AITabOffersBothOllamaAndRemoteProviders) {
+    SettingsWindow settingsWindow(deviceManager, appProperties, *aiService, *aiChatComponent, shortcutManager,
+                                  themeManager, nullptr);
+    settingsWindow.setSize(600, 400);
+    settingsWindow.resized();
+
+    auto* aiTab = settingsWindow.getTabs().getTabContentComponent(1);
+    ASSERT_NE(aiTab, nullptr);
+
+    juce::ComboBox* providerCombo = nullptr;
+    for (auto* child : aiTab->getChildren()) {
+        if (auto* combo = dynamic_cast<juce::ComboBox*>(child)) {
+            providerCombo = combo;
+            break;
+        }
+    }
+    ASSERT_NE(providerCombo, nullptr);
+
+    ASSERT_EQ(providerCombo->getNumItems(), 2);
+    EXPECT_EQ(providerCombo->getItemText(0), "Ollama (local)");
+    EXPECT_EQ(providerCombo->getItemText(1), "Remote (hosted)");
+}
+
+// Regression lock for the pre-P4-6 host-key collision: Ollama and Remote each persist (and
+// display) their OWN host, under separate settings keys ("ollamaHost"/"remoteHost") — the
+// pre-P4-6 code shared a single "ollamaHost" key, so switching providers silently carried one
+// provider's host text over as the other's (e.g. RemoteProvider ending up pointed at Ollama's
+// port).
+//
+// Verified by reconstructing AISettingsTab against differently-persisted state, NOT by live-
+// switching the combo mid-test: AISettingsTab has no seam to inject a fake provider registry, so
+// triggering its onChange/updateSettings() for real would construct an actual OllamaProvider or
+// RemoteProvider — touching real threads, the network and DeviceIdStore's on-disk file, none of
+// which belong in a unit test and one of which (confirmed while writing this test) hangs/aborts
+// in this headless environment. The constructor path alone (read the persisted host for whichever
+// provider is selected) exercises the exact same hostSettingsKeyFor()/defaultHostFor() lookup that
+// updateSettings() uses to choose which key to WRITE, so this still locks the collision fix.
+TEST_F(SettingsWindowTest, EachProviderReadsItsOwnPersistedHost) {
+    appProperties.getUserSettings()->setValue("ollamaHost", "http://ollama.example:11434");
+    appProperties.getUserSettings()->setValue("remoteHost", "https://remote.example");
+
+    auto findHostEditor = [](juce::Component* aiTab) -> juce::TextEditor* {
+        for (auto* child : aiTab->getChildren())
+            if (auto* editor = dynamic_cast<juce::TextEditor*>(child))
+                return editor;
+        return nullptr;
+    };
+
+    appProperties.getUserSettings()->setValue("aiProvider", "ollama");
+    {
+        SettingsWindow settingsWindow(deviceManager, appProperties, *aiService, *aiChatComponent, shortcutManager,
+                                      themeManager, nullptr);
+        settingsWindow.setSize(600, 400);
+        settingsWindow.resized();
+        auto* aiTab = settingsWindow.getTabs().getTabContentComponent(1);
+        ASSERT_NE(aiTab, nullptr);
+        auto* hostEditor = findHostEditor(aiTab);
+        ASSERT_NE(hostEditor, nullptr);
+        EXPECT_EQ(hostEditor->getText(), "http://ollama.example:11434");
+    }
+
+    appProperties.getUserSettings()->setValue("aiProvider", "remote");
+    {
+        SettingsWindow settingsWindow(deviceManager, appProperties, *aiService, *aiChatComponent, shortcutManager,
+                                      themeManager, nullptr);
+        settingsWindow.setSize(600, 400);
+        settingsWindow.resized();
+        auto* aiTab = settingsWindow.getTabs().getTabContentComponent(1);
+        ASSERT_NE(aiTab, nullptr);
+        auto* hostEditor = findHostEditor(aiTab);
+        ASSERT_NE(hostEditor, nullptr);
+        EXPECT_EQ(hostEditor->getText(), "https://remote.example");
+    }
+}
+
 TEST_F(SettingsWindowTest, RemembersLastSelectedTab) {
     // Set the settingsTab preference to 1 (AI tab) before constructing
     appProperties.getUserSettings()->setValue("settingsTab", 1);

--- a/docs/AI_Engine.md
+++ b/docs/AI_Engine.md
@@ -623,7 +623,7 @@ Locked by `OllamaProviderTest.CancelledRequestInvokesCallbackWithCancelledKind`,
 > hit Cancel, and confirm the input frees immediately and the next message is answered without delay.
 > A regression here is invisible to the suite — the mock path would still pass.
 
-### RemoteProvider: synth-platform Inference Service (libcurl, hidden pending Phase 4)
+### RemoteProvider: synth-platform Inference Service (libcurl, default as of P4-6)
 
 `Source/AI/RemoteProvider.{h,cpp}` is the first non-Ollama `AIProvider`: it talks to a local
 instance of the `synth-platform` inference service over libcurl instead of `juce::WebInputStream`.
@@ -716,15 +716,47 @@ Root `CMakeLists.txt` requires `CURL` (`find_package(CURL REQUIRED)`) under `if(
 covering both Linux and macOS (whose SDK ships a `curl.tbd` stub, so no Homebrew dependency is
 needed there) — and deliberately does not require it on `WIN32`.
 
-**Ships hidden.** `ProviderDescriptor::hidden` (`Source/AI/AIProviderRegistry.h`) is a runtime
-flag, not a build-time one: `RemoteProvider` is fully registered and constructible via
+**Visible as of P4-6.** `ProviderDescriptor::hidden` (`Source/AI/AIProviderRegistry.h`) is a
+runtime flag, not a build-time one: `RemoteProvider` is fully registered and constructible via
 `AIProviderRegistry::createDefault()` (id `"remote"`, registered after `"ollama"` so the
-unknown-id fallback to `descriptors.front()` is unaffected), but `AISettingsTab`
-(`Source/UI/SettingsWindow.cpp`) filters out any `hidden` descriptor before populating the
-provider combo box, via a `visibleProviders` member used consistently by both the population loop
-and `selectedDescriptor()` (indexing the combo's selected item against the *unfiltered* list would
-desync the moment a hidden entry sits between two visible ones). Phase 4 is expected to flip
-`"remote"`'s `hidden` to `false`.
+unknown-id fallback to `descriptors.front()` is unaffected — and stays that way deliberately: an
+unrecognised/corrupt persisted id fails safe to the provider that sends no data anywhere, never to
+the one that does), and since P4-6 `hidden=false`, so `AISettingsTab`
+(`Source/UI/SettingsWindow.cpp`) offers it in the provider combo box alongside `"ollama"`. The
+`visibleProviders` member (still present even with nothing currently hidden) is used consistently
+by both the population loop and `selectedDescriptor()` — indexing the combo's selected item
+against the *unfiltered* `providerRegistry.listAll()` would desync the moment a future hidden
+provider sits between two visible ones.
+
+**Default provider (P4-6).** `"remote"` (hosted) is the default for a brand new install;
+`"ollama"` (local) remains the default for an install that has already launched before, even if it
+has never opened AI settings — see `MainComponent::resolveDefaultProviderId()` and the migration
+comment in `MainComponent::initialiseCommon()`. The persisted `"aiProvider"` key is only ever
+*written* by `AISettingsTab::updateSettings()`, so its absence alone can't distinguish "brand new
+install" from "existing user who never touched AI settings"; `initialiseCommon()` instead checks
+whether the settings file already existed on disk before this launch. Each provider persists its
+own host under its own key (`"ollamaHost"` / `"remoteHost"`) — sharing one key, the pre-P4-6
+behaviour, meant switching providers in Settings silently pointed the new one at whatever host
+string the previous provider had left behind. An empty/unset `"remoteHost"` falls back to
+`synth::branding::kApiBaseUrl` (`Source/Branding.h`), the production Cloud Run URL — see that
+constant's comment for the P4-7 caveat that the service doesn't accept public traffic yet.
+
+**Privacy disclosure (P4-6 acceptance criterion).** A visible line — not just a tooltip, since the
+acceptance criterion is explicit that this "should not be discoverable only by reading a policy
+page" — appears next to the model picker in `AIChatComponent` whenever the active provider is
+hosted: `"Hosted mode sends your prompt and current patch to Agent Synth's servers."`
+`AIProvider::isHosted()` (default `false`, overridden `true` in `RemoteProvider`) drives this via
+`AIIntegrationService::isCurrentProviderHosted()`; `AIChatComponent::updateHostedModeNotice()` is
+called from `refreshModels()`, the same post-`setProvider()` resync point documented above for
+model discovery, so the notice's visibility never lags a provider switch. `AISettingsTab`'s
+provider combo box also carries the same disclosure as a tooltip, for the toggle itself.
+
+**Model picker in hosted mode.** `RemoteProvider::fetchAvailableModels()` always resolves
+`success=true` with an empty list (the service picks its own model server-side — see that method's
+doc comment). `AIChatComponent::refreshModels()`'s callback treats `success && models.isEmpty()`
+as "nothing to choose from," not a fetch failure: the picker shows a single disabled
+`"Model chosen automatically"` entry rather than the misleading `"Error fetching models"` a plain
+`success` check would have produced for every hosted-mode user.
 
 **Eval harness parity.** `Tools/AIEvalHarness` (see its README) can replay its golden prompt set
 through `RemoteProvider` instead of `OllamaProvider` via `--provider remote`, so a model can be
@@ -809,11 +841,14 @@ nothing to layout until an `AccountService` is attached *and* has a known entitl
 `GET /v1/entitlement` response (`docs/billing.md`) — `AuthClient::fetchEntitlement()` degrades to
 `requestsUsed = 0` rather than failing the whole parse if an older server doesn't send it.
 
-**Not yet end-to-end reachable.** `RemoteProvider` is still `hidden=true` (see "Ships hidden"
-above) — flipping the default to hosted is P4-6. This feature is fully built and unit-tested (the
-429→`Quota` mapping, `fetchEntitlement()`, `AccountService`'s entitlement fields, `PlanBadge`, and
-the upgrade bubble), but nothing in the shipped app can currently select the hosted provider that
-would ever produce a real `Quota` error.
+**Reachable client-side as of P4-6, still blocked at the infra layer.** `RemoteProvider` is no
+longer `hidden` (see "Visible as of P4-6" above) and is the default provider for a fresh install,
+so this feature — the 429→`Quota` mapping, `fetchEntitlement()`, `AccountService`'s entitlement
+fields, `PlanBadge`, and the upgrade bubble — is reachable end to end from the client for the first
+time. It still can't complete against production today: the deployed Cloud Run service has no
+`allUsers` invoker binding, so every request 403s at the IAM layer before the app's own
+`AUTH_REQUIRED` check ever runs — a deliberate P4-7 follow-up, not a defect in this client (see
+`synth::branding::kApiBaseUrl`'s comment in `Source/Branding.h`).
 
 ## 6. Future Considerations
 

--- a/docs/AI_Usage_Guide.md
+++ b/docs/AI_Usage_Guide.md
@@ -5,8 +5,9 @@ This guide provides practical instructions and tips for effectively using the AI
 ## 1. Getting Started with the AI Sound Designer
 
 1.  **Open the AI Chat Panel**: In the Agent Synth application, locate and open the AI chat panel. This is typically accessible via a dedicated button or menu option.
-2.  **Select an AI Model**: Use the model picker dropdown to choose an available AI model (e.g., `qwen3-coder-next:latest`). Ensure your Ollama server (or other AI backend) is running and accessible if using local models.
-3.  **Start Chatting**: Type your requests or descriptions in the input field and press "Send" or Enter.
+2.  **Choose Hosted or Local**: By default, a new install uses **Hosted** mode — no setup required, but your prompt and current patch are sent to Agent Synth's servers for processing (a notice next to the model picker says so whenever hosted mode is active; see Settings → AI for the toggle and the same disclosure on hover). Switch to **Ollama (local)** in Settings → AI to keep everything on this machine instead; that requires your own Ollama server running and accessible.
+3.  **Select an AI Model**: In local (Ollama) mode, use the model picker dropdown to choose an available AI model (e.g., `qwen3-coder-next:latest`). In hosted mode the picker shows "Model chosen automatically" — the service selects its own model server-side, so there's nothing to pick.
+4.  **Start Chatting**: Type your requests or descriptions in the input field and press "Send" or Enter.
 
 ## 2. Prompting Best Practices
 
@@ -52,8 +53,9 @@ Here are some examples of effective prompts you can use:
 
 ## 4. Troubleshooting
 
-*   **"Error: No AI provider selected."**: Ensure you have selected an AI model from the dropdown. If no models appear, check if your Ollama server is running and accessible at `http://localhost:11434`.
-*   **"Error fetching models"**: Your Agent Synth application might not be able to connect to the Ollama server. Verify the server is running and there are no firewall issues. Check the application logs for "AI Discovery Error" messages.
+*   **"Error: No AI provider selected."**: In local (Ollama) mode, ensure you have selected an AI model from the dropdown. If no models appear, check if your Ollama server is running and accessible at `http://localhost:11434`. (In hosted mode the picker shows "Model chosen automatically" instead — that's expected, not an error.)
+*   **"Error fetching models"**: This only appears in local (Ollama) mode, and means Agent Synth couldn't connect to the Ollama server. Verify the server is running and there are no firewall issues. Check the application logs for "AI Discovery Error" messages.
+*   **Nothing happens after sending a prompt, in hosted mode**: The hosted service may not be reachable yet in this environment. Switch to Ollama (local) in Settings → AI as a fallback, or check with your Agent Synth administrator.
 *   **AI provides text, but no patch is applied**: The AI's response might not contain a valid JSON patch in the expected ````json` block format, or the JSON might be malformed. Try rephrasing your prompt to explicitly ask for a JSON patch (e.g., "Provide the patch as a JSON block").
 *   **Unexpected Patch Behavior**: The AI might generate a patch that doesn't sound as expected. Review the generated JSON (by expanding the patch card) to understand the AI's interpretation and refine your prompt accordingly.
 


### PR DESCRIPTION
## Summary
- Hosted (`RemoteProvider`) is now the default AI provider for a **fresh install**; an install that has already launched before keeps its working local Ollama default even if it never opened AI settings — see `MainComponent::resolveDefaultProviderId()` and the migration comment in `initialiseCommon()`.
- `ProviderDescriptor::hidden` flips to `false` for `"remote"`, so it's now selectable in Settings → AI alongside Ollama.
- **Production API host wired for the first time**: `AccountService`/`AuthClient`/`RemoteProvider` previously had no real default anywhere in the client (`http://localhost:8787` everywhere) — added `synth::branding::kApiBaseUrl` (the Cloud Run URL from `synth-platform`'s `apps/infra/Pulumi.prod.yaml`). Note: that service isn't public yet (no `allUsers` invoker binding — tracked under P4-7), so hosted requests 403 at the IAM layer until that follow-up ships; this is expected, not a defect here.
- **Fixed a host-key collision**: Ollama and Remote were sharing a single `"ollamaHost"` settings key, so switching providers in Settings silently pointed the new one at whatever host the previous provider had left behind. Each provider now persists under its own key (`"ollamaHost"` / `"remoteHost"`).
- **Fixed a misleading error**: `RemoteProvider::fetchAvailableModels()` always resolves `success=true` with an empty list (the service picks its own model server-side) — the model picker used to render that as "Error fetching models" for every hosted user. It now shows a disabled "Model chosen automatically" entry instead.
- **Privacy disclosure** (P4-6 acceptance criterion): a persistent label next to the model picker in `AIChatComponent`, visible whenever the active provider is hosted — "Hosted mode sends your prompt and current patch to Agent Synth's servers." Also a matching tooltip on the Settings provider toggle. Driven by a new `AIProvider::isHosted()` virtual (default `false`, `true` in `RemoteProvider`).

## Test plan
- [x] `AIProviderRegistryTest`: remote now visible; unknown/corrupt id still fails safe to `"ollama"`; empty-host `"remote"` construction defaults to the production API URL.
- [x] `MainComponentDefaultProviderIdTest` / `MainComponentTest`: pure default-decision function unit-tested; integration test confirms an "existing install with no aiProvider key" requests `"ollama"` from the registry.
- [x] `SettingsWindowTest`: combo now offers both providers; each provider reads its own persisted host (host-key collision regression lock — verified via reconstruction, not live-switching, since `AISettingsTab` has no seam to inject a fake registry and live-switching constructs a real networked provider, which is unsafe in a unit test).
- [x] `AIChatComponentTest`: hosted-mode notice shows/hides correctly across provider switches; hosted empty-model-list no longer renders as an error.
- [x] Full suite: 1560/1563 passing. The 3 failures (`KeychainTokenStoreTest`) are pre-existing macOS Keychain-access failures in this sandbox, unrelated to any file this PR touches.
- [x] `docs/AI_Engine.md`, `docs/AI_Usage_Guide.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)