### PR TITLE
fix(ai): derive structured-output classifier from module registry

### DIFF
--- a/Source/AI/AIIntegrationService.cpp
+++ b/Source/AI/AIIntegrationService.cpp
@@ -95,7 +95,11 @@ juce::String AIIntegrationService::buildPatchAugmentedContent(const juce::String
             }
         }
     }
-    return text;
+    // Structured output was requested but the live graph has no nodes. Silently falling back to
+    // bare `text` gave the model no signal either way about whether a patch already exists, so a
+    // fresh-session "create a bass patch" request would come back asking the user to paste their
+    // (nonexistent) current patch. Say explicitly that the canvas is empty instead.
+    return "Current patch is empty.\n\nUser request: " + text;
 }
 
 void AIIntegrationService::trimHistory() {

--- a/Source/UI/AIChatComponent.cpp
+++ b/Source/UI/AIChatComponent.cpp
@@ -520,6 +520,34 @@ void AIChatComponent::paint(juce::Graphics& g) {
     }
 }
 
+bool AIChatComponent::shouldUseStructuredOutput(const juce::String& text, const juce::StringArray& moduleTypeNames) {
+    // Any real module/effect type name (Chorus, Distortion, Oscillator, ...) means the user is
+    // almost certainly talking about the graph, even without an explicit edit verb ("what does
+    // the Reverb's decay knob do?"). Deriving this from the module factory registry — rather than
+    // a hand-picked handful — means a new module type is covered automatically; the old hardcoded
+    // list (oscillator/filter/vca/adsr) silently missed everything else, which is what caused this
+    // bug ("Add a chorus between the distortion to the delay" matched none of the four).
+    for (const auto& moduleType : moduleTypeNames)
+        if (text.containsIgnoreCase(moduleType))
+            return true;
+
+    // Generic edit-intent verbs/nouns that show up in a patch-authoring request regardless of
+    // which module is named (or when no module is named at all, e.g. "add a filter" without
+    // capitalizing on a specific type, or "increase the cutoff"). Bias toward inclusion: a false
+    // positive here just spends ~1.5k tokens of unnecessary patch context; a false negative
+    // reproduces the original bug (request goes out with no graph context and the model has to
+    // guess or ask).
+    static const char* kEditIntentWords[] = {
+        "patch",   "create", "modify", "sound",    "preset",   "add",  "remove", "delete",
+        "connect", "change", "set",    "increase", "decrease", "swap", "insert", "between",
+    };
+    for (const auto* word : kEditIntentWords)
+        if (text.containsIgnoreCase(word))
+            return true;
+
+    return false;
+}
+
 void AIChatComponent::sendButtonClicked() {
     auto text = inputField.getText().trim();
     if (text.isEmpty())
@@ -527,11 +555,7 @@ void AIChatComponent::sendButtonClicked() {
 
     inputField.clear();
 
-    // Heuristic to decide if we want structured output (e.g. if the user asks for a patch)
-    bool useStructuredOutput =
-        text.containsIgnoreCase("patch") || text.containsIgnoreCase("create") || text.containsIgnoreCase("modify") ||
-        text.containsIgnoreCase("oscillator") || text.containsIgnoreCase("filter") || text.containsIgnoreCase("vca") ||
-        text.containsIgnoreCase("adsr") || text.containsIgnoreCase("sound") || text.containsIgnoreCase("preset");
+    bool useStructuredOutput = shouldUseStructuredOutput(text, AIStateMapper::moduleFactoryTypeNames());
 
     // Add user message to local state immediately
     messages.push_back({"user", text, ""});

--- a/Source/UI/AIChatComponent.h
+++ b/Source/UI/AIChatComponent.h
@@ -46,6 +46,14 @@ public:
     void sendButtonClicked();
     void triggerSend() { sendButtonClicked(); }
 
+    // Decides whether an outgoing message should carry the live patch JSON + structured-output
+    // schema (see AIIntegrationService::sendMessage). Pure and free-standing (no UI state) so it
+    // can be unit-tested directly: any message naming a real module/effect type, or using a
+    // generic edit-intent verb, is treated as patch-related. `moduleTypeNames` is normally
+    // AIStateMapper::moduleFactoryTypeNames() — passed in explicitly so a test can supply a
+    // synthetic registry without touching the real module factory.
+    static bool shouldUseStructuredOutput(const juce::String& text, const juce::StringArray& moduleTypeNames);
+
     /**
      * @brief Attaches (or detaches, with nullptr) the account UI to `service`.
      *

--- a/Tests/AIChatComponentTests.cpp
+++ b/Tests/AIChatComponentTests.cpp
@@ -245,6 +245,57 @@ TEST_F(AIChatComponentTest, SendMessageUpdatesUIAndHistory) {
     EXPECT_GT(service.getHistory().size(), initialHistorySize + 1);
 }
 
+// AIChatComponent::shouldUseStructuredOutput() classifies whether a user message should carry
+// live patch JSON + the structured-output schema. Regression coverage for the bug where a
+// hand-picked keyword list (patch/create/modify/oscillator/filter/vca/adsr/sound/preset) silently
+// missed real module names like "Chorus", "Distortion", and "Delay" — the classifier under test
+// derives its module-name match set from the real module factory registry instead.
+TEST(AIChatComponentClassifierTest, ExactBugReportStringIsRecognizedAsPatchRelated) {
+    // The reported failing message: matched none of the 4 hardcoded module names in the old
+    // classifier (oscillator/filter/vca/adsr), even though it names three real modules
+    // (Chorus, Distortion, Delay) plus the edit-intent word "between".
+    EXPECT_TRUE(synth::AIChatComponent::shouldUseStructuredOutput("Add a chorus between the distortion to the delay",
+                                                                  synth::AIStateMapper::moduleFactoryTypeNames()));
+}
+
+TEST(AIChatComponentClassifierTest, AnyRealModuleTypeNameTriggersStructuredOutput) {
+    // A synthetic registry, independent of the real module list, proves the classifier walks
+    // whatever names it is given rather than a hardcoded subset.
+    // Neither sentence below contains any of the classifier's generic edit-intent words, so a true
+    // result can only come from matching the registry entry itself.
+    juce::StringArray registry{"Widget", "Gizmo"};
+    EXPECT_TRUE(
+        synth::AIChatComponent::shouldUseStructuredOutput("I really like the tone of a Widget lately.", registry));
+    EXPECT_FALSE(synth::AIChatComponent::shouldUseStructuredOutput("What is a gadget?", registry));
+}
+
+// These two are close calls between "conversational" and "patch-related" — see the bias-toward-
+// inclusion rule in AIChatComponent.cpp: attaching unnecessary context costs ~1.5k tokens, while
+// missing a real edit request reproduces this exact bug. Both strings happen to contain a real
+// word from the classifier's match set ("filter" is a module type name; "sound" is a generic
+// edit-intent word carried over from the original list), so the classifier intentionally treats
+// them as patch-related even though a human reading them in isolation might call them "just
+// conversation". That is the correct tradeoff: a user asking "what does a low-pass filter do" is
+// one clarifying follow-up away from "now add one to my patch", and the live graph context is
+// harmless to include either way.
+TEST(AIChatComponentClassifierTest, FilterQuestionIsTreatedAsPatchRelated) {
+    EXPECT_TRUE(synth::AIChatComponent::shouldUseStructuredOutput("What does a low-pass filter do conceptually?",
+                                                                  synth::AIStateMapper::moduleFactoryTypeNames()));
+}
+
+TEST(AIChatComponentClassifierTest, BassSoundTipsIsTreatedAsPatchRelated) {
+    EXPECT_TRUE(synth::AIChatComponent::shouldUseStructuredOutput("Any tips for a fat bass sound?",
+                                                                  synth::AIStateMapper::moduleFactoryTypeNames()));
+}
+
+// A genuinely keyword-free conversational message — no module type name, no edit-intent verb —
+// stays conversational. This is the counterpart to the two tests above: it proves the classifier
+// doesn't degenerate into "always true" once module names are folded in.
+TEST(AIChatComponentClassifierTest, KeywordFreeMusicTheoryQuestionStaysConversational) {
+    EXPECT_FALSE(synth::AIChatComponent::shouldUseStructuredOutput(
+        "How does subtractive synthesis differ from FM synthesis?", synth::AIStateMapper::moduleFactoryTypeNames()));
+}
+
 // REGRESSION LOCK: reproduces MainComponent's member-init ordering, where AIChatComponent is
 // constructed BEFORE the owning component installs a provider on the service. The ctor's own
 // refreshModels() call therefore finds no provider and short-circuits, leaving currentModel

--- a/Tests/AIIntegrationServiceTests.cpp
+++ b/Tests/AIIntegrationServiceTests.cpp
@@ -421,6 +421,27 @@ TEST_F(AIIntegrationServiceTest, OutgoingRequestStillIncludesPatchContext) {
     EXPECT_TRUE(rawProvider->lastConversation.back().content.contains("Add a filter"));
 }
 
+// Regression: buildPatchAugmentedContent() used to silently return bare `text` when the live
+// graph had zero nodes, giving the model no signal either way about whether a patch already
+// exists. A fresh-session "create a bass patch" request needs an explicit "empty" marker instead,
+// or the model has no way to distinguish "there is a patch but you weren't told about it" from
+// "there is genuinely nothing yet".
+TEST_F(AIIntegrationServiceTest, OutgoingRequestOnEmptyGraphStatesPatchIsEmpty) {
+    // No nodes added to `graph` — deliberately left empty.
+    auto provider = std::make_unique<MockAIProvider>();
+    auto* rawProvider = provider.get();
+    service->setProvider(std::move(provider));
+
+    service->sendMessage("Create a fat bass patch", nullptr, true);
+
+    ASSERT_FALSE(rawProvider->lastConversation.empty());
+    const auto& content = rawProvider->lastConversation.back().content;
+    EXPECT_TRUE(content.contains("Current patch is empty"));
+    EXPECT_TRUE(content.contains("Create a fat bass patch"));
+    // Must not claim a patch state block that doesn't exist.
+    EXPECT_FALSE(content.contains("Current patch state"));
+}
+
 TEST_F(AIIntegrationServiceTest, HistoryIsTrimmedToCap) {
     auto provider = std::make_unique<MockAIProvider>();
     service->setProvider(std::move(provider));

--- a/docs/AI_Engine.md
+++ b/docs/AI_Engine.md
@@ -655,7 +655,10 @@ for the rules this inherits unchanged.
 **Why `userPrompt` can carry the client's already-wrapped text unmodified.**
 `AIIntegrationService::buildPatchAugmentedContent()` renders the current graph into the *last*
 conversation message as `"Current patch state:\n\`\`\`json\n<JSON>\n\`\`\`\n\nUser request:
-<text>"` whenever the graph is non-empty, and leaves it as plain text otherwise. The service's own
+<text>"` whenever the graph is non-empty, and as `"Current patch is empty.\n\nUser request:
+<text>"` when it has zero nodes — the model always gets an explicit signal about whether a patch
+already exists, rather than silently falling back to the bare request text (which left "is there
+already a patch?" unanswered for a fresh-session prompt like "create a bass patch"). The service's own
 `buildUserMessage()` (`synth-platform/packages/capabilities/src/patch-generate/capability.ts`)
 performs the *exact same* wrapping server-side, from a separate `currentPatch` + `userPrompt`
 pair, and only wraps when `currentPatch` is present. Sending the client's already-wrapped text as


### PR DESCRIPTION
## Summary
- The AI chat's structured-output classifier used a hardcoded 9-word keyword list to decide whether to attach the live patch JSON + request the schema. Real module/effect names like "Chorus", "Distortion", "Delay" weren't in it, so a message like "Add a chorus between the distortion and delay" went out with zero graph context — the model correctly (from its perspective) said it didn't have the patch.
- Replaces the list with `AIChatComponent::shouldUseStructuredOutput()`, a pure/testable function checked against `AIStateMapper::moduleFactoryTypeNames()` (the real module registry) plus generic edit-intent verbs, so any current or future module name is covered automatically.
- `buildPatchAugmentedContent()` now explicitly states "Current patch is empty" instead of silently omitting patch-state context when the graph has zero nodes.
- Pre-existing bug, unrelated to the P6-2 diff-preview work in the sibling PR — found while testing that feature.

## Test plan
- [x] New `AIChatComponentClassifierTest` cases (exact bug-report string, real module-name matches, empty-graph marker)
- [x] Full suite: 1597/1597 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)