### PR TITLE
feat(distribution): Sparkle auto-update for macOS (P5-3)

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -145,13 +145,24 @@ jobs:
 
     # Configure CMake — Ninja on every OS so this matches the PR CI build path
     # (see the "Setup MSVC" note above for why Ninja and not the VS generator).
+    # GRAVISYNTH_BUILD_NUMBER becomes CFBundleVersion, the value Sparkle actually compares to decide
+    # an update is available (see CMakeLists.txt's comment on GRAVISYNTH_BUILD_NUMBER for why this
+    # can't just be the project's marketing VERSION: that's hand-bumped in CMakeLists.txt, while
+    # this workflow's tag-and-release step below bumps semver tags independently). run_number is
+    # known before this step runs and increases every run, so it stays correct regardless of what
+    # tag the release job mints afterwards. SYNTH_SPARKLE_PUBLIC_KEY reads from a repo VARIABLE
+    # (not a secret — SUPublicEDKey is the public half of the key pair) that doesn't exist yet; see
+    # docs/distribution.md. Both are harmless no-ops on Linux/Windows, where SYNTH_SPARKLE_* is
+    # unused.
     - name: Configure CMake
       shell: bash
       run: |
         cmake -B build -G Ninja \
           -DCMAKE_BUILD_TYPE=Release \
           -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+          -DGRAVISYNTH_BUILD_NUMBER=${{ github.run_number }} \
+          -DSYNTH_SPARKLE_PUBLIC_KEY="${{ vars.SPARKLE_PUBLIC_KEY }}"
 
     # Build (Ninja is single-config; the build type comes from configure)
     - name: Build
@@ -237,6 +248,8 @@ jobs:
     # (incl. the Windows build) before merging.
     if: always() && !contains(needs.build.result, 'failure') && github.event_name == 'push'
     runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.tag_version.outputs.new_tag }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -266,3 +279,51 @@ jobs:
           files: artifacts/*
           draft: false
           prerelease: true
+
+  publish-appcast:
+    name: Publish Sparkle appcast
+    needs: [release]
+    # Skips cleanly (not a failure) until both halves of the EdDSA signing key exist: the public
+    # key as a repo VARIABLE (embedded into the app's Info.plist by the build job above) and the
+    # private key as this job's SPARKLE_PRIVATE_KEY secret. See docs/distribution.md for how to
+    # generate both with Sparkle's own `generate_keys` tool. Until then, "Check for Updates" in the
+    # app itself also stays inert (UpdateManager checks for a non-empty SUPublicEDKey at startup).
+    if: needs.release.result == 'success' && vars.SPARKLE_PUBLIC_KEY != ''
+    runs-on: macos-latest
+    steps:
+      - name: Download macOS artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: AgentSynth-macOS-arm64
+          path: appcast-work
+
+      # Version pin duplicated from cmake/DependencyVersions.cmake's SYNTH_SPARKLE_URL/
+      # SYNTH_SPARKLE_SHA256 — this job runs standalone (no CMake configure), so it re-fetches the
+      # same release directly rather than parsing the .cmake file. Keep both in sync when bumping.
+      - name: Fetch Sparkle tools
+        run: |
+          curl -sL -o sparkle.tar.xz https://github.com/sparkle-project/Sparkle/releases/download/2.9.5/Sparkle-2.9.5.tar.xz
+          echo "015336b601493e05c237964954bff6191370003d94edefe663724c88840d73cc  sparkle.tar.xz" | shasum -a 256 -c -
+          mkdir sparkle-tools
+          tar -xf sparkle.tar.xz -C sparkle-tools
+
+      # --download-url-prefix points at this same release's GitHub asset URLs, so only this small
+      # appcast.xml file needs hosting on agentsynth.app — the zip itself stays on GitHub Releases.
+      - name: Generate appcast
+        env:
+          SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
+        run: |
+          echo "$SPARKLE_PRIVATE_KEY" | ./sparkle-tools/bin/generate_appcast \
+            --ed-key-file - \
+            --download-url-prefix "https://github.com/${{ github.repository }}/releases/download/${{ needs.release.outputs.tag }}/" \
+            -o appcast.xml \
+            appcast-work/
+
+      # Attaches appcast.xml to the release as a downloadable/inspectable asset. This is NOT the
+      # same as deploying it to https://agentsynth.app/updates/appcast.xml (the app's SUFeedURL) —
+      # that publish step still needs to be wired up separately (marketing site / Cloudflare), see
+      # docs/distribution.md's "what's not automated yet".
+      - name: Attach appcast to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload ${{ needs.release.outputs.tag }} appcast.xml --clobber --repo ${{ github.repository }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,4 +71,5 @@ Every implementation plan **must** include:
 - [`docs/Module_Development_Guide.md`](docs/Module_Development_Guide.md) — step-by-step guide to adding a module
 - [`docs/AI_Engine.md`](docs/AI_Engine.md) · [`docs/AI_Usage_Guide.md`](docs/AI_Usage_Guide.md) — AI patching subsystem (OllamaProvider, AIStateMapper, chat UI)
 - [`docs/midi_input.md`](docs/midi_input.md) · [`docs/shortcuts.md`](docs/shortcuts.md) — external MIDI routing, keyboard shortcuts
+- [`docs/distribution.md`](docs/distribution.md) — version identity, Sparkle auto-update (macOS), EdDSA key generation, CI appcast publishing, WinSparkle status
 - Feature planning artifacts (timeline concept & task tracker) live in the **private** `synth-platform` repo under `docs/plans/` — kept out of this public repo on purpose.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,12 @@ cmake_minimum_required(VERSION 3.22)
 
 project(AgentSynth VERSION 0.13.2)
 
+# Sparkle's update bridge (Source/Update/SparkleUpdateManager.mm) is Objective-C++. JUCE's own
+# project() only declares C/CXX, so this must be enabled explicitly before any .mm source is added.
+if(APPLE)
+    enable_language(OBJCXX)
+endif()
+
 # Enable ccache if available
 find_program(CCACHE_PROGRAM ccache)
 if(CCACHE_PROGRAM)
@@ -27,6 +33,19 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(juce)
 
+# Fetch Sparkle (macOS auto-update). Prebuilt .xcframework distribution, not a CMake project —
+# FetchContent_MakeAvailable populates it and, finding no CMakeLists.txt at its root, does not try
+# to add_subdirectory it. See docs/distribution.md for the WinSparkle (Windows) equivalent, tracked
+# as a separate roadmap task.
+if(APPLE)
+    FetchContent_Declare(
+        sparkle
+        URL      ${SYNTH_SPARKLE_URL}
+        URL_HASH SHA256=${SYNTH_SPARKLE_SHA256}
+    )
+    FetchContent_MakeAvailable(sparkle)
+endif()
+
 # Coverage Option
 option(ENABLE_COVERAGE "Enable code coverage testing" OFF)
 option(ENABLE_TESTS "Enable building test suite" OFF)
@@ -39,6 +58,25 @@ option(ENABLE_AI_HARNESS "Build the AI patch validity/quality measurement harnes
 set(SYNTH_PRODUCT_NAME "Agent Synth" CACHE STRING "Display name: window title, About box, installer")
 set(SYNTH_COMPANY_NAME "yourcompany" CACHE STRING "JUCE COMPANY_NAME / macOS bundle vendor")
 set(SYNTH_BUNDLE_ID "com.agentsynth.app" CACHE STRING "macOS/iOS CFBundleIdentifier")
+
+# Auto-update (Sparkle on macOS — see docs/distribution.md). SYNTH_SPARKLE_PUBLIC_KEY is
+# deliberately empty by default: SparkleUpdateManager checks for a non-empty key at startup and
+# stays inert without one, so a dev/local build never shows Sparkle's "app is misconfigured" alert.
+# CI supplies the real key via -DSYNTH_SPARKLE_PUBLIC_KEY, read from the (non-secret, public)
+# SPARKLE_PUBLIC_KEY repository variable once it exists.
+set(SYNTH_UPDATE_FEED_URL "https://agentsynth.app/updates/appcast.xml"
+    CACHE STRING "Sparkle SUFeedURL — the appcast this build checks for updates")
+set(SYNTH_SPARKLE_PUBLIC_KEY "" CACHE STRING "Sparkle SUPublicEDKey (base64, public half of the EdDSA signing key)")
+
+# CFBundleVersion (Sparkle's actual update-comparison key) is intentionally NOT the same as
+# PROJECT_VERSION above: PROJECT_VERSION is the human-facing marketing version, hand-bumped in this
+# file, while the release workflow auto-tags every push to main independently (mathieudutour/
+# github-tag-action) without touching this file. A build number that only advances when a human
+# remembers to bump it would make Sparkle either never detect an update or always think one is
+# available. GITHUB_RUN_NUMBER is known before the build starts and increases every run regardless
+# of what tag the release job later mints, so CI passes it via -DGRAVISYNTH_BUILD_NUMBER. Local
+# builds default to "0" — never distributed, so Sparkle comparison doesn't matter for them.
+set(GRAVISYNTH_BUILD_NUMBER "0" CACHE STRING "CFBundleVersion — monotonic build number, CI sets this to the workflow run number")
 
 if(ENABLE_COVERAGE)
     if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
@@ -199,14 +237,24 @@ else()
     target_compile_options(Core PRIVATE -Wall -Wextra)
 endif()
 
+# Sparkle Info.plist keys, merged into JUCE's generated plist. Empty string on non-Apple
+# platforms, where JUCE ignores the argument entirely.
+set(SYNTH_SPARKLE_PLIST_TO_MERGE "")
+if(APPLE)
+    set(SYNTH_SPARKLE_PLIST_TO_MERGE
+        "<?xml version='1.0' encoding='UTF-8'?><plist version='1.0'><dict><key>SUFeedURL</key><string>${SYNTH_UPDATE_FEED_URL}</string><key>SUEnableAutomaticChecks</key><true/><key>SUScheduledCheckInterval</key><integer>86400</integer><key>SUPublicEDKey</key><string>${SYNTH_SPARKLE_PUBLIC_KEY}</string></dict></plist>")
+endif()
+
 # Create the application target
 juce_add_gui_app(AgentSynth
     PRODUCT_NAME "${SYNTH_PRODUCT_NAME}"
-    VERSION "0.13.2"
+    VERSION "${PROJECT_VERSION}"
+    BUILD_VERSION "${GRAVISYNTH_BUILD_NUMBER}"
     COMPANY_NAME "${SYNTH_COMPANY_NAME}"
     BUNDLE_ID "${SYNTH_BUNDLE_ID}"
     BLUETOOTH_PERMISSION_ENABLED TRUE
     BLUETOOTH_PERMISSION_TEXT "We need Bluetooth access to connect to your external MIDI devices."
+    PLIST_TO_MERGE "${SYNTH_SPARKLE_PLIST_TO_MERGE}"
 )
 
 juce_generate_juce_header(AgentSynth)
@@ -316,7 +364,16 @@ target_sources(AgentSynth PRIVATE
     Source/UI/AppearanceSettingsTab.h
     Source/UI/ShortcutsSettingsTab.cpp
     Source/ShortcutManager.h
+    Source/Update/UpdateManager.h
 )
+
+if(APPLE)
+    target_sources(AgentSynth PRIVATE Source/Update/SparkleUpdateManager.mm)
+    # ARC explicitly, rather than relying on JUCE's project-wide ObjC++ default (which is
+    # non-ARC — JUCE's own .mm files manage retain/release by hand), so this one bridge file can
+    # use SPUStandardUpdaterController without hand-written retain/release bookkeeping.
+    set_source_files_properties(Source/Update/SparkleUpdateManager.mm PROPERTIES COMPILE_OPTIONS -fobjc-arc)
+endif()
 
 # Link against JUCE modules
 target_link_libraries(AgentSynth PRIVATE
@@ -345,6 +402,32 @@ target_compile_definitions(AgentSynth PRIVATE
 if(UNIX AND NOT APPLE)
     target_link_libraries(AgentSynth PRIVATE ${GTK3_LIBRARIES})
     target_include_directories(AgentSynth PRIVATE ${GTK3_INCLUDE_DIRS})
+endif()
+
+if(APPLE)
+    # `-F` must be a COMPILE flag too, not just a link flag — target_link_libraries only puts it on
+    # the link line, but #import <Sparkle/Sparkle.h> in SparkleUpdateManager.mm needs the compiler
+    # to see it as well.
+    target_compile_options(AgentSynth PRIVATE "-F${sparkle_SOURCE_DIR}")
+    target_link_libraries(AgentSynth PRIVATE "-F${sparkle_SOURCE_DIR}" "-framework Sparkle")
+
+    set_target_properties(AgentSynth PROPERTIES
+        BUILD_WITH_INSTALL_RPATH TRUE
+        INSTALL_RPATH "@executable_path/../Frameworks"
+    )
+
+    # Sparkle.framework is a prebuilt binary, not something CMake's bundle logic knows to embed —
+    # this project builds with Ninja (see build-artifacts.yml), which has no "Embed Frameworks"
+    # build phase the way an Xcode project would, so copy it into Contents/Frameworks ourselves.
+    # `ditto` (not `cp`) preserves the framework's Versions/Current symlink structure, matching how
+    # CI already ditto's the whole .app for packaging. CI's `codesign --deep` step re-signs this
+    # nested framework along with everything else in the bundle.
+    add_custom_command(TARGET AgentSynth POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E make_directory "$<TARGET_BUNDLE_CONTENT_DIR:AgentSynth>/Frameworks"
+        COMMAND ${CMAKE_COMMAND} -E rm -rf "$<TARGET_BUNDLE_CONTENT_DIR:AgentSynth>/Frameworks/Sparkle.framework"
+        COMMAND ditto "${sparkle_SOURCE_DIR}/Sparkle.framework" "$<TARGET_BUNDLE_CONTENT_DIR:AgentSynth>/Frameworks/Sparkle.framework"
+        COMMENT "Embedding Sparkle.framework"
+    )
 endif()
 
 # Enable strict warnings to catch issues early

--- a/Source/Main.cpp
+++ b/Source/Main.cpp
@@ -108,7 +108,13 @@ private:
 
         void closeButtonPressed() override { JUCEApplication::getInstance()->systemRequestedQuit(); }
 
-        juce::StringArray getMenuBarNames() override { return {"File", "Edit"}; }
+        juce::StringArray getMenuBarNames() override {
+#if JUCE_MAC
+            return {"File", "Edit", "Help"};
+#else
+            return {"File", "Edit"};
+#endif
+        }
 
         juce::PopupMenu getMenuForIndex(int menuIndex, const juce::String&) override {
             juce::PopupMenu menu;
@@ -123,6 +129,11 @@ private:
                     menu.addCommandItem(&cm, AppCommands::undo);
                     menu.addCommandItem(&cm, AppCommands::redo);
                 }
+#if JUCE_MAC
+                else if (menuIndex == 2) {
+                    menu.addCommandItem(&cm, AppCommands::checkForUpdates);
+                }
+#endif
             }
             return menu;
         }

--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -478,6 +478,9 @@ void MainComponent::getAllCommands(juce::Array<juce::CommandID>& commands) {
                        AppCommands::toggleMinimap, AppCommands::toggleAiPanel, AppCommands::autoArrange,
                        AppCommands::toggleLibrary, AppCommands::selectAllModules, AppCommands::saveSnippet,
                        AppCommands::copySelection, AppCommands::pasteSelection, AppCommands::duplicateSelection});
+#if JUCE_MAC
+    commands.add(AppCommands::checkForUpdates);
+#endif
 }
 
 void MainComponent::getCommandInfo(juce::CommandID commandID, juce::ApplicationCommandInfo& result) {
@@ -582,6 +585,13 @@ void MainComponent::getCommandInfo(juce::CommandID commandID, juce::ApplicationC
         result.addDefaultKeypress(kp.getKeyCode(), kp.getModifiers());
         break;
     }
+#if JUCE_MAC
+    case AppCommands::checkForUpdates: {
+        result.setInfo("Check for Updates…", "Check for a newer version of the app", "Help", 0);
+        result.setActive(updateManager.isAvailable());
+        break;
+    }
+#endif
     default:
         break;
     }
@@ -662,6 +672,11 @@ bool MainComponent::perform(const InvocationInfo& info) {
             statusBar.showMessage("Nothing to duplicate - select one or more modules first");
         return true;
     }
+#if JUCE_MAC
+    case AppCommands::checkForUpdates:
+        updateManager.checkForUpdates();
+        return true;
+#endif
     default:
         return false;
     }

--- a/Source/MainComponent.h
+++ b/Source/MainComponent.h
@@ -17,6 +17,7 @@
 #include "UI/Theme/ThemeManager.h"
 #include "UI/ToolbarComponent.h"
 #include "UI/UIAnimation.h"
+#include "Update/UpdateManager.h"
 #include <juce_audio_utils/juce_audio_utils.h>
 #include <juce_gui_basics/juce_gui_basics.h>
 #include <memory>
@@ -226,6 +227,10 @@ private:
 
     ShortcutManager shortcutManager;
     juce::ApplicationCommandManager commandManager;
+
+#if JUCE_MAC
+    synth::update::UpdateManager updateManager;
+#endif
 
     // ---- Panel slide animations (time-bounded, auto-stop) ----
     // One VBlankAnimatorUpdater shared by both panel animations (driven by MainComponent).

--- a/Source/ShortcutManager.h
+++ b/Source/ShortcutManager.h
@@ -19,7 +19,11 @@ enum CommandIDs {
     saveSnippet,
     copySelection,
     pasteSelection,
-    duplicateSelection
+    duplicateSelection,
+    // Not user-rebindable (no ShortcutManager actionId/binding) — Sparkle's own convention is a
+    // plain "Check for Updates…" menu item with no keyboard shortcut. macOS only; see
+    // Source/Update/UpdateManager.h.
+    checkForUpdates
 };
 
 inline juce::CommandID getCommandForAction(const juce::String& actionId) {

--- a/Source/Update/SparkleUpdateManager.mm
+++ b/Source/Update/SparkleUpdateManager.mm
@@ -1,0 +1,43 @@
+#include "UpdateManager.h"
+
+#if JUCE_MAC
+
+#import <Foundation/Foundation.h>
+#import <Sparkle/Sparkle.h>
+
+namespace synth::update {
+
+class UpdateManager::Impl {
+public:
+    Impl() {
+        NSString* publicKey = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"SUPublicEDKey"];
+        NSString* feedURL = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"SUFeedURL"];
+
+        started = (publicKey.length > 0 && feedURL.length > 0);
+
+        if (started) {
+            controller = [[SPUStandardUpdaterController alloc] initWithStartingUpdater:YES
+                                                                       updaterDelegate:nil
+                                                                    userDriverDelegate:nil];
+        }
+    }
+
+    bool started = false;
+    SPUStandardUpdaterController* controller = nil;
+};
+
+UpdateManager::UpdateManager()
+    : impl(std::make_unique<Impl>()) {}
+
+UpdateManager::~UpdateManager() = default;
+
+bool UpdateManager::isAvailable() const { return impl->started; }
+
+void UpdateManager::checkForUpdates() {
+    if (impl->started)
+        [impl->controller checkForUpdates:nil];
+}
+
+} // namespace synth::update
+
+#endif // JUCE_MAC

--- a/Source/Update/UpdateManager.h
+++ b/Source/Update/UpdateManager.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <juce_core/juce_core.h>
+
+#if JUCE_MAC
+
+#include <memory>
+
+namespace synth::update {
+
+// Thin bridge to Sparkle's SPUStandardUpdaterController (Source/Update/SparkleUpdateManager.mm).
+// Construction reads SUFeedURL/SUPublicEDKey from the app bundle's Info.plist (populated at
+// configure time from SYNTH_UPDATE_FEED_URL/SYNTH_SPARKLE_PUBLIC_KEY in CMakeLists.txt) and only
+// starts Sparkle's updater if both are non-empty. A build with no signing key configured yet
+// (the default until someone runs Sparkle's generate_keys tool — see docs/distribution.md)
+// therefore never starts Sparkle and never shows its "app is misconfigured" alert.
+class UpdateManager {
+public:
+    UpdateManager();
+    ~UpdateManager();
+
+    // False if Sparkle didn't start — callers should hide/disable "Check for Updates" in that case.
+    bool isAvailable() const;
+
+    // Shows Sparkle's standard progress UI and reports results (up to date / update available /
+    // check failed) directly to the user. No-op if !isAvailable().
+    void checkForUpdates();
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> impl;
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(UpdateManager)
+};
+
+} // namespace synth::update
+
+#endif // JUCE_MAC

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -114,6 +114,24 @@ add_executable(Tests
     ../Source/UI/ShortcutsSettingsTab.cpp
 )
 
+# MainComponent.cpp above pulls in synth::update::UpdateManager (Source/Update/UpdateManager.h) on
+# macOS — Tests compiles MainComponent.cpp directly rather than linking the AgentSynth target, so
+# it needs the same Sparkle sources/linking AgentSynth gets in the top-level CMakeLists.txt.
+if(APPLE)
+    target_sources(Tests PRIVATE ../Source/Update/SparkleUpdateManager.mm)
+    set_source_files_properties(../Source/Update/SparkleUpdateManager.mm PROPERTIES COMPILE_OPTIONS -fobjc-arc)
+    target_compile_options(Tests PRIVATE "-F${sparkle_SOURCE_DIR}")
+    target_link_libraries(Tests PRIVATE "-F${sparkle_SOURCE_DIR}" "-framework Sparkle")
+
+    # Tests is a plain executable (not a .app bundle), always run from the build tree, so — unlike
+    # AgentSynth — there's no Contents/Frameworks to embed into; just point rpath straight at
+    # Sparkle.framework's fetched location.
+    set_target_properties(Tests PROPERTIES
+        BUILD_WITH_INSTALL_RPATH TRUE
+        INSTALL_RPATH "${sparkle_SOURCE_DIR}"
+    )
+endif()
+
 target_link_libraries(Tests PRIVATE
     GTest::gtest
     Core

--- a/Tests/MainComponentTests.cpp
+++ b/Tests/MainComponentTests.cpp
@@ -184,7 +184,15 @@ TEST_F(MainComponentTest, CommandManagerHasCommands) {
     // command behind it, or its key fires and nothing happens (MainComponent::keyPressed resolves
     // action -> command -> perform). A new action with no command here would otherwise ship silent.
     ShortcutManager shortcuts;
-    EXPECT_EQ(commands.size(), shortcuts.getActionIds().size());
+    // checkForUpdates (macOS only, AppCommands::checkForUpdates) is deliberately absent from the
+    // shortcut table — Sparkle's own convention is a menu-only "Check for Updates…" item with no
+    // keyboard shortcut, so the "keypress fires and nothing happens" risk this invariant guards
+    // against doesn't apply to it.
+    auto expectedCommandCount = shortcuts.getActionIds().size();
+#if JUCE_MAC
+    expectedCommandCount += 1;
+#endif
+    EXPECT_EQ(commands.size(), expectedCommandCount);
     for (const auto& actionId : shortcuts.getActionIds())
         EXPECT_TRUE(commands.contains(AppCommands::getCommandForAction(actionId)))
             << actionId << " is bindable but has no registered command";

--- a/cmake/DependencyVersions.cmake
+++ b/cmake/DependencyVersions.cmake
@@ -23,3 +23,12 @@ set(SYNTH_JUCE_GIT_TAG "8.0.3"
 
 set(SYNTH_GOOGLETEST_URL "https://github.com/google/googletest/archive/refs/tags/v1.14.0.zip"
     CACHE STRING "googletest archive fetched via FetchContent (test builds only)")
+
+# Sparkle ships as a prebuilt .xcframework, not a CMake project — fetched only on APPLE (see
+# CMakeLists.txt), so this adds ~15 MB to build/_deps on macOS only, well under the budget that
+# made the CMakeLists-wide cache key a problem (see header comment above).
+set(SYNTH_SPARKLE_URL "https://github.com/sparkle-project/Sparkle/releases/download/2.9.5/Sparkle-2.9.5.tar.xz"
+    CACHE STRING "Sparkle (macOS auto-update) binary distribution fetched via FetchContent")
+
+set(SYNTH_SPARKLE_SHA256 "015336b601493e05c237964954bff6191370003d94edefe663724c88840d73cc"
+    CACHE STRING "SHA-256 of SYNTH_SPARKLE_URL — verified against the GitHub release asset at pin time")

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -1,0 +1,150 @@
+# Distribution & Auto-Update
+
+Direct-download distribution (no app stores — see [P5·2](../CLAUDE.md) / the roadmap). This doc
+covers how release builds get their version identity and how Sparkle (macOS) checks for updates.
+WinSparkle (Windows) is a separate, not-yet-started roadmap task — see "What's not built yet" below.
+
+## Version identity
+
+Two numbers are baked into every macOS build, and they mean different things:
+
+- **`CFBundleShortVersionString`** (`PROJECT_VERSION` in `CMakeLists.txt`, e.g. `0.13.2`) — the
+  human-facing marketing version. Hand-bumped by editing `project(AgentSynth VERSION ...)`.
+- **`CFBundleVersion`** (`GRAVISYNTH_BUILD_NUMBER` cache var) — the value Sparkle actually compares
+  to decide whether an update is available. This is **not** the same value on purpose:
+  `build-artifacts.yml`'s release job (`mathieudutour/github-tag-action`) auto-tags every push to
+  `main` with a semver bump, entirely independent of `CMakeLists.txt`. If `CFBundleVersion` only
+  advanced when a human remembered to bump `PROJECT_VERSION`, Sparkle would either never detect a
+  real update or always think one was available. Instead, CI passes
+  `-DGRAVISYNTH_BUILD_NUMBER=${{ github.run_number }}` at configure time — a value that's known
+  before the build starts and increases every workflow run, regardless of what tag gets minted
+  afterwards. Local/dev builds default to `0` and are never distributed, so this doesn't matter for
+  them.
+
+## Sparkle integration (macOS)
+
+- Fetched as a prebuilt `.xcframework` distribution via `FetchContent` (`cmake/DependencyVersions.cmake`'s
+  `SYNTH_SPARKLE_URL`/`SYNTH_SPARKLE_SHA256`), APPLE-only. It's a binary artifact, not a CMake
+  project, so `FetchContent_MakeAvailable` just populates it — no `add_subdirectory`.
+- `Source/Update/UpdateManager.h` / `SparkleUpdateManager.mm` wrap `SPUStandardUpdaterController`
+  behind a two-method interface (`isAvailable()`, `checkForUpdates()`). The `.mm` file is compiled
+  with `-fobjc-arc` explicitly (JUCE's own `.mm` sources are non-ARC — see the `set_source_files_properties`
+  call in `CMakeLists.txt`), so this one bridge file manages its own memory without hand-written
+  retain/release.
+- **Safe-by-default startup**: the constructor reads `SUPublicEDKey`/`SUFeedURL` from the running
+  app's `Info.plist` and only starts Sparkle's updater if both are non-empty. Without a real public
+  key configured, Sparkle would otherwise show an "app is misconfigured" alert on every launch —
+  this keeps dev builds and any build before a signing key exists completely inert. When inert,
+  `isAvailable()` returns `false` and `MainComponent::getCommandInfo` marks the Help ▸ Check for
+  Updates… menu item inactive (greyed out) rather than hiding it.
+- Framework embedding: this project builds with Ninja (not Xcode), which has no automatic "Embed
+  Frameworks" build phase. `CMakeLists.txt` copies `Sparkle.framework` into
+  `Contents/Frameworks/` via a `POST_BUILD` custom command (using `ditto`, which preserves the
+  framework's `Versions/Current` symlink structure) and sets `INSTALL_RPATH` to
+  `@executable_path/../Frameworks` so the binary's `@rpath/Sparkle.framework/...` load command
+  resolves. CI's existing `codesign --force --deep -s -` step re-signs the embedded framework along
+  with the rest of the bundle — no separate signing step needed.
+- No App Sandbox / XPC services: the app isn't sandboxed today, so the simpler non-sandboxed Sparkle
+  integration applies (see Sparkle's [sandboxing docs](https://sparkle-project.org/documentation/sandboxing/)
+  if that ever changes).
+
+## Generating the EdDSA signing key (one-time, you run this — not CI)
+
+Sparkle signs update archives with an EdDSA (Ed25519) key pair, kept in your macOS Keychain. This
+is separate from Apple code signing (P5·2) — it's Sparkle's own update-integrity mechanism.
+
+1. Build once locally on macOS (`cmake -S . -B build && cmake --build build`) so Sparkle's
+   distribution is fetched to `build/_deps/sparkle-src/`.
+2. Generate (or look up an existing) key pair, stored in your login Keychain:
+   ```bash
+   ./build/_deps/sparkle-src/bin/generate_keys
+   ```
+   This prints the public key and the exact `SUPublicEDKey` Info.plist snippet.
+3. Set the public key as a **repository variable** (not a secret — it's public by design):
+   Settings ▸ Secrets and variables ▸ Actions ▸ Variables ▸ new variable `SPARKLE_PUBLIC_KEY`.
+   Also pass it locally when you want to test the real flow: `-DSYNTH_SPARKLE_PUBLIC_KEY=<key>`.
+4. Export the private key for CI to use when signing releases:
+   ```bash
+   ./build/_deps/sparkle-src/bin/generate_keys -x /tmp/sparkle_private_key
+   ```
+   Add its contents as the **repository secret** `SPARKLE_PRIVATE_KEY`, then delete
+   `/tmp/sparkle_private_key`. Never commit it.
+
+Once both exist, `build-artifacts.yml`'s `publish-appcast` job (gated on
+`vars.SPARKLE_PUBLIC_KEY != ''`) starts running for real instead of skipping.
+
+## CI: what's automated vs. what isn't
+
+Automated (`build-artifacts.yml`):
+- The macOS build job bakes in `CFBundleVersion` = `github.run_number` and (once the variable
+  exists) the real `SUPublicEDKey`.
+- After the `release` job tags and publishes the GitHub Release, `publish-appcast` downloads that
+  release's macOS zip, runs Sparkle's `generate_appcast` tool against it (signing with
+  `SPARKLE_PRIVATE_KEY`, `--download-url-prefix` pointing at that same release's GitHub asset URLs),
+  and uploads the resulting `appcast.xml` back onto the release as an asset.
+
+**Not automated**: deploying `appcast.xml` to `https://agentsynth.app/updates/appcast.xml` — the
+`SUFeedURL` baked into the app (`SYNTH_UPDATE_FEED_URL` in `CMakeLists.txt`). The zip itself stays
+on GitHub Releases (`--download-url-prefix` points there directly, so only the small `appcast.xml`
+file needs hosting elsewhere); publishing that one file to agentsynth.app still needs a manual step
+or a future automated one (P5·1 marketing site / P5·4 both touch that domain's Cloudflare Pages
+deployment, which this repo has no credentials for). Until that's wired up, "Check for Updates"
+starts (once a key exists) but the feed check itself 404s — Sparkle's default UX for that is a
+silent no-op on a background check and a plain "couldn't check" alert only if the user explicitly
+clicks the menu item, so this fails safely rather than looking broken.
+
+## What's not built yet
+
+- **Windows (WinSparkle)** — tracked as a separate roadmap task (macOS-first was a deliberate scope
+  cut: P5·2 defers the Windows code-signing cert past first revenue, and someone testing on Windows
+  recently reported no audio, so a full Windows pass belongs together regardless).
+- **Notarization** — CI's existing `codesign --force --deep -s -` is ad-hoc signing, not a real
+  Developer ID + notarization (that's P5·2). Sparkle's own update-signature check (the EdDSA key
+  above) doesn't require notarization to function, but Gatekeeper may still warn on the *initial*
+  install until P5·2 lands — that's an existing, separate problem this task doesn't change.
+
+## Testing
+
+There's no automated (GoogleTest) coverage for this feature. `UpdateManager`'s only logic is two
+one-line methods delegating straight to `SPUStandardUpdaterController` — a native macOS GUI
+framework with its own (separately maintained, widely-used) test suite upstream — so there's
+nothing headless-testable to lock down here; the real risk surface is build/packaging/CI wiring,
+which GoogleTest can't exercise either. Verify manually instead:
+
+**1. Compiles and embeds correctly:**
+```bash
+cmake -S . -B build && cmake --build build
+otool -L "build/AgentSynth_artefacts/AgentSynth.app/Contents/MacOS/Agent Synth" | grep Sparkle
+# expect: @rpath/Sparkle.framework/Versions/B/Sparkle
+ls "build/AgentSynth_artefacts/AgentSynth.app/Contents/Frameworks/Sparkle.framework"
+```
+
+**2. Inert without a key** (the default state right now): launch the built app, open Help ▸ Check
+for Updates… — it should be greyed out, and no misconfiguration alert should appear.
+
+**3. Full local update flow**, once you've generated a key (see above):
+- Configure with your real public key: `cmake -S . -B build -DSYNTH_SPARKLE_PUBLIC_KEY=<your key> -DGRAVISYNTH_BUILD_NUMBER=1` and rebuild.
+- Build a second copy with a *higher* build number (e.g. `-DGRAVISYNTH_BUILD_NUMBER=2`), zip its
+  `.app`, and run Sparkle's `generate_appcast` against a directory containing just that zip:
+  ```bash
+  ./build/_deps/sparkle-src/bin/generate_appcast /path/to/dir-with-the-zip
+  ```
+- Serve that directory locally: `python3 -m http.server 8000` from inside it.
+- Point the *first* (lower build number) app at it for this one test run:
+  `-DSYNTH_UPDATE_FEED_URL=http://127.0.0.1:8000/appcast.xml`. Sparkle's App Transport Security
+  normally requires HTTPS — `http://127.0.0.1` is exempted by default (loopback), so no ATS
+  exception plist entry should be needed; if it is blocked, add a Debug-only
+  `NSAppTransportSecurity` / `NSExceptionDomains` entry for `127.0.0.1`, never for the real feed URL.
+  Rebuild the first app with this override.
+- Launch it, Help ▸ Check for Updates… — Sparkle should offer the higher-numbered build, download,
+  verify the EdDSA signature, and install it.
+
+**4. Signature-rejection check** (the actual security-relevant case): re-run `generate_appcast`
+against the same zip but with a different, throwaway key (`generate_keys --account test-throwaway`
+first), or hand-edit the `<sparkle:edSignature>` in the generated `appcast.xml`. Confirm Sparkle
+refuses the update instead of installing it.
+
+**5. End-to-end against the real deployment** — once the appcast is actually hosted at
+`https://agentsynth.app/updates/appcast.xml` (see "what's not built yet" above) and a signed
+release exists, repeat step 3 against production. This can't be verified until then; treat it as
+the acceptance test for whichever task wires up that deployment.


### PR DESCRIPTION
## Summary
- Sparkle 2.9.5 fetched as a prebuilt framework (macOS only), embedded into the app bundle via a `POST_BUILD` copy + rpath (Ninja has no Xcode-style "Embed Frameworks" phase)
- `Source/Update/UpdateManager.h` / `SparkleUpdateManager.mm` wrap `SPUStandardUpdaterController` behind a 2-method bridge, wired to a new **Help ▸ Check for Updates…** menu item
- Stays inert (no Sparkle startup, menu item disabled) until a real `SUPublicEDKey` is configured — never shows Sparkle's misconfiguration alert on a dev build or before a signing key exists
- Fixes a real version-identity bug along the way: `CFBundleVersion` (what Sparkle actually compares) was a duplicated literal that never changed release to release, while the release workflow auto-tags every push independently. CI now bakes in the workflow run number instead, kept distinct from the hand-bumped marketing version
- New `publish-appcast` CI job signs and attaches `appcast.xml` to each release once `SPARKLE_PUBLIC_KEY`/`SPARKLE_PRIVATE_KEY` exist — skips cleanly until then
- Windows (WinSparkle) is out of scope here — tracked as [synth-platform#57](https://github.com/Diabl0269/synth-platform/pull/57) (roadmap P5-6)

## Two things only you can do next (documented in `docs/distribution.md`)
1. Run Sparkle's `generate_keys` tool locally, add the public key as repo variable `SPARKLE_PUBLIC_KEY` and the exported private key as repo secret `SPARKLE_PRIVATE_KEY`
2. Wire up actually publishing `appcast.xml` to `https://agentsynth.app/updates/appcast.xml` (the app's `SUFeedURL`) — not automated by this PR; the zip itself stays on GitHub Releases, only the small appcast file needs hosting elsewhere

## Test plan
- [x] `cmake -S . -B build && cmake --build build` — clean build, `Sparkle.framework` embeds into `Contents/Frameworks/`, `otool -l` shows the correct `@executable_path/../Frameworks` rpath
- [x] Launched the built app — no crash, no Sparkle misconfiguration alert (expected: no key configured yet), quit cleanly
- [x] `ENABLE_TESTS=ON` build — full suite passes, 1572/1572 (including a pre-existing exact-count test I updated for the new platform-gated command, see `Tests/MainComponentTests.cpp`)
- [ ] Real update-check flow against a locally-hosted appcast — documented as a manual step in `docs/distribution.md`, needs a real signing key
- [ ] End-to-end against production — blocked on the two follow-up items above

See `docs/distribution.md` for full architecture, key-generation steps, and testing instructions.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>