### PR TITLE
feat(ai): patch diff preview before apply (P6-2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,6 +152,8 @@ add_library(Core STATIC
     Source/AI/AIProviderRegistry.cpp
     Source/AI/PatchEval.h
     Source/AI/PatchEval.cpp
+    Source/AI/PatchDiff.h
+    Source/AI/PatchDiff.cpp
     Source/AI/AuthClient.h
     Source/AI/AuthClient.cpp
     Source/AI/AccountService.h

--- a/Source/AI/AIIntegrationService.cpp
+++ b/Source/AI/AIIntegrationService.cpp
@@ -117,6 +117,52 @@ void AIIntegrationService::trimHistory() {
                       chatHistory.begin() + static_cast<long>(start + messagesToRemove));
 }
 
+void AIIntegrationService::replayLiveGraphTrusted(juce::AudioProcessorGraph& scratch) const {
+    juce::var currentState = AIStateMapper::graphToJSON(audioGraph);
+    AIStateMapper::applyJSONToGraph(currentState, scratch, /*clearExisting=*/true, /*trusted=*/true);
+}
+
+bool AIIntegrationService::computePatchPreview(const juce::String& jsonString, bool mergeMode, juce::var& before,
+                                               juce::var& after) {
+    juce::String extractedJson = extractJsonFromResponse(jsonString);
+    juce::var json = juce::JSON::parse(extractedJson);
+    if (!json.isObject())
+        return false;
+
+    bool clearExisting = !mergeMode;
+
+    // Mirror applyPatch()'s mode-less-patch repair (see the identical check there): a patch with
+    // no stated "mode" that only validates as a merge is applied as a merge, so the previewed
+    // diff must use the same clearExisting the real apply will use, or the user approves one
+    // diff and gets a different one.
+    if (clearExisting && !hasExplicitMode(json)) {
+        auto asReplace = AIStateMapper::validatePatch(json, audioGraph, /*clearExisting=*/true, /*trusted=*/false);
+        if (!asReplace.ok) {
+            auto asMerge = AIStateMapper::validatePatch(json, audioGraph, /*clearExisting=*/false, /*trusted=*/false);
+            if (asMerge.ok)
+                clearExisting = false;
+        }
+    }
+
+    juce::AudioProcessorGraph scratch;
+    synth::prepareGraphForPatchEval(scratch);
+    if (!clearExisting)
+        replayLiveGraphTrusted(scratch);
+
+    // Both "before" and "after" are read off graphToJSON() — never the raw patch JSON — so the
+    // diff sees exactly what applying the patch would actually do to the graph (auto-wiring,
+    // deletions, value rescaling included). For merge mode, "before" is the scratch's
+    // just-replayed state rather than a second graphToJSON(audioGraph) call: both travel the same
+    // param round-trip (denormalize -> setValueNotifyingHost -> renormalize, including any
+    // snapToLegalValue on a skewed/int range), so a no-op patch can't show a phantom param change
+    // from replay-only rounding that the live graph's own snapshot never went through.
+    before = clearExisting ? AIStateMapper::graphToJSON(audioGraph) : AIStateMapper::graphToJSON(scratch);
+
+    bool applied = AIStateMapper::applyJSONToGraph(json, scratch, clearExisting, /*trusted=*/false);
+    after = AIStateMapper::graphToJSON(scratch);
+    return applied;
+}
+
 bool AIIntegrationService::hasExplicitMode(const juce::var& json) {
     auto* obj = json.getDynamicObject();
     if (obj == nullptr || !obj->hasProperty("mode"))
@@ -196,9 +242,8 @@ bool AIIntegrationService::applyPatch(const juce::String& jsonString, bool merge
             // Replaying the live graph's current state as trusted mirrors exactly what undo/redo's
             // own snapshot-restore does (see the "Preserve node identity" comment in
             // AIStateMapper::applyJSONToGraph), so ids line up with what the candidate patch
-            // references.
-            juce::var currentState = AIStateMapper::graphToJSON(audioGraph);
-            AIStateMapper::applyJSONToGraph(currentState, scratch, /*clearExisting=*/true, /*trusted=*/true);
+            // references. Shared with computePatchPreview() — see replayLiveGraphTrusted().
+            replayLiveGraphTrusted(scratch);
             const auto before = synth::evaluatePatch(scratch);
             beforeOk = before.hasAudioOutput && before.sourceReachesOutput;
         }

--- a/Source/AI/AIIntegrationService.h
+++ b/Source/AI/AIIntegrationService.h
@@ -88,6 +88,32 @@ public:
     bool applyPatch(const juce::String& jsonString, bool mergeMode = false);
 
     /**
+     * @brief Computes the before/after graph snapshots a proposed patch would produce, WITHOUT
+     *        applying anything to the live graph — the basis for the chat UI's diff preview.
+     *
+     * `before` is always the live graph's current AIStateMapper::graphToJSON(). `after` is
+     * graphToJSON() of a scratch graph the patch was actually applied to (merge mode first
+     * trusted-replays the live graph into that scratch, exactly like applyPatch()'s own
+     * PatchEval regression check, so pre-existing nodes keep their live id/uuid). Diffing these
+     * two snapshots — never the raw patch JSON — is what makes the preview correct: it is the
+     * only way to see merge mode's auto-wiring of new nodes, replace mode's implicit deletion of
+     * everything the patch doesn't restate, and the untrusted-apply [0,1] rescale heuristic. See
+     * PatchDiff.h.
+     *
+     * Mirrors applyPatch()'s mode-less-patch repair (a replace that only validates as a merge is
+     * applied as a merge) so the previewed diff matches what Apply/Merge will actually do.
+     *
+     * @return true if the patch applied cleanly to the scratch graph (matching what applyPatch()
+     *         would report on a fresh live graph); false if it failed validation or application —
+     *         `before`/`after` are still populated (after reflects the unapplied, pre-patch
+     *         state) so a caller can still show "preview unavailable" using the same values.
+     *         Does NOT touch getLastPatchError()/getLastPatchErrorCode()/didLastPatchRepairMode()
+     *         — this never mutates the graph the user is looking at, so it must not clobber the
+     *         error state from a previous real Apply attempt.
+     */
+    bool computePatchPreview(const juce::String& jsonString, bool mergeMode, juce::var& before, juce::var& after);
+
+    /**
      * @brief How many correction round-trips applyPatchWithRetry() may make after the first
      *        rejected patch. Total attempts are kMaxPatchRetries + 1.
      *
@@ -244,6 +270,15 @@ private:
      *        that the mode repair in applyPatch() must not override.
      */
     static bool hasExplicitMode(const juce::var& json);
+
+    /**
+     * @brief Trusted-replays the live graph's current AIStateMapper::graphToJSON() into `scratch`
+     *        (clearExisting=true, trusted=true) — the shared first step for building a scratch
+     *        graph that starts as an exact copy of the live one, used by both applyPatch()'s
+     *        PatchEval regression check and computePatchPreview(). Only meaningful for merge mode:
+     *        a replace-mode candidate patch has no "before" to build on top of.
+     */
+    void replayLiveGraphTrusted(juce::AudioProcessorGraph& scratch) const;
 
     JUCE_DECLARE_WEAK_REFERENCEABLE(AIIntegrationService)
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(AIIntegrationService)

--- a/Source/AI/PatchDiff.cpp
+++ b/Source/AI/PatchDiff.cpp
@@ -1,0 +1,407 @@
+#include "PatchDiff.h"
+#include "../Modules/ModuleBase.h"
+#include "AIStateMapper.h"
+#include <algorithm>
+#include <cmath>
+#include <juce_audio_processors/juce_audio_processors.h>
+#include <map>
+#include <memory>
+#include <tuple>
+#include <unordered_map>
+
+namespace synth {
+
+namespace {
+
+constexpr double kNumericTolerance = 1.0e-4;
+
+struct NodeEntry {
+    juce::String uuid;
+    juce::String type;
+    const juce::DynamicObject* params = nullptr;
+};
+
+// Per-snapshot lookup: graphToJSON's integer node "id" is only meaningful within the snapshot it
+// came from (a fresh scratch-graph rebuild assigns unrelated ids to brand-new nodes), so
+// connection/modulation endpoints must be resolved to uuid through THIS map before comparing
+// across before/after.
+struct SnapshotIndex {
+    std::unordered_map<int, juce::String> idToUuid;
+    std::map<juce::String, NodeEntry> byUuid;
+};
+
+SnapshotIndex indexSnapshot(const juce::var& snapshot) {
+    SnapshotIndex idx;
+    auto* root = snapshot.getDynamicObject();
+    if (root == nullptr)
+        return idx;
+    auto* nodes = root->getProperty("nodes").getArray();
+    if (nodes == nullptr)
+        return idx;
+
+    for (const auto& nVar : *nodes) {
+        auto* nObj = nVar.getDynamicObject();
+        if (nObj == nullptr)
+            continue;
+        juce::String uuid = nObj->getProperty("uuid").toString();
+        if (uuid.isEmpty())
+            continue;
+
+        int id = (int)nObj->getProperty("id");
+        idx.idToUuid[id] = uuid;
+
+        NodeEntry entry;
+        entry.uuid = uuid;
+        entry.type = nObj->getProperty("type").toString();
+        entry.params = nObj->getProperty("params").getDynamicObject();
+        idx.byUuid[uuid] = entry;
+    }
+    return idx;
+}
+
+juce::String resolveUuid(const SnapshotIndex& idx, int id) {
+    auto it = idx.idToUuid.find(id);
+    return it == idx.idToUuid.end() ? juce::String() : it->second;
+}
+
+bool isAttenuverterType(const juce::String& type) { return type == "Attenuverter"; }
+
+// ~3 significant figures, no unit-formatting table exists in this codebase (confirmed against
+// ParametricEQModule's getText()) so raw numeric values are shown without units.
+juce::String formatSigFigs(double v, int sig = 3) {
+    if (!std::isfinite(v))
+        return juce::String(v);
+    if (v == 0.0)
+        return "0";
+
+    double av = std::abs(v);
+    int magnitude = (int)std::floor(std::log10(av));
+    int decimals = juce::jlimit(0, 6, sig - 1 - magnitude);
+
+    juce::String s(v, decimals);
+    if (s.containsChar('.')) {
+        while (s.endsWithChar('0'))
+            s = s.dropLastCharacters(1);
+        if (s.endsWithChar('.'))
+            s = s.dropLastCharacters(1);
+    }
+    return s;
+}
+
+juce::String describeVar(const juce::var& v) {
+    if (v.isBool())
+        return (bool)v ? "true" : "false";
+    if (v.isString())
+        return v.toString();
+    if (v.isDouble() || v.isInt() || v.isInt64())
+        return formatSigFigs((double)v);
+    return v.toString();
+}
+
+bool varsEqual(const juce::var& a, const juce::var& b) {
+    if (a.isBool() || b.isBool())
+        return (bool)a == (bool)b;
+    if (a.isString() || b.isString())
+        return a.toString() == b.toString();
+    if ((a.isDouble() || a.isInt() || a.isInt64()) && (b.isDouble() || b.isInt() || b.isInt64()))
+        return std::abs((double)a - (double)b) <= kNumericTolerance;
+    return a == b;
+}
+
+// Lazily-instantiated, never-processed processors, one per node type, purely to read parameter
+// display names and modulation-target names. Headless (no GUI, no audio device), same pattern as
+// AIStateMapper::validateNodeParams's "probe" processors.
+class TypeMetadataCache {
+public:
+    juce::String paramDisplayName(const juce::String& type, const juce::String& paramId) {
+        if (auto* proc = get(type))
+            if (auto* p = findParameterByID(proc, paramId))
+                return p->name;
+        return paramId;
+    }
+
+    juce::String modTargetName(const juce::String& type, int channel) {
+        if (auto* proc = get(type))
+            if (auto* mb = dynamic_cast<ModuleBase*>(proc))
+                for (const auto& t : mb->getModulationTargets())
+                    if (t.channelIndex == channel)
+                        return t.name;
+        return {};
+    }
+
+private:
+    juce::AudioProcessor* get(const juce::String& type) {
+        auto it = cache.find(type);
+        if (it != cache.end())
+            return it->second.get();
+        auto processor = AIStateMapper::createModule(type);
+        auto* raw = processor.get();
+        cache[type] = std::move(processor);
+        return raw;
+    }
+
+    std::map<juce::String, std::unique_ptr<juce::AudioProcessor>> cache;
+};
+
+// src uuid, srcPort, dst uuid, dstPort, isMidi
+using ConnKey = std::tuple<juce::String, int, juce::String, int, bool>;
+
+struct ConnRecord {
+    ConnKey key;
+    juce::String srcType, dstType;
+};
+
+std::vector<ConnRecord> collectConnections(const juce::var& snapshot, const SnapshotIndex& idx) {
+    std::vector<ConnRecord> out;
+    auto* root = snapshot.getDynamicObject();
+    if (root == nullptr)
+        return out;
+    auto* conns = root->getProperty("connections").getArray();
+    if (conns == nullptr)
+        return out;
+
+    for (const auto& cVar : *conns) {
+        auto* cObj = cVar.getDynamicObject();
+        if (cObj == nullptr)
+            continue;
+
+        juce::String srcUuid = resolveUuid(idx, (int)cObj->getProperty("src"));
+        juce::String dstUuid = resolveUuid(idx, (int)cObj->getProperty("dst"));
+        if (srcUuid.isEmpty() || dstUuid.isEmpty())
+            continue;
+
+        juce::String srcType, dstType;
+        if (auto it = idx.byUuid.find(srcUuid); it != idx.byUuid.end())
+            srcType = it->second.type;
+        if (auto it = idx.byUuid.find(dstUuid); it != idx.byUuid.end())
+            dstType = it->second.type;
+
+        // Attenuverter plumbing is reported exclusively via modulations[]; suppress it here so a
+        // modulation doesn't ALSO show up as a raw node + two connections.
+        if (isAttenuverterType(srcType) || isAttenuverterType(dstType))
+            continue;
+
+        ConnRecord rec;
+        rec.key = {srcUuid, (int)cObj->getProperty("srcPort"), dstUuid, (int)cObj->getProperty("dstPort"),
+                   (bool)cObj->getProperty("isMidi")};
+        rec.srcType = srcType;
+        rec.dstType = dstType;
+        out.push_back(rec);
+    }
+    return out;
+}
+
+// src uuid, srcPort, dst uuid, dstPort
+using ModKey = std::tuple<juce::String, int, juce::String, int>;
+
+struct ModRecord {
+    ModKey key;
+    juce::String srcType, dstType;
+    double amount = 1.0;
+    bool bypass = false;
+};
+
+std::vector<ModRecord> collectModulations(const juce::var& snapshot, const SnapshotIndex& idx) {
+    std::vector<ModRecord> out;
+    auto* root = snapshot.getDynamicObject();
+    if (root == nullptr)
+        return out;
+    auto* mods = root->getProperty("modulations").getArray();
+    if (mods == nullptr)
+        return out;
+
+    for (const auto& mVar : *mods) {
+        auto* mObj = mVar.getDynamicObject();
+        if (mObj == nullptr)
+            continue;
+
+        int srcPort = mObj->hasProperty("sourcePort") ? (int)mObj->getProperty("sourcePort") : 0;
+        int dstPort = (int)mObj->getProperty("destPort");
+        juce::String srcUuid = resolveUuid(idx, (int)mObj->getProperty("source"));
+        juce::String dstUuid = resolveUuid(idx, (int)mObj->getProperty("dest"));
+        if (srcUuid.isEmpty() || dstUuid.isEmpty())
+            continue;
+
+        ModRecord rec;
+        rec.key = {srcUuid, srcPort, dstUuid, dstPort};
+        if (auto it = idx.byUuid.find(srcUuid); it != idx.byUuid.end())
+            rec.srcType = it->second.type;
+        if (auto it = idx.byUuid.find(dstUuid); it != idx.byUuid.end())
+            rec.dstType = it->second.type;
+        rec.amount = mObj->hasProperty("amount") ? (double)mObj->getProperty("amount") : 1.0;
+        rec.bypass = mObj->hasProperty("bypass") ? (bool)mObj->getProperty("bypass") : false;
+        out.push_back(rec);
+    }
+    return out;
+}
+
+} // namespace
+
+juce::String PatchChange::describe() const {
+    switch (kind) {
+    case Kind::NodeAdded:
+        return "+ " + nodeType;
+    case Kind::NodeRemoved:
+        return "- " + nodeType;
+    case Kind::ParamChanged:
+        return nodeType + ": " + paramName + " " + beforeText + " -> " + afterText;
+    case Kind::ConnectionAdded:
+        return "+ connect " + srcType + (isMidi ? " (MIDI) -> " : " -> ") + dstType;
+    case Kind::ConnectionRemoved:
+        return "- connect " + srcType + (isMidi ? " (MIDI) -> " : " -> ") + dstType;
+    case Kind::ModulationAdded:
+        return "+ mod " + srcType + " -> " + dstType +
+               (destParamName.isNotEmpty() ? (" " + destParamName) : juce::String());
+    case Kind::ModulationRemoved:
+        return "- mod " + srcType + " -> " + dstType +
+               (destParamName.isNotEmpty() ? (" " + destParamName) : juce::String());
+    }
+    return {};
+}
+
+std::vector<PatchChange> computeDiff(const juce::var& before, const juce::var& after) {
+    std::vector<PatchChange> changes;
+
+    SnapshotIndex beforeIdx = indexSnapshot(before);
+    SnapshotIndex afterIdx = indexSnapshot(after);
+    TypeMetadataCache meta;
+
+    // --- Nodes + params (matched by uuid; see PatchDiff.h for why not "id") ---
+    for (const auto& [uuid, entry] : beforeIdx.byUuid) {
+        if (isAttenuverterType(entry.type))
+            continue;
+
+        auto afterIt = afterIdx.byUuid.find(uuid);
+        if (afterIt == afterIdx.byUuid.end()) {
+            PatchChange c;
+            c.kind = PatchChange::Kind::NodeRemoved;
+            c.nodeType = entry.type;
+            c.nodeUuid = uuid;
+            changes.push_back(c);
+            continue;
+        }
+
+        // Matched node: diff "params" contents only. Deliberately NOT "position" (merge-mode
+        // patches routinely carry positions for unrelated existing nodes — that would read as
+        // "moved" noise) or "state"/"id"/"uuid" (never meaningfully diffable here).
+        const auto& afterEntry = afterIt->second;
+        std::vector<juce::String> keys;
+        if (entry.params != nullptr)
+            for (const auto& p : entry.params->getProperties())
+                keys.push_back(p.name.toString());
+        if (afterEntry.params != nullptr)
+            for (const auto& p : afterEntry.params->getProperties()) {
+                juce::String k = p.name.toString();
+                if (std::find(keys.begin(), keys.end(), k) == keys.end())
+                    keys.push_back(k);
+            }
+
+        for (const auto& key : keys) {
+            juce::var beforeVal = entry.params != nullptr ? entry.params->getProperty(key) : juce::var();
+            juce::var afterVal = afterEntry.params != nullptr ? afterEntry.params->getProperty(key) : juce::var();
+            if (varsEqual(beforeVal, afterVal))
+                continue;
+
+            PatchChange c;
+            c.kind = PatchChange::Kind::ParamChanged;
+            c.nodeType = entry.type;
+            c.nodeUuid = uuid;
+            c.paramId = key;
+            c.paramName = meta.paramDisplayName(entry.type, key);
+            c.beforeValue = beforeVal;
+            c.afterValue = afterVal;
+            c.beforeText = describeVar(beforeVal);
+            c.afterText = describeVar(afterVal);
+            changes.push_back(c);
+        }
+    }
+
+    for (const auto& [uuid, entry] : afterIdx.byUuid) {
+        if (isAttenuverterType(entry.type))
+            continue;
+        if (beforeIdx.byUuid.count(uuid) != 0)
+            continue; // matched above
+
+        PatchChange c;
+        c.kind = PatchChange::Kind::NodeAdded;
+        c.nodeType = entry.type;
+        c.nodeUuid = uuid;
+        changes.push_back(c);
+    }
+
+    // --- Connections ---
+    std::map<ConnKey, ConnRecord> beforeConnMap;
+    for (auto& c : collectConnections(before, beforeIdx))
+        beforeConnMap[c.key] = c;
+    std::map<ConnKey, ConnRecord> afterConnMap;
+    for (auto& c : collectConnections(after, afterIdx))
+        afterConnMap[c.key] = c;
+
+    for (const auto& [key, rec] : beforeConnMap) {
+        if (afterConnMap.count(key) != 0)
+            continue;
+        PatchChange c;
+        c.kind = PatchChange::Kind::ConnectionRemoved;
+        c.srcType = rec.srcType;
+        c.dstType = rec.dstType;
+        c.srcPort = std::get<1>(key);
+        c.dstPort = std::get<3>(key);
+        c.isMidi = std::get<4>(key);
+        changes.push_back(c);
+    }
+    for (const auto& [key, rec] : afterConnMap) {
+        if (beforeConnMap.count(key) != 0)
+            continue;
+        PatchChange c;
+        c.kind = PatchChange::Kind::ConnectionAdded;
+        c.srcType = rec.srcType;
+        c.dstType = rec.dstType;
+        c.srcPort = std::get<1>(key);
+        c.dstPort = std::get<3>(key);
+        c.isMidi = std::get<4>(key);
+        changes.push_back(c);
+    }
+
+    // --- Modulations ---
+    std::map<ModKey, ModRecord> beforeModMap;
+    for (auto& m : collectModulations(before, beforeIdx))
+        beforeModMap[m.key] = m;
+    std::map<ModKey, ModRecord> afterModMap;
+    for (auto& m : collectModulations(after, afterIdx))
+        afterModMap[m.key] = m;
+
+    auto makeModChange = [&](PatchChange::Kind kind, const ModKey& key, const ModRecord& rec) {
+        PatchChange c;
+        c.kind = kind;
+        c.srcType = rec.srcType;
+        c.dstType = rec.dstType;
+        c.srcPort = std::get<1>(key);
+        c.dstPort = std::get<3>(key);
+        c.amount = rec.amount;
+        c.bypass = rec.bypass;
+        c.destParamName = meta.modTargetName(rec.dstType, std::get<3>(key));
+        changes.push_back(c);
+    };
+
+    for (const auto& [key, rec] : beforeModMap) {
+        auto afterIt = afterModMap.find(key);
+        if (afterIt == afterModMap.end()) {
+            makeModChange(PatchChange::Kind::ModulationRemoved, key, rec);
+        } else if (std::abs(afterIt->second.amount - rec.amount) > kNumericTolerance ||
+                   afterIt->second.bypass != rec.bypass) {
+            // Same route, different amount/bypass. There is no ModulationChanged kind, so a
+            // changed route is reported as its old value removed and its new value added — both
+            // amounts stay visible rather than picking one.
+            makeModChange(PatchChange::Kind::ModulationRemoved, key, rec);
+            makeModChange(PatchChange::Kind::ModulationAdded, key, afterIt->second);
+        }
+    }
+    for (const auto& [key, rec] : afterModMap) {
+        if (beforeModMap.count(key) == 0)
+            makeModChange(PatchChange::Kind::ModulationAdded, key, rec);
+    }
+
+    return changes;
+}
+
+} // namespace synth

--- a/Source/AI/PatchDiff.cpp
+++ b/Source/AI/PatchDiff.cpp
@@ -404,4 +404,36 @@ std::vector<PatchChange> computeDiff(const juce::var& before, const juce::var& a
     return changes;
 }
 
+PatchSummary summarizePatch(const juce::var& after) {
+    PatchSummary summary;
+
+    auto* root = after.getDynamicObject();
+    if (root == nullptr)
+        return summary;
+
+    if (auto* nodes = root->getProperty("nodes").getArray()) {
+        for (const auto& nVar : *nodes) {
+            auto* nObj = nVar.getDynamicObject();
+            if (nObj == nullptr)
+                continue;
+            juce::String type = nObj->getProperty("type").toString();
+            if (isAttenuverterType(type))
+                continue;
+            summary.nodeTypes.push_back(type);
+        }
+    }
+
+    SnapshotIndex idx = indexSnapshot(after);
+    summary.connectionCount = (int)collectConnections(after, idx).size();
+    return summary;
+}
+
+std::vector<PatchChange> groupChangesByKind(const std::vector<PatchChange>& changes) {
+    std::vector<PatchChange> grouped = changes;
+    std::stable_sort(grouped.begin(), grouped.end(), [](const PatchChange& a, const PatchChange& b) {
+        return static_cast<int>(a.kind) < static_cast<int>(b.kind);
+    });
+    return grouped;
+}
+
 } // namespace synth

--- a/Source/AI/PatchDiff.h
+++ b/Source/AI/PatchDiff.h
@@ -73,11 +73,14 @@ struct PatchChange {
  *
  * Replace-mode patches (clearExisting=true) have NO stable node identity between snapshots —
  * applyJSONToGraph only preserves id/uuid on the trusted path, and a replace-mode apply is always
- * untrusted — so a replace-mode diff will show the entire prior graph removed and the entire new
- * patch added, even where a node is conceptually unchanged. This matches what actually happens to
- * the running graph (every processor really is destroyed and recreated) and in practice replace
- * mode is reserved for from-scratch patches (see AIChatComponent's merge-vs-replace inference),
- * so this is not the common single-edit case.
+ * untrusted — so computeDiff() over a replace-mode before/after pair reports the entire prior
+ * graph removed and the entire new patch added, even where a node is conceptually unchanged. That
+ * is technically correct (every processor really is destroyed and recreated) but not useful to a
+ * user reviewing a brand-new patch, which is why the chat UI never feeds a replace-mode PatchCard
+ * through computeDiff() for display — see summarizePatch() below, which it uses instead to
+ * describe what the new patch contains rather than what changed relative to the old graph.
+ * computeDiff() itself stays mode-agnostic and correct for any snapshot pair; this is a note about
+ * how the UI uses it, not a limitation of the function.
  *
  * Attenuverter nodes/connections (the implementation detail behind the "modulations" array) are
  * excluded from the node/connection diff and reported exclusively via ModulationAdded/Removed.
@@ -87,5 +90,37 @@ struct PatchChange {
  * malformed patch.
  */
 std::vector<PatchChange> computeDiff(const juce::var& before, const juce::var& after);
+
+/**
+ * @brief Summarizes a single AIStateMapper::graphToJSON() snapshot's contents — node types (in
+ * snapshot node order) plus a connection count — for rendering a plain "what's in this patch"
+ * description.
+ *
+ * This is what the chat UI's PatchCard shows for a replace-mode (clearExisting=true) patch,
+ * instead of computeDiff()'s output — see computeDiff()'s doc comment above for why a replace-mode
+ * diff is technically correct but not useful. summarizePatch() reads only `after`.
+ *
+ * Attenuverter nodes (a modulation implementation detail) are excluded from `nodeTypes`, and their
+ * connections from `connectionCount`, matching computeDiff()'s treatment.
+ */
+struct PatchSummary {
+    std::vector<juce::String> nodeTypes; // display type per node, in graphToJSON node order
+    int connectionCount = 0;             // non-attenuverter connections only
+};
+
+PatchSummary summarizePatch(const juce::var& after);
+
+/**
+ * @brief Stable-groups `changes` by PatchChange::Kind so the UI can render adds, removes,
+ * param changes, connection changes, and modulation changes as separate blocks instead of
+ * interleaved in computeDiff()'s natural (node-then-connection-then-modulation, but add/remove
+ * intermixed within each) order.
+ *
+ * Grouping follows Kind's declaration order (NodeAdded/NodeRemoved, then ParamChanged, then
+ * ConnectionAdded/ConnectionRemoved, then ModulationAdded/ModulationRemoved) via a stable sort, so
+ * changes that share a Kind keep computeDiff()'s original relative order. Pure function over
+ * `changes` — does not call computeDiff() or re-derive anything from a snapshot.
+ */
+std::vector<PatchChange> groupChangesByKind(const std::vector<PatchChange>& changes);
 
 } // namespace synth

--- a/Source/AI/PatchDiff.h
+++ b/Source/AI/PatchDiff.h
@@ -1,0 +1,91 @@
+#pragma once
+
+#include <juce_core/juce_core.h>
+#include <vector>
+
+namespace synth {
+
+/**
+ * @brief One human-readable change between two AIStateMapper::graphToJSON() snapshots.
+ *
+ * Every field that isn't relevant to `kind` is left at its default — callers should switch on
+ * `kind` before reading kind-specific fields. `describe()` renders the one-line string the UI
+ * shows; tests should prefer asserting on the structured fields below over string-matching it.
+ */
+struct PatchChange {
+    enum class Kind {
+        NodeAdded,
+        NodeRemoved,
+        ParamChanged,
+        ConnectionAdded,
+        ConnectionRemoved,
+        ModulationAdded,
+        ModulationRemoved,
+    };
+
+    Kind kind = Kind::NodeAdded;
+
+    // NodeAdded / NodeRemoved / ParamChanged: the node's display type ("Filter", "Reverb", ...)
+    // and its graphToJSON "uuid" (empty for connection/modulation entries).
+    juce::String nodeType;
+    juce::String nodeUuid;
+
+    // ParamChanged only.
+    juce::String paramId;    // the raw parameter ID (e.g. "cutoff")
+    juce::String paramName;  // display name, falls back to paramId when unknown
+    juce::var beforeValue;   // the value exactly as it appears in the "before" snapshot's params
+    juce::var afterValue;    // the value exactly as it appears in the "after" snapshot's params
+    juce::String beforeText; // beforeValue rendered for display, e.g. "400" or "sine" or "false"
+    juce::String afterText;
+
+    // ConnectionAdded / ConnectionRemoved / ModulationAdded / ModulationRemoved: endpoint types.
+    juce::String srcType;
+    juce::String dstType;
+    int srcPort = 0;
+    int dstPort = 0;
+    bool isMidi = false;
+
+    // ModulationAdded / ModulationRemoved only.
+    juce::String destParamName; // the modulation target's display name (e.g. "cutoff"), if known
+    double amount = 0.0;
+    bool bypass = false;
+
+    /** @brief One-line human-readable rendering, e.g. "Filter: cutoff 400 -> 800". */
+    juce::String describe() const;
+};
+
+/**
+ * @brief Diffs two AIStateMapper::graphToJSON() snapshots into a human-readable change list.
+ *
+ * This is the ONLY correct way to preview a proposed patch: diffing the raw patch JSON against
+ * the live graph would miss merge-mode's auto-wiring of new nodes, replace-mode's implicit
+ * deletion of everything the patch doesn't restate, and the untrusted-apply path's [0,1]
+ * rescale heuristic. `before`/`after` must therefore both be graphToJSON() output — `after` from
+ * a scratch graph the candidate patch was actually applied to (trusted-replayed from `before`'s
+ * source graph first, for merge mode) — never the patch JSON itself. See
+ * AIIntegrationService::computePatchPreview(), the intended way to obtain both.
+ *
+ * Node identity is keyed on graphToJSON's "uuid" field, not the integer "id": merge-mode apply
+ * preserves uuid (and id) for nodes it updates in place, so before/after nodes with the same uuid
+ * are the same node. A brand-new node has no uuid in `before`, so it never spuriously matches.
+ * Connection/modulation endpoints are resolved to uuid via each snapshot's OWN id->uuid mapping
+ * before comparing, since raw integer ids are only meaningful within a single snapshot.
+ *
+ * Replace-mode patches (clearExisting=true) have NO stable node identity between snapshots —
+ * applyJSONToGraph only preserves id/uuid on the trusted path, and a replace-mode apply is always
+ * untrusted — so a replace-mode diff will show the entire prior graph removed and the entire new
+ * patch added, even where a node is conceptually unchanged. This matches what actually happens to
+ * the running graph (every processor really is destroyed and recreated) and in practice replace
+ * mode is reserved for from-scratch patches (see AIChatComponent's merge-vs-replace inference),
+ * so this is not the common single-edit case.
+ *
+ * Attenuverter nodes/connections (the implementation detail behind the "modulations" array) are
+ * excluded from the node/connection diff and reported exclusively via ModulationAdded/Removed.
+ * An attenuverter wired on only one side (source XOR destination) produces no "modulations" entry
+ * in graphToJSON at all, so it is silently omitted from the diff rather than shown as raw
+ * add/remove noise — a deliberate tradeoff, since a half-wired attenuverter only arises from a
+ * malformed patch.
+ */
+std::vector<PatchChange> computeDiff(const juce::var& before, const juce::var& after);
+
+} // namespace synth

--- a/Source/UI/AIChatComponent.cpp
+++ b/Source/UI/AIChatComponent.cpp
@@ -1,4 +1,5 @@
 #include "AIChatComponent.h"
+#include "../AI/PatchDiff.h"
 #include "../Branding.h"
 
 namespace synth {
@@ -27,7 +28,13 @@ juce::StringArray extractJSONBlocks(const juce::String& text) {
 //==============================================================================
 class AIChatComponent::PatchCard : public juce::Component {
 public:
-    PatchCard(const juce::String& json, std::function<void()> applyCallback, bool isMerge)
+    // `changes`/`diffAvailable` come from diffing before/after AIStateMapper::graphToJSON()
+    // snapshots (AIIntegrationService::computePatchPreview() + synth::computeDiff(), computed by
+    // the caller in updateChatDisplay()) — see docs/AI_Engine.md "Patch preview". This IS the
+    // preview: it's the card's default view, rendered before Apply/Merge is ever clicked. The raw
+    // JSON stays available behind the "View JSON" toggle for anyone who wants it.
+    PatchCard(const juce::String& json, std::function<void()> applyCallback, bool isMerge,
+              const std::vector<PatchChange>& changes, bool diffAvailable)
         : patchJson(json)
         , onApply(applyCallback) {
 
@@ -38,11 +45,11 @@ public:
                               isMerge ? juce::Colours::lightyellow : juce::Colours::lightgreen);
 
         addAndMakeVisible(expandButton);
-        expandButton.setButtonText("Expand JSON");
+        expandButton.setButtonText("View JSON");
         expandButton.setToggleable(true);
         expandButton.onClick = [this]() {
             isExpanded = !isExpanded;
-            expandButton.setButtonText(isExpanded ? "Collapse" : "Expand JSON");
+            expandButton.setButtonText(isExpanded ? "Hide JSON" : "View JSON");
             if (auto* parent = getParentComponent())
                 parent->resized();
         };
@@ -52,6 +59,22 @@ public:
         applyButton.setColour(juce::TextButton::buttonColourId,
                               isMerge ? juce::Colour(0xFF8B6914) : juce::Colours::darkgreen);
         applyButton.onClick = onApply;
+
+        juce::StringArray lines;
+        if (!diffAvailable)
+            lines.add("Preview unavailable — this patch may be rejected when applied.");
+        else if (changes.empty())
+            lines.add("No changes.");
+        else
+            for (const auto& c : changes)
+                lines.add(c.describe());
+        diffLineCount = lines.size();
+
+        addAndMakeVisible(diffDisplay);
+        diffDisplay.setMultiLine(true);
+        diffDisplay.setReadOnly(true);
+        diffDisplay.setText(lines.joinIntoString("\n"));
+        diffDisplay.setColour(juce::TextEditor::backgroundColourId, juce::Colours::black.withAlpha(0.3f));
 
         addAndMakeVisible(jsonDisplay);
         jsonDisplay.setMultiLine(true);
@@ -70,25 +93,45 @@ public:
         applyButton.setBounds(buttons.removeFromRight(80).reduced(2));
         expandButton.setBounds(buttons.removeFromRight(90).reduced(2));
 
+        b.removeFromTop(5);
         if (isExpanded) {
+            diffDisplay.setBounds(b.removeFromTop(diffAreaHeight()));
             b.removeFromTop(5);
             jsonDisplay.setVisible(true);
             jsonDisplay.setBounds(b);
         } else {
+            diffDisplay.setBounds(b);
             jsonDisplay.setVisible(false);
         }
     }
 
-    int getRequiredHeight() const { return isExpanded ? 200 : 35; }
+    int getRequiredHeight() const {
+        int height = 35 + diffAreaHeight();
+        if (isExpanded)
+            height += 5 + kRawJsonHeight;
+        return height;
+    }
 
 private:
+    static constexpr int kLineHeight = 16;
+    static constexpr int kMinDiffHeight = 24;
+    // Caps how tall a very long diff can grow the card; the "View JSON" toggle (which also shows
+    // the diff area above the raw JSON, both individually scrollable TextEditors) is the escape
+    // hatch rather than letting the message list grow unbounded.
+    static constexpr int kMaxDiffHeight = 220;
+    static constexpr int kRawJsonHeight = 160;
+
+    int diffAreaHeight() const { return juce::jlimit(kMinDiffHeight, kMaxDiffHeight, diffLineCount * kLineHeight + 8); }
+
     juce::String patchJson;
     std::function<void()> onApply;
     bool isExpanded = false;
+    int diffLineCount = 1;
 
     juce::Label headerLabel;
     juce::TextButton expandButton;
     juce::TextButton applyButton;
+    juce::TextEditor diffDisplay;
     juce::TextEditor jsonDisplay;
 };
 
@@ -96,7 +139,8 @@ private:
 class AIChatComponent::MessageBubble : public juce::Component {
 public:
     MessageBubble(const MessageData& data, std::function<void(const juce::String&)> applyPatch, bool isMerge,
-                  std::function<void(const juce::URL&)> urlOpener) {
+                  std::function<void(const juce::URL&)> urlOpener, const std::vector<PatchChange>& patchDiff,
+                  bool patchDiffAvailable) {
         role = data.role;
         text = data.text;
 
@@ -107,7 +151,8 @@ public:
 
         if (data.jsonPatch.isNotEmpty()) {
             patchCard = std::make_unique<PatchCard>(
-                data.jsonPatch, [applyPatch, json = data.jsonPatch]() { applyPatch(json); }, isMerge);
+                data.jsonPatch, [applyPatch, json = data.jsonPatch]() { applyPatch(json); }, isMerge, patchDiff,
+                patchDiffAvailable);
             addAndMakeVisible(*patchCard);
         }
 
@@ -313,6 +358,7 @@ AIChatComponent::AIChatComponent(AIIntegrationService& service, juce::Applicatio
         // showUpgradeAction deliberately left at its default false: a replayed history turn never
         // resurrects the Upgrade button, same as Cancel-button/spinner state being session-only.
         messages.push_back({msg.role, cleanText.trim(), json});
+        attachPatchPreview(messages.back());
     }
 
     updateChatDisplay();
@@ -601,6 +647,7 @@ void AIChatComponent::sendButtonClicked() {
                     }
 
                     self->messages.push_back({"assistant", cleanText.trim(), json});
+                    self->attachPatchPreview(self->messages.back());
                 } else if (aiResponse.error.kind == AIProvider::AIErrorKind::Quota) {
                     // The server's message is already a complete, user-facing sentence — no
                     // "Error: " prefix, same precedent as TrialExhausted/ServiceCapacityExceeded.
@@ -628,47 +675,64 @@ void AIChatComponent::sendButtonClicked() {
         activeRequestId = requestId;
 }
 
+void AIChatComponent::attachPatchPreview(MessageData& data) {
+    if (data.jsonPatch.isEmpty())
+        return;
+
+    // Determine merge mode for this message's patch (used for button text + apply behavior, and
+    // to pick the merge/replace branch computePatchPreview() diffs below).
+    bool isMerge = false;
+    juce::var parsed = juce::JSON::parse(data.jsonPatch);
+    if (auto* obj = parsed.getDynamicObject()) {
+        juce::String mode = obj->getProperty("mode").toString();
+        if (mode == "merge") {
+            isMerge = true;
+        } else if (mode.isEmpty()) {
+            // AI didn't specify mode — infer from user intent + graph state. `data` is already
+            // the last element of `messages` (see this method's doc comment), so scan backward
+            // from the end for the preceding user turn.
+            juce::String userText;
+            for (auto it = messages.rbegin(); it != messages.rend(); ++it) {
+                if (it->role == "user") {
+                    userText = it->text;
+                    break;
+                }
+            }
+            juce::var ctx = juce::JSON::parse(aiService.getPatchContext());
+            bool graphHasNodes = false;
+            if (auto* ctxObj = ctx.getDynamicObject()) {
+                if (auto* nodes = ctxObj->getProperty("nodes").getArray())
+                    graphHasNodes = !nodes->isEmpty();
+            }
+            if (graphHasNodes && userText.isNotEmpty()) {
+                isMerge = userText.containsIgnoreCase("add") || userText.containsIgnoreCase("change") ||
+                          userText.containsIgnoreCase("modify") || userText.containsIgnoreCase("tweak") ||
+                          userText.containsIgnoreCase("adjust") || userText.containsIgnoreCase("remove") ||
+                          userText.containsIgnoreCase("delete") || userText.containsIgnoreCase("make it") ||
+                          userText.containsIgnoreCase("more") || userText.containsIgnoreCase("less") ||
+                          userText.containsIgnoreCase("brighter") || userText.containsIgnoreCase("warmer") ||
+                          userText.containsIgnoreCase("darker");
+            }
+        }
+    }
+    data.patchIsMerge = isMerge;
+
+    // The human-readable diff preview — the PatchCard's default view. Diffed from before/after
+    // AIStateMapper::graphToJSON() snapshots (never the raw patch JSON): see PatchDiff.h for why
+    // that's the only correct way to preview merge-mode auto-wiring, replace-mode deletions, and
+    // value rescaling.
+    juce::var diffBefore, diffAfter;
+    data.patchDiffAvailable = aiService.computePatchPreview(data.jsonPatch, isMerge, diffBefore, diffAfter);
+    if (data.patchDiffAvailable)
+        data.patchDiff = computeDiff(diffBefore, diffAfter);
+}
+
 void AIChatComponent::updateChatDisplay() {
     messageList.deleteAllChildren();
 
     for (size_t i = 0; i < messages.size(); ++i) {
         const auto& data = messages[i];
-
-        // Determine merge mode for this message's patch (used for button text + apply behavior)
-        bool isMerge = false;
-        if (data.jsonPatch.isNotEmpty()) {
-            juce::var parsed = juce::JSON::parse(data.jsonPatch);
-            if (auto* obj = parsed.getDynamicObject()) {
-                juce::String mode = obj->getProperty("mode").toString();
-                if (mode == "merge") {
-                    isMerge = true;
-                } else if (mode.isEmpty()) {
-                    // AI didn't specify mode — infer from user intent + graph state
-                    juce::String userText;
-                    for (int j = (int)i - 1; j >= 0; --j) {
-                        if (messages[(size_t)j].role == "user") {
-                            userText = messages[(size_t)j].text;
-                            break;
-                        }
-                    }
-                    juce::var ctx = juce::JSON::parse(aiService.getPatchContext());
-                    bool graphHasNodes = false;
-                    if (auto* ctxObj = ctx.getDynamicObject()) {
-                        if (auto* nodes = ctxObj->getProperty("nodes").getArray())
-                            graphHasNodes = !nodes->isEmpty();
-                    }
-                    if (graphHasNodes && userText.isNotEmpty()) {
-                        isMerge = userText.containsIgnoreCase("add") || userText.containsIgnoreCase("change") ||
-                                  userText.containsIgnoreCase("modify") || userText.containsIgnoreCase("tweak") ||
-                                  userText.containsIgnoreCase("adjust") || userText.containsIgnoreCase("remove") ||
-                                  userText.containsIgnoreCase("delete") || userText.containsIgnoreCase("make it") ||
-                                  userText.containsIgnoreCase("more") || userText.containsIgnoreCase("less") ||
-                                  userText.containsIgnoreCase("brighter") || userText.containsIgnoreCase("warmer") ||
-                                  userText.containsIgnoreCase("darker");
-                    }
-                }
-            }
-        }
+        bool isMerge = data.patchIsMerge;
 
         auto* bubble = new MessageBubble(
             data,
@@ -726,7 +790,7 @@ void AIChatComponent::updateChatDisplay() {
                         refreshLater();
                     });
             },
-            isMerge, urlOpener);
+            isMerge, urlOpener, data.patchDiff, data.patchDiffAvailable);
         messageList.addAndMakeVisible(bubble);
     }
 

--- a/Source/UI/AIChatComponent.cpp
+++ b/Source/UI/AIChatComponent.cpp
@@ -25,16 +25,58 @@ juce::StringArray extractJSONBlocks(const juce::String& text) {
     return blocks;
 }
 
+namespace {
+
+// Colour for a merge-mode diff line, grouped by PatchChange::Kind (see groupChangesByKind() in
+// PatchDiff.h). "+"-prefixed adds are green, "-"-prefixed removals are red/orange; param changes
+// and modulation add/remove (which are often a matched pair representing one conceptual "change",
+// not an independent add and remove) get a neutral amber rather than fighting for green/red.
+juce::Colour colourForKind(PatchChange::Kind kind) {
+    using Kind = PatchChange::Kind;
+    switch (kind) {
+    case Kind::NodeAdded:
+    case Kind::ConnectionAdded:
+        return juce::Colours::lightgreen;
+    case Kind::NodeRemoved:
+    case Kind::ConnectionRemoved:
+        return juce::Colour(0xFFFF8A65); // orange-red
+    case Kind::ParamChanged:
+    case Kind::ModulationAdded:
+    case Kind::ModulationRemoved:
+        return juce::Colour(0xFFFFC107); // amber
+    }
+    return juce::Colours::white;
+}
+
+// Round-trips `raw` through JUCE's JSON formatter for indentation, so the "View JSON" panel isn't
+// one unbroken line in a ~280px-wide chat column. Falls back to the raw string on parse failure
+// (shouldn't happen — this is a patch that already round-tripped through extractJSONBlocks — but
+// must not blank the view if it ever does).
+juce::String prettyPrintJson(const juce::String& raw) {
+    juce::var parsed = juce::JSON::parse(raw);
+    if (parsed.isVoid())
+        return raw;
+    return juce::JSON::toString(parsed, /*allOnOneLine=*/false);
+}
+
+} // namespace
+
 //==============================================================================
 class AIChatComponent::PatchCard : public juce::Component {
 public:
-    // `changes`/`diffAvailable` come from diffing before/after AIStateMapper::graphToJSON()
-    // snapshots (AIIntegrationService::computePatchPreview() + synth::computeDiff(), computed by
-    // the caller in updateChatDisplay()) — see docs/AI_Engine.md "Patch preview". This IS the
-    // preview: it's the card's default view, rendered before Apply/Merge is ever clicked. The raw
-    // JSON stays available behind the "View JSON" toggle for anyone who wants it.
+    // `changes`/`diffAvailable`/`summary` come from AIIntegrationService::computePatchPreview()'s
+    // before/after AIStateMapper::graphToJSON() snapshots, computed by the caller in
+    // attachPatchPreview() — see docs/AI_Engine.md "Patch Diff Preview". This IS the preview: it's
+    // the card's default view, rendered before Apply/Merge is ever clicked. The raw JSON stays
+    // available behind the "View JSON" toggle for anyone who wants it.
+    //
+    // `changes` (synth::computeDiff() output) is used for merge-mode cards, which have stable node
+    // identity to diff against. `summary` (synth::summarizePatch() of just the "after" snapshot) is
+    // used for replace-mode cards instead: replace mode has no stable node identity between
+    // snapshots, so a diff would show the entire prior graph removed and the entire new patch
+    // added — technically correct, useless to read. See PatchDiff.h.
     PatchCard(const juce::String& json, std::function<void()> applyCallback, bool isMerge,
-              const std::vector<PatchChange>& changes, bool diffAvailable)
+              const std::vector<PatchChange>& changes, bool diffAvailable, const PatchSummary& summary)
         : patchJson(json)
         , onApply(applyCallback) {
 
@@ -60,26 +102,52 @@ public:
                               isMerge ? juce::Colour(0xFF8B6914) : juce::Colours::darkgreen);
         applyButton.onClick = onApply;
 
-        juce::StringArray lines;
-        if (!diffAvailable)
-            lines.add("Preview unavailable — this patch may be rejected when applied.");
-        else if (changes.empty())
-            lines.add("No changes.");
-        else
-            for (const auto& c : changes)
-                lines.add(c.describe());
-        diffLineCount = lines.size();
-
         addAndMakeVisible(diffDisplay);
         diffDisplay.setMultiLine(true);
         diffDisplay.setReadOnly(true);
-        diffDisplay.setText(lines.joinIntoString("\n"));
         diffDisplay.setColour(juce::TextEditor::backgroundColourId, juce::Colours::black.withAlpha(0.3f));
+
+        if (!diffAvailable) {
+            diffLineCount = 1;
+            diffDisplay.setText("Preview unavailable - this patch may be rejected when applied.");
+        } else if (isMerge) {
+            // Grouped by Kind (adds, then removes, then param changes, then connection
+            // adds/removes, then modulation adds/removes) so the list doesn't interleave — see
+            // groupChangesByKind()'s doc comment. Rendered line-by-line via insertTextAtCaret with
+            // the TextEditor's textColourId set per segment (setText() can't colour per-line; this
+            // is the same pattern flushDebugLog() uses for insertTextAtCaret, minus the colouring).
+            auto grouped = groupChangesByKind(changes);
+            if (grouped.empty()) {
+                diffLineCount = 1;
+                diffDisplay.setText("No changes.");
+            } else {
+                diffLineCount = (int)grouped.size();
+                for (size_t i = 0; i < grouped.size(); ++i) {
+                    diffDisplay.setColour(juce::TextEditor::textColourId, colourForKind(grouped[i].kind));
+                    diffDisplay.insertTextAtCaret(grouped[i].describe());
+                    if (i + 1 < grouped.size())
+                        diffDisplay.insertTextAtCaret("\n");
+                }
+            }
+        } else {
+            // Replace mode: a plain positive summary of what the new patch contains, not a diff
+            // against the old graph (see class doc comment above).
+            juce::StringArray lines;
+            lines.add("New patch: " + juce::String((int)summary.nodeTypes.size()) +
+                      (summary.nodeTypes.size() == 1 ? " module" : " modules"));
+            for (const auto& t : summary.nodeTypes)
+                lines.add(t);
+            if (summary.connectionCount > 0)
+                lines.add(juce::String(summary.connectionCount) +
+                          (summary.connectionCount == 1 ? " connection" : " connections"));
+            diffLineCount = lines.size();
+            diffDisplay.setText(lines.joinIntoString("\n"));
+        }
 
         addAndMakeVisible(jsonDisplay);
         jsonDisplay.setMultiLine(true);
         jsonDisplay.setReadOnly(true);
-        jsonDisplay.setText(patchJson);
+        jsonDisplay.setText(prettyPrintJson(patchJson));
         jsonDisplay.setColour(juce::TextEditor::backgroundColourId, juce::Colours::black.withAlpha(0.3f));
         jsonDisplay.setVisible(false);
     }
@@ -119,7 +187,9 @@ private:
     // the diff area above the raw JSON, both individually scrollable TextEditors) is the escape
     // hatch rather than letting the message list grow unbounded.
     static constexpr int kMaxDiffHeight = 220;
-    static constexpr int kRawJsonHeight = 160;
+    // Grew from 160: pretty-printed (indented) JSON runs noticeably taller than the single
+    // unbroken line this used to hold.
+    static constexpr int kRawJsonHeight = 240;
 
     int diffAreaHeight() const { return juce::jlimit(kMinDiffHeight, kMaxDiffHeight, diffLineCount * kLineHeight + 8); }
 
@@ -140,7 +210,7 @@ class AIChatComponent::MessageBubble : public juce::Component {
 public:
     MessageBubble(const MessageData& data, std::function<void(const juce::String&)> applyPatch, bool isMerge,
                   std::function<void(const juce::URL&)> urlOpener, const std::vector<PatchChange>& patchDiff,
-                  bool patchDiffAvailable) {
+                  bool patchDiffAvailable, const PatchSummary& patchSummary) {
         role = data.role;
         text = data.text;
 
@@ -152,7 +222,7 @@ public:
         if (data.jsonPatch.isNotEmpty()) {
             patchCard = std::make_unique<PatchCard>(
                 data.jsonPatch, [applyPatch, json = data.jsonPatch]() { applyPatch(json); }, isMerge, patchDiff,
-                patchDiffAvailable);
+                patchDiffAvailable, patchSummary);
             addAndMakeVisible(*patchCard);
         }
 
@@ -717,14 +787,20 @@ void AIChatComponent::attachPatchPreview(MessageData& data) {
     }
     data.patchIsMerge = isMerge;
 
-    // The human-readable diff preview — the PatchCard's default view. Diffed from before/after
+    // The human-readable preview — the PatchCard's default view. Computed from before/after
     // AIStateMapper::graphToJSON() snapshots (never the raw patch JSON): see PatchDiff.h for why
     // that's the only correct way to preview merge-mode auto-wiring, replace-mode deletions, and
-    // value rescaling.
+    // value rescaling. Merge mode has stable node identity to diff against, so it gets
+    // computeDiff(); replace mode does not (PatchDiff.h), so it gets summarizePatch() of the new
+    // patch's contents instead — never a diff against the old graph.
     juce::var diffBefore, diffAfter;
     data.patchDiffAvailable = aiService.computePatchPreview(data.jsonPatch, isMerge, diffBefore, diffAfter);
-    if (data.patchDiffAvailable)
-        data.patchDiff = computeDiff(diffBefore, diffAfter);
+    if (data.patchDiffAvailable) {
+        if (isMerge)
+            data.patchDiff = computeDiff(diffBefore, diffAfter);
+        else
+            data.patchSummary = summarizePatch(diffAfter);
+    }
 }
 
 void AIChatComponent::updateChatDisplay() {
@@ -790,7 +866,7 @@ void AIChatComponent::updateChatDisplay() {
                         refreshLater();
                     });
             },
-            isMerge, urlOpener, data.patchDiff, data.patchDiffAvailable);
+            isMerge, urlOpener, data.patchDiff, data.patchDiffAvailable, data.patchSummary);
         messageList.addAndMakeVisible(bubble);
     }
 

--- a/Source/UI/AIChatComponent.h
+++ b/Source/UI/AIChatComponent.h
@@ -2,6 +2,7 @@
 
 #include "../AI/AIIntegrationService.h"
 #include "../AI/AccountService.h"
+#include "../AI/PatchDiff.h"
 #include "AccountRow.h"
 #include "PlanBadge.h"
 #include "Theme/AppLookAndFeel.h"
@@ -204,8 +205,29 @@ private:
         // constructor, so a New Chat or app restart drops it along with the rest of that turn's
         // transient UI state (mirrors how Cancel-button/spinner state is session-only).
         bool showUpgradeAction = false;
+
+        // Patch diff preview, computed ONCE (attachPatchPreview()) at the point this message is
+        // created, not on every updateChatDisplay() re-render — see that method's doc comment.
+        // patchIsMerge also pins which mode Apply/Merge will actually use, so it can't drift if
+        // the live graph changes while this message is still on screen.
+        bool patchIsMerge = false;
+        bool patchDiffAvailable = false;
+        std::vector<PatchChange> patchDiff;
     };
     std::vector<MessageData> messages;
+
+    // Computes and caches data.patchIsMerge/patchDiff/patchDiffAvailable ONCE, at the point a
+    // message carrying a patch is created (every messages.push_back() site that can set
+    // jsonPatch) — NOT in updateChatDisplay(), which reruns on every redraw (message arrival,
+    // apply result, retry announcement) and would otherwise rebuild a scratch graph per
+    // patch-bearing message on every single one of those redraws. See docs/AI_Engine.md
+    // "Patch Diff Preview". Also more correct, not just faster: the diff is a snapshot of the
+    // graph at proposal time and must not silently change if the live graph is edited later
+    // (e.g. an earlier patch in the same conversation gets applied) while this message is still
+    // on screen. No-op when data.jsonPatch is empty. Reads `messages` (must already contain every
+    // turn up to and including `data`, for the merge-vs-replace user-intent heuristic) and
+    // `aiService`, so it must be called after data is appended to `messages`.
+    void attachPatchPreview(MessageData& data);
 
 #ifndef NDEBUG
     juce::TextEditor debugConsole;

--- a/Source/UI/AIChatComponent.h
+++ b/Source/UI/AIChatComponent.h
@@ -210,9 +210,16 @@ private:
         // created, not on every updateChatDisplay() re-render — see that method's doc comment.
         // patchIsMerge also pins which mode Apply/Merge will actually use, so it can't drift if
         // the live graph changes while this message is still on screen.
+        //
+        // Only one of patchDiff/patchSummary is ever populated: merge-mode patches get patchDiff
+        // (synth::computeDiff() against the live graph, since a merge has stable node identity to
+        // diff against); replace-mode patches get patchSummary (synth::summarizePatch() of just
+        // the new patch's contents, since replace mode has no stable node identity to diff against
+        // — see PatchDiff.h). Both are empty when patchDiffAvailable is false.
         bool patchIsMerge = false;
         bool patchDiffAvailable = false;
         std::vector<PatchChange> patchDiff;
+        PatchSummary patchSummary;
     };
     std::vector<MessageData> messages;
 

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -36,6 +36,7 @@ add_executable(Tests
     AIPatchValidationTests.cpp
     AIPatchRetryTests.cpp
     PatchEvalTests.cpp
+    PatchDiffTests.cpp
     AIProviderRegistryTests.cpp
     OllamaProviderTests.cpp
     RemoteProviderTests.cpp

--- a/Tests/PatchDiffTests.cpp
+++ b/Tests/PatchDiffTests.cpp
@@ -1,0 +1,341 @@
+// Unit coverage for Source/AI/PatchDiff.h: the human-readable diff the chat UI's PatchCard shows
+// as its default (pre-Apply) view. Two things matter structurally, both exercised below:
+//
+//  1. Node identity is the graphToJSON "uuid" field, not the integer "id" (merge-mode's scratch
+//     rebuild only preserves "id" for nodes the trusted replay recreates — see
+//     AIIntegrationService::replayLiveGraphTrusted()).
+//  2. computeDiff() must be fed two graphToJSON() SNAPSHOTS, never the raw patch JSON — that is
+//     the only way to see merge mode's auto-wiring of new nodes, the untrusted-apply [0,1] rescale
+//     heuristic, and (via AIStateMapper::graphToJSON already collapsing attenuverter chains into
+//     "modulations") a clean "+ mod LFO -> Filter Cutoff" instead of raw Attenuverter node/wire
+//     noise. MergeModeAutoWireAppearsInDiff and UntrustedRescale... below are the regression tests
+//     proving snapshot-diffing catches what raw-patch-diffing would miss.
+
+#include "AI/AIIntegrationService.h"
+#include "AI/AIStateMapper.h"
+#include "AI/PatchDiff.h"
+#include <algorithm>
+#include <gtest/gtest.h>
+#include <juce_audio_processors/juce_audio_processors.h>
+
+namespace synth {
+namespace {
+
+using Kind = PatchChange::Kind;
+
+const PatchChange* firstOfKind(const std::vector<PatchChange>& changes, Kind kind) {
+    auto it = std::find_if(changes.begin(), changes.end(), [&](const PatchChange& c) { return c.kind == kind; });
+    return it == changes.end() ? nullptr : &*it;
+}
+
+int countOfKind(const std::vector<PatchChange>& changes, Kind kind) {
+    return (int)std::count_if(changes.begin(), changes.end(), [&](const PatchChange& c) { return c.kind == kind; });
+}
+
+void applyStep(juce::AudioProcessorGraph& graph, const char* json, bool clearExisting) {
+    juce::var patch = juce::JSON::parse(juce::String(json));
+    ASSERT_TRUE(AIStateMapper::applyJSONToGraph(patch, graph, clearExisting, /*trusted=*/true));
+}
+
+// graphToJSON() of a graph built (trusted) from `json` — real ids/uuids, not hand-typed ones.
+juce::var snapshotOf(const char* json) {
+    juce::AudioProcessorGraph graph;
+    applyStep(graph, json, /*clearExisting=*/true);
+    return AIStateMapper::graphToJSON(graph);
+}
+
+// Builds "before" from `beforeJson`, then merges `afterDeltaJson` onto the SAME graph (trusted)
+// so nodes the delta doesn't touch keep their id/uuid — the shape a real merge-mode rebuild
+// produces, and what makes uuid-keyed identity meaningful across the two returned snapshots.
+struct BeforeAfter {
+    juce::var before, after;
+};
+
+BeforeAfter mergeSnapshot(const char* beforeJson, const char* afterDeltaJson) {
+    juce::AudioProcessorGraph graph;
+    applyStep(graph, beforeJson, /*clearExisting=*/true);
+    juce::var before = AIStateMapper::graphToJSON(graph);
+    applyStep(graph, afterDeltaJson, /*clearExisting=*/false);
+    juce::var after = AIStateMapper::graphToJSON(graph);
+    return {before, after};
+}
+
+//==============================================================================
+// Pure computeDiff() cases — before/after come from the real AIStateMapper pipeline (or, where
+// there is no patch operation to drive a case through it, hand-built graphToJSON-shaped JSON).
+
+TEST(PatchDiffTest, NodeAdded) {
+    auto ba = mergeSnapshot(R"({"nodes":[{"id":1,"type":"Oscillator"}],"connections":[]})",
+                            R"({"nodes":[{"id":2,"type":"Reverb"}],"connections":[]})");
+
+    auto changes = computeDiff(ba.before, ba.after);
+    auto* c = firstOfKind(changes, Kind::NodeAdded);
+    ASSERT_NE(c, nullptr);
+    EXPECT_EQ(c->nodeType, "Reverb");
+    EXPECT_EQ(countOfKind(changes, Kind::NodeAdded), 1);
+    EXPECT_EQ(countOfKind(changes, Kind::NodeRemoved), 0);
+}
+
+TEST(PatchDiffTest, NodeRemoved) {
+    auto ba = mergeSnapshot(R"({"nodes":[{"id":1,"type":"Oscillator"},{"id":2,"type":"Reverb"}],"connections":[]})",
+                            R"({"nodes":[],"connections":[],"remove":[2]})");
+
+    auto changes = computeDiff(ba.before, ba.after);
+    auto* c = firstOfKind(changes, Kind::NodeRemoved);
+    ASSERT_NE(c, nullptr);
+    EXPECT_EQ(c->nodeType, "Reverb");
+    EXPECT_EQ(countOfKind(changes, Kind::NodeAdded), 0);
+}
+
+TEST(PatchDiffTest, ParamChanged) {
+    auto ba = mergeSnapshot(R"({"nodes":[{"id":1,"type":"Filter","params":{"cutoff":300.0}}],"connections":[]})",
+                            R"({"nodes":[{"id":1,"type":"Filter","params":{"cutoff":800.0}}],"connections":[]})");
+
+    auto changes = computeDiff(ba.before, ba.after);
+    auto* c = firstOfKind(changes, Kind::ParamChanged);
+    ASSERT_NE(c, nullptr);
+    EXPECT_EQ(c->nodeType, "Filter");
+    EXPECT_EQ(c->paramId, "cutoff");
+    EXPECT_EQ(c->paramName, "Cutoff"); // display name, not the raw paramID
+    EXPECT_NEAR((double)c->beforeValue, 300.0, 1.0e-3);
+    EXPECT_NEAR((double)c->afterValue, 800.0, 1.0e-3);
+    EXPECT_EQ(c->beforeText, "300");
+    EXPECT_EQ(c->afterText, "800");
+    EXPECT_EQ(countOfKind(changes, Kind::NodeAdded), 0);
+    EXPECT_EQ(countOfKind(changes, Kind::NodeRemoved), 0);
+}
+
+TEST(PatchDiffTest, ConnectionAdded) {
+    auto ba = mergeSnapshot(R"({"nodes":[{"id":1,"type":"Oscillator"},{"id":2,"type":"Filter"}],"connections":[]})",
+                            R"({"nodes":[],"connections":[{"src":1,"srcPort":0,"dst":2,"dstPort":0}]})");
+
+    auto changes = computeDiff(ba.before, ba.after);
+    auto* c = firstOfKind(changes, Kind::ConnectionAdded);
+    ASSERT_NE(c, nullptr);
+    EXPECT_EQ(c->srcType, "Oscillator");
+    EXPECT_EQ(c->dstType, "Filter");
+    EXPECT_EQ(countOfKind(changes, Kind::ConnectionRemoved), 0);
+}
+
+TEST(PatchDiffTest, ConnectionRemoved) {
+    // There is no "remove a connection without removing a node" patch operation, so this one
+    // exercises computeDiff() directly against hand-built graphToJSON-shaped snapshots rather
+    // than through applyJSONToGraph — it is a pure function over the JSON, per PatchDiff.h.
+    const char* beforeJson = R"({
+        "nodes": [
+            {"id": 1, "uuid": "osc-1", "type": "Oscillator", "params": {}},
+            {"id": 2, "uuid": "filt-1", "type": "Filter", "params": {}}
+        ],
+        "connections": [{"src": 1, "srcPort": 0, "dst": 2, "dstPort": 0, "isMidi": false}],
+        "modulations": []
+    })";
+    const char* afterJson = R"({
+        "nodes": [
+            {"id": 1, "uuid": "osc-1", "type": "Oscillator", "params": {}},
+            {"id": 2, "uuid": "filt-1", "type": "Filter", "params": {}}
+        ],
+        "connections": [],
+        "modulations": []
+    })";
+
+    auto changes = computeDiff(juce::JSON::parse(juce::String(beforeJson)), juce::JSON::parse(juce::String(afterJson)));
+    auto* c = firstOfKind(changes, Kind::ConnectionRemoved);
+    ASSERT_NE(c, nullptr);
+    EXPECT_EQ(c->srcType, "Oscillator");
+    EXPECT_EQ(c->dstType, "Filter");
+    EXPECT_EQ(countOfKind(changes, Kind::NodeAdded), 0);
+    EXPECT_EQ(countOfKind(changes, Kind::NodeRemoved), 0);
+}
+
+TEST(PatchDiffTest, ModulationAddedAndSuppressesAttenuverterNoise) {
+    juce::AudioProcessorGraph graph;
+    applyStep(graph, R"({"nodes":[{"id":1,"type":"LFO"},{"id":2,"type":"Filter"}],"connections":[]})",
+              /*clearExisting=*/true);
+    juce::var before = AIStateMapper::graphToJSON(graph);
+
+    // Filter's mono "Cutoff" modulation target is channel 1 (FilterModule::getModulationTargets).
+    applyStep(graph,
+              R"({"nodes":[],"connections":[],
+                 "modulations":[{"source":1,"sourcePort":0,"dest":2,"destPort":1,"amount":0.5}]})",
+              /*clearExisting=*/false);
+    juce::var after = AIStateMapper::graphToJSON(graph);
+
+    auto changes = computeDiff(before, after);
+
+    // The modulation is implemented as a real Attenuverter node + 2 connections — neither must
+    // leak into the diff as raw node/connection noise; only the collapsed ModulationAdded should.
+    EXPECT_EQ(countOfKind(changes, Kind::NodeAdded), 0);
+    EXPECT_EQ(countOfKind(changes, Kind::ConnectionAdded), 0);
+
+    auto* c = firstOfKind(changes, Kind::ModulationAdded);
+    ASSERT_NE(c, nullptr);
+    EXPECT_EQ(c->srcType, "LFO");
+    EXPECT_EQ(c->dstType, "Filter");
+    EXPECT_EQ(c->destParamName, "Cutoff");
+    EXPECT_NEAR(c->amount, 0.5, 1.0e-3);
+}
+
+TEST(PatchDiffTest, ModulationRemoved) {
+    juce::AudioProcessorGraph graph;
+    applyStep(graph, R"({"nodes":[{"id":1,"type":"LFO"},{"id":2,"type":"Filter"}],"connections":[]})",
+              /*clearExisting=*/true);
+    applyStep(graph,
+              R"({"nodes":[],"connections":[],
+                 "modulations":[{"source":1,"sourcePort":0,"dest":2,"destPort":1,"amount":0.5}]})",
+              /*clearExisting=*/false);
+    juce::var before = AIStateMapper::graphToJSON(graph);
+
+    applyStep(graph,
+              R"({"nodes":[],"connections":[],
+                 "removeModulations":[{"source":1,"dest":2,"destPort":1}]})",
+              /*clearExisting=*/false);
+    juce::var after = AIStateMapper::graphToJSON(graph);
+
+    auto changes = computeDiff(before, after);
+    auto* c = firstOfKind(changes, Kind::ModulationRemoved);
+    ASSERT_NE(c, nullptr);
+    EXPECT_EQ(c->srcType, "LFO");
+    EXPECT_EQ(c->dstType, "Filter");
+    // The attenuverter node's removal must not leak in as a NodeRemoved.
+    EXPECT_EQ(countOfKind(changes, Kind::NodeRemoved), 0);
+}
+
+TEST(PatchDiffTest, IdenticalSnapshotsProduceEmptyDiff) {
+    juce::var snap = snapshotOf(R"({
+        "nodes": [
+            {"id": 1, "type": "Oscillator"},
+            {"id": 2, "type": "Filter", "params": {"cutoff": 333.0}},
+            {"id": 3, "type": "Audio Output"}
+        ],
+        "connections": [
+            {"src": 1, "srcPort": 0, "dst": 2, "dstPort": 0},
+            {"src": 2, "srcPort": 0, "dst": 3, "dstPort": 0}
+        ]
+    })");
+
+    EXPECT_TRUE(computeDiff(snap, snap).empty());
+}
+
+TEST(PatchDiffTest, DescribeRendersHumanReadableLines) {
+    PatchChange added;
+    added.kind = Kind::NodeAdded;
+    added.nodeType = "Reverb";
+    EXPECT_EQ(added.describe(), "+ Reverb");
+
+    PatchChange removed;
+    removed.kind = Kind::NodeRemoved;
+    removed.nodeType = "Delay";
+    EXPECT_EQ(removed.describe(), "- Delay");
+
+    PatchChange paramChanged;
+    paramChanged.kind = Kind::ParamChanged;
+    paramChanged.nodeType = "Filter";
+    paramChanged.paramName = "Cutoff";
+    paramChanged.beforeText = "400";
+    paramChanged.afterText = "800";
+    EXPECT_EQ(paramChanged.describe(), "Filter: Cutoff 400 -> 800");
+
+    PatchChange modAdded;
+    modAdded.kind = Kind::ModulationAdded;
+    modAdded.srcType = "LFO";
+    modAdded.dstType = "Filter";
+    modAdded.destParamName = "Cutoff";
+    EXPECT_EQ(modAdded.describe(), "+ mod LFO -> Filter Cutoff");
+}
+
+//==============================================================================
+// Integration-level regression tests: the whole reason to diff snapshots instead of the raw
+// patch JSON is that applyJSONToGraph does things the patch itself never states.
+
+class PatchDiffIntegrationTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        graph = std::make_unique<juce::AudioProcessorGraph>();
+        service = std::make_unique<AIIntegrationService>(*graph);
+    }
+
+    std::unique_ptr<juce::AudioProcessorGraph> graph;
+    std::unique_ptr<AIIntegrationService> service;
+};
+
+TEST_F(PatchDiffIntegrationTest, MergeModeAutoWireAppearsInDiff) {
+    ASSERT_TRUE(service->applyPatch(R"({"nodes":[{"id":1,"type":"Oscillator"},{"id":2,"type":"Audio Output"}],
+                                        "connections":[{"src":1,"srcPort":0,"dst":2,"dstPort":0}]})"));
+
+    // The candidate patch adds a Reverb with NO connection at all. Merge mode's auto-connect
+    // affordance (applyJSONToGraph, autoConnectNewNodes) is what wires it to Audio Output — the
+    // raw patch JSON never says so, which is exactly why diffing the raw patch would miss it.
+    const char* candidate = R"({"mode":"merge","nodes":[{"id":99,"type":"Reverb"}],"connections":[]})";
+    ASSERT_FALSE(juce::String(candidate).contains("Audio Output"));
+
+    juce::var before, after;
+    EXPECT_TRUE(service->computePatchPreview(candidate, /*mergeMode=*/true, before, after));
+
+    auto changes = computeDiff(before, after);
+    auto* nodeAdded = firstOfKind(changes, Kind::NodeAdded);
+    ASSERT_NE(nodeAdded, nullptr);
+    EXPECT_EQ(nodeAdded->nodeType, "Reverb");
+
+    auto* connAdded = firstOfKind(changes, Kind::ConnectionAdded);
+    ASSERT_NE(connAdded, nullptr);
+    EXPECT_EQ(connAdded->srcType, "Reverb");
+    EXPECT_EQ(connAdded->dstType, "Audio Output");
+}
+
+TEST_F(PatchDiffIntegrationTest, UntrustedRescaleShowsLandedValueNotRawPatchValue) {
+    ASSERT_TRUE(service->applyPatch(
+        R"({"nodes":[{"id":1,"type":"Oscillator"},{"id":2,"type":"Filter"},{"id":3,"type":"Audio Output"}],
+            "connections":[{"src":1,"srcPort":0,"dst":2,"dstPort":0},{"src":2,"srcPort":0,"dst":3,"dstPort":0}]})"));
+
+    // Filter cutoff's real range is [20, 20000] (FilterModule.h), linear (no skew). 0.5 is inside
+    // [0,1], so AIStateMapper::applyParamsToProcessor's untrusted-apply heuristic treats it as a
+    // normalised value the model forgot to denormalize and rescales it to
+    // range.convertFrom0to1(0.5) == 10010.0 — not the literal 0.5 the patch states.
+    const char* candidate =
+        R"({"mode":"merge","nodes":[{"id":2,"type":"Filter","params":{"cutoff":0.5}}],"connections":[]})";
+
+    juce::var before, after;
+    EXPECT_TRUE(service->computePatchPreview(candidate, /*mergeMode=*/true, before, after));
+
+    auto changes = computeDiff(before, after);
+    auto* c = firstOfKind(changes, Kind::ParamChanged);
+    ASSERT_NE(c, nullptr);
+    EXPECT_EQ(c->paramId, "cutoff");
+    EXPECT_NEAR((double)c->afterValue, 10010.0, 1.0);
+    EXPECT_GT(std::abs((double)c->afterValue - 0.5), 1.0) << "must show the RESCALED value, not the raw patch value";
+}
+
+TEST_F(PatchDiffIntegrationTest, NoOpPatchWithSkewedParamProducesEmptyDiff) {
+    // LFO's "rateHz" uses a skewed NormalisableRange (LFOModule.h). computePatchPreview()'s
+    // "before" must travel the SAME trusted-replay round-trip (denormalize -> setValueNotifyingHost
+    // -> renormalize) as "after" does, or a merge-mode preview of an empty delta could show a
+    // phantom ParamChanged purely from replay round-trip rounding on an untouched node.
+    ASSERT_TRUE(service->applyPatch(R"({"nodes":[{"id":1,"type":"Oscillator"},{"id":2,"type":"Audio Output"},
+                                          {"id":3,"type":"LFO"}],
+                                "connections":[{"src":1,"srcPort":0,"dst":2,"dstPort":0}]})"));
+
+    const char* candidate = R"({"mode":"merge","nodes":[],"connections":[]})";
+
+    juce::var before, after;
+    EXPECT_TRUE(service->computePatchPreview(candidate, /*mergeMode=*/true, before, after));
+
+    EXPECT_TRUE(computeDiff(before, after).empty());
+}
+
+TEST_F(PatchDiffIntegrationTest, ComputePatchPreviewDoesNotClobberLastPatchError) {
+    // computePatchPreview() runs entirely against a scratch graph and must never touch the
+    // service's error state — a preview computed while a previous real Apply failure is still on
+    // screen must not silently blank (or change) that message.
+    ASSERT_FALSE(service->applyPatch(R"({"nodes":[],"connections":[]})")); // fails the structural gate
+    const juce::String errorBefore = service->getLastPatchError();
+    ASSERT_FALSE(errorBefore.isEmpty());
+
+    juce::var before, after;
+    service->computePatchPreview(R"({"mode":"merge","nodes":[{"id":1,"type":"Reverb"}],"connections":[]})", true,
+                                 before, after);
+
+    EXPECT_EQ(service->getLastPatchError(), errorBefore);
+}
+
+} // namespace
+} // namespace synth

--- a/Tests/PatchDiffTests.cpp
+++ b/Tests/PatchDiffTests.cpp
@@ -244,6 +244,115 @@ TEST(PatchDiffTest, DescribeRendersHumanReadableLines) {
 }
 
 //==============================================================================
+// summarizePatch() — what replace-mode PatchCards render instead of a computeDiff() diff (see
+// PatchDiff.h's doc comment for why a replace-mode diff, while technically correct, isn't useful).
+
+TEST(PatchDiffTest, SummarizePatchListsNodeTypesInSnapshotOrderAndCountsConnections) {
+    // Hand-built graphToJSON-shaped snapshot (like PatchDiffTest.ConnectionRemoved above) rather
+    // than routed through applyJSONToGraph: summarizePatch() is a pure function over the JSON
+    // shape, and going through the real graph would tie this test to per-module channel-layout
+    // behaviour (e.g. whether a given src/dst port pair is actually connectable) that has nothing
+    // to do with what's under test here.
+    const char* afterJson = R"({
+        "nodes": [
+            {"id": 1, "uuid": "osc-1", "type": "Oscillator", "params": {}},
+            {"id": 2, "uuid": "filt-1", "type": "Filter", "params": {}},
+            {"id": 3, "uuid": "out-1", "type": "Audio Output", "params": {}}
+        ],
+        "connections": [
+            {"src": 1, "srcPort": 0, "dst": 2, "dstPort": 0, "isMidi": false},
+            {"src": 2, "srcPort": 0, "dst": 3, "dstPort": 0, "isMidi": false}
+        ],
+        "modulations": []
+    })";
+    juce::var after = juce::JSON::parse(juce::String(afterJson));
+
+    auto summary = summarizePatch(after);
+    ASSERT_EQ(summary.nodeTypes.size(), 3u);
+    EXPECT_EQ(summary.nodeTypes[0], "Oscillator");
+    EXPECT_EQ(summary.nodeTypes[1], "Filter");
+    EXPECT_EQ(summary.nodeTypes[2], "Audio Output");
+    EXPECT_EQ(summary.connectionCount, 2);
+}
+
+TEST(PatchDiffTest, SummarizePatchExcludesAttenuverterNodesAndTheirConnections) {
+    juce::AudioProcessorGraph graph;
+    applyStep(graph, R"({"nodes":[{"id":1,"type":"LFO"},{"id":2,"type":"Filter"}],"connections":[]})",
+              /*clearExisting=*/true);
+    applyStep(graph,
+              R"({"nodes":[],"connections":[],
+                 "modulations":[{"source":1,"sourcePort":0,"dest":2,"destPort":1,"amount":0.5}]})",
+              /*clearExisting=*/false);
+    juce::var after = AIStateMapper::graphToJSON(graph);
+
+    auto summary = summarizePatch(after);
+    for (const auto& t : summary.nodeTypes)
+        EXPECT_NE(t, "Attenuverter");
+}
+
+TEST(PatchDiffTest, SummarizePatchOnEmptyGraphIsEmpty) {
+    juce::var after = snapshotOf(R"({"nodes":[],"connections":[]})");
+    auto summary = summarizePatch(after);
+    EXPECT_TRUE(summary.nodeTypes.empty());
+    EXPECT_EQ(summary.connectionCount, 0);
+}
+
+//==============================================================================
+// groupChangesByKind() — used only for merge-mode PatchCard rendering; must not touch
+// computeDiff()'s own output order (its tests assert on that directly).
+
+TEST(PatchDiffTest, GroupChangesByKindGroupsWithoutReordering) {
+    std::vector<PatchChange> changes;
+    auto add = [&](Kind k, juce::String tag) {
+        PatchChange c;
+        c.kind = k;
+        c.nodeType = tag; // reused as a tag to check relative order within a kind
+        changes.push_back(c);
+    };
+    // Deliberately interleaved input order.
+    add(Kind::ParamChanged, "p1");
+    add(Kind::NodeAdded, "a1");
+    add(Kind::ModulationRemoved, "mr1");
+    add(Kind::NodeRemoved, "r1");
+    add(Kind::NodeAdded, "a2");
+    add(Kind::ConnectionAdded, "ca1");
+    add(Kind::ModulationAdded, "ma1");
+    add(Kind::ParamChanged, "p2");
+
+    auto grouped = groupChangesByKind(changes);
+    ASSERT_EQ(grouped.size(), changes.size());
+
+    // Kind order follows PatchChange::Kind's declaration order (NodeAdded/NodeRemoved, then
+    // ParamChanged, then ConnectionAdded/ConnectionRemoved, then ModulationAdded/Removed): after
+    // grouping, kinds must be non-decreasing by declaration order.
+    for (size_t i = 0; i + 1 < grouped.size(); ++i)
+        EXPECT_LE(static_cast<int>(grouped[i].kind), static_cast<int>(grouped[i + 1].kind))
+            << "kinds must be non-decreasing after grouping (index " << i << ")";
+
+    // Within the NodeAdded group, original relative order ("a1" before "a2") is preserved.
+    std::vector<juce::String> nodeAddedTags;
+    for (const auto& c : grouped)
+        if (c.kind == Kind::NodeAdded)
+            nodeAddedTags.push_back(c.nodeType);
+    ASSERT_EQ(nodeAddedTags.size(), 2u);
+    EXPECT_EQ(nodeAddedTags[0], "a1");
+    EXPECT_EQ(nodeAddedTags[1], "a2");
+}
+
+TEST(PatchDiffTest, GroupChangesByKindDoesNotMutateInput) {
+    std::vector<PatchChange> changes;
+    PatchChange c;
+    c.kind = Kind::NodeRemoved;
+    c.nodeType = "Delay";
+    changes.push_back(c);
+
+    auto grouped = groupChangesByKind(changes);
+    ASSERT_EQ(changes.size(), 1u);
+    EXPECT_EQ(changes[0].kind, Kind::NodeRemoved);
+    ASSERT_EQ(grouped.size(), 1u);
+}
+
+//==============================================================================
 // Integration-level regression tests: the whole reason to diff snapshots instead of the raw
 // patch JSON is that applyJSONToGraph does things the patch itself never states.
 

--- a/docs/AI_Engine.md
+++ b/docs/AI_Engine.md
@@ -152,6 +152,94 @@ which presets, undo snapshots and AI patches all address parameters by.
 -   **Model Management**: Users can select from various available AI models (e.g., different Ollama models) via the application's UI.
 -   **Extensible Provider System**: The `AIProvider` interface allows for easy integration of new AI backends in the future.
 -   **Undoable Patches**: Apply/Merge on a patch card is recorded on the app undo stack, so `Cmd+Z` restores the user's previous patch (see below).
+-   **Patch Diff Preview**: A proposed patch's `PatchCard` shows a human-readable change list by
+    default (see below) — the user sees what a patch will actually do before clicking Apply/Merge.
+
+### Patch Diff Preview (PatchCard)
+
+`AIChatComponent::PatchCard` (`Source/UI/AIChatComponent.cpp`) shows a change list — "+ Reverb",
+"Filter: Cutoff 400 -> 800", "+ mod LFO -> Filter Cutoff" — as its **default** view, computed in
+`updateChatDisplay()` when each message is rendered. Raw JSON stays available behind a secondary
+"View JSON" toggle for anyone who wants it; the card's height is derived from the diff's line
+count (capped, with the toggle as the escape hatch for a very long diff), not a fixed constant.
+
+**The diff is computed from two full graph snapshots, never the raw patch JSON.** This is the
+whole point, not an implementation detail: diffing the patch JSON against the live graph would
+misreport three things the patch itself never states —
+
+- merge mode auto-connects a new audio node with no outgoing wire to Audio Output, and a new
+  MIDI-accepting node to an existing MIDI source (`applyJSONToGraph`'s `autoConnectNewNodes`);
+- replace mode deletes every node the patch doesn't restate;
+- the untrusted-apply path rescales any `[0,1]`-range value against a wider parameter range
+  (`AIStateMapper::applyParamsToProcessor`'s normalized-value heuristic) — the value that lands is
+  not the value the patch states.
+
+`AIIntegrationService::computePatchPreview(jsonString, mergeMode, before, after)`
+(`Source/AI/AIIntegrationService.h/.cpp`) produces the two snapshots without touching the live
+graph:
+
+- `before` is `AIStateMapper::graphToJSON(audioGraph)` for replace mode. For merge mode it is
+  `graphToJSON` of a scratch graph immediately after `replayLiveGraphTrusted()` — the live graph
+  replayed onto scratch trusted, clearExisting=true — rather than a second direct call on
+  `audioGraph`. Both must travel the *same* param round-trip (denormalize ->
+  `setValueNotifyingHost` -> renormalize, including `snapToLegalValue` on a skewed or interval
+  range) or an untouched node on a skewed range (e.g. `LFOModule`'s `rateHz`) can show a phantom
+  `ParamChanged` purely from replay rounding. Guarded by
+  `PatchDiffIntegrationTest.NoOpPatchWithSkewedParamProducesEmptyDiff`.
+- `after` is `graphToJSON` of that same scratch graph once the untrusted candidate patch has
+  actually been applied to it (`applyJSONToGraph(json, scratch, clearExisting, trusted=false)`) —
+  the exact scratch-graph construction `applyPatch()`'s own `PatchEval` regression check uses
+  (`replayLiveGraphTrusted()` is the extracted, shared piece).
+- Mirrors `applyPatch()`'s mode-less-patch repair (a replace that only validates as a merge is
+  applied as a merge) so the previewed diff matches what Apply/Merge will actually do.
+- Never mutates `getLastPatchError()` / `getLastPatchErrorCode()` / `didLastPatchRepairMode()` —
+  it runs entirely against a scratch graph and must not clobber the error state from a previous
+  real Apply attempt still on screen. Guarded by
+  `PatchDiffIntegrationTest.ComputePatchPreviewDoesNotClobberLastPatchError`.
+- Returns `false` (with `before`/`after` still populated) if the candidate patch fails validation
+  or application on the scratch graph; `PatchCard` shows "Preview unavailable" rather than a diff
+  in that case, since `after` would otherwise reflect the unapplied, pre-patch state (misleadingly
+  "everything removed" for a failed replace-mode patch, whose scratch starts empty).
+
+`Source/AI/PatchDiff.h`'s `computeDiff(before, after)` is a pure function over two
+`graphToJSON`-shaped `juce::var` snapshots, returning `std::vector<PatchChange>`
+(`NodeAdded`/`NodeRemoved`/`ParamChanged`/`ConnectionAdded`/`ConnectionRemoved`/
+`ModulationAdded`/`ModulationRemoved`), each renderable via `describe()`. Structural notes:
+
+- **Node identity is the `uuid` field, not the integer `id`.** Merge mode's trusted replay
+  preserves both `id` and `uuid` for nodes it recreates 1:1 from the live graph
+  (`applyJSONToGraph`'s `preservedId` + `adoptUuidIfTrusted`, trusted-path only), and the
+  subsequent untrusted patch apply never reassigns a matched node's `uuid`. A brand-new node has
+  no `uuid` in `before`, so it never spuriously matches. Connection/modulation endpoints (which
+  reference nodes by `id`, meaningful only within one snapshot) are resolved to `uuid` via each
+  snapshot's own `id -> uuid` map before comparing.
+- **Replace mode has no stable node identity between snapshots.** `applyJSONToGraph` only
+  preserves `id`/`uuid` on the trusted path, and a replace-mode apply is always untrusted, so a
+  replace-mode diff shows the entire prior graph removed and the entire new patch added — even
+  where a node is conceptually unchanged. This matches what actually happens to the running graph
+  (every processor really is destroyed and recreated on replace) and is not the common case in
+  practice: `AIChatComponent`'s merge-vs-replace inference routes any tweak-shaped request
+  ("change", "add", "more", "brighter", …) to merge, so replace is reserved for from-scratch
+  patches where "+ everything" is the correct diff.
+- **`graphToJSON` already collapses attenuverter chains into a `modulations` array** (scanning
+  `AttenuverterModule` nodes and their wires), so `computeDiff` does not need to pattern-match
+  attenuverter plumbing itself — it diffs `modulations` directly. It does exclude
+  `type == "Attenuverter"` nodes from the node diff and any connection with an Attenuverter
+  endpoint from the connection diff, so a modulation change is reported exactly once (as
+  `ModulationAdded`/`Removed`), not also as raw node/connection noise. One known omission: an
+  attenuverter wired on only one side produces no `modulations` entry in `graphToJSON` at all, so
+  it is silently dropped from the diff rather than shown as add/remove noise — deliberate, since a
+  half-wired attenuverter only arises from a malformed patch.
+- Only a node's `params` object is diffed — never `position`, `state`, `id`, or `uuid` — so a
+  merge-mode patch that repositions or re-lists an unrelated existing node doesn't read as
+  "moved"/"changed" noise. A parameter's display name comes from a throwaway, never-processed
+  instance of its module type (`AIStateMapper::createModule`), falling back to the raw param ID
+  when not found; numeric values render at ~3 significant figures (no per-module unit-formatting
+  table exists in this codebase, so no units are shown).
+
+Tests: `Tests/PatchDiffTests.cpp` — pure `computeDiff` cases plus two regression tests
+(`MergeModeAutoWireAppearsInDiff`, `UntrustedRescaleShowsLandedValueNotRawPatchValue`) proving the
+snapshot-diff catches what a raw-patch-vs-live-graph diff would miss.
 
 ### AI Patch Undo/Redo Contract
 

--- a/docs/AI_Engine.md
+++ b/docs/AI_Engine.md
@@ -152,16 +152,40 @@ which presets, undo snapshots and AI patches all address parameters by.
 -   **Model Management**: Users can select from various available AI models (e.g., different Ollama models) via the application's UI.
 -   **Extensible Provider System**: The `AIProvider` interface allows for easy integration of new AI backends in the future.
 -   **Undoable Patches**: Apply/Merge on a patch card is recorded on the app undo stack, so `Cmd+Z` restores the user's previous patch (see below).
--   **Patch Diff Preview**: A proposed patch's `PatchCard` shows a human-readable change list by
-    default (see below) — the user sees what a patch will actually do before clicking Apply/Merge.
+-   **Patch Diff Preview**: A proposed patch's `PatchCard` shows a human-readable preview by
+    default — a grouped, colour-coded change list for a merge, or a plain contents summary for a
+    replace (see below) — so the user sees what a patch will actually do before clicking
+    Apply/Merge.
 
 ### Patch Diff Preview (PatchCard)
 
-`AIChatComponent::PatchCard` (`Source/UI/AIChatComponent.cpp`) shows a change list — "+ Reverb",
-"Filter: Cutoff 400 -> 800", "+ mod LFO -> Filter Cutoff" — as its **default** view, computed in
-`updateChatDisplay()` when each message is rendered. Raw JSON stays available behind a secondary
-"View JSON" toggle for anyone who wants it; the card's height is derived from the diff's line
-count (capped, with the toggle as the escape hatch for a very long diff), not a fixed constant.
+`AIChatComponent::PatchCard` (`Source/UI/AIChatComponent.cpp`) shows a human-readable preview as
+its **default** view, computed once in `attachPatchPreview()` when each message is created (not on
+every `updateChatDisplay()` re-render). What it shows depends on the patch's mode:
+
+- **Merge mode** (`isMerge == true`, has stable node identity — see below): a change list —
+  "+ Reverb", "Filter: Cutoff 400 -> 800", "+ mod LFO -> Filter Cutoff" — grouped by
+  `PatchChange::Kind` (adds, then param changes, then connection changes, then modulation changes;
+  see `groupChangesByKind()` below) so adds/removes/changes aren't interleaved, and colour-coded:
+  green for `+` (node/connection adds), red/orange for `-` (node/connection removes), amber for
+  param changes and modulation adds/removes (a modulation change is reported as a matched
+  remove+add pair — see `PatchDiff.h` — so it gets a neutral colour rather than fighting for
+  green/red). Rendered into the `TextEditor` line-by-line via `insertTextAtCaret()` with
+  `textColourId` set per segment, since `setText()` can't colour per line.
+- **Replace mode** (`isMerge == false`): a plain positive summary of the *new* patch's contents —
+  "New patch: 12 modules" followed by each node's type name (no `+`/`-` prefix — nothing is being
+  "added" relative to something the user cares about, it's just what the patch contains), plus a
+  connection count if any. **Never a diff against the old graph** — see "Replace mode" below for
+  why that would be technically correct but useless.
+
+Raw JSON stays available behind a secondary "View JSON" toggle for anyone who wants it, pretty-
+printed (`juce::JSON::toString(parsed, allOnOneLine=false)`) so it isn't one unbroken line in a
+narrow chat column — falling back to the raw string if it fails to parse (shouldn't happen, since
+this is a patch that already round-tripped through `extractJSONBlocks`). The card's height is
+derived from the preview's line count (capped, with the toggle as the escape hatch for a very long
+preview), not a fixed constant; this is a count of *logical* lines, not rendered/wrapped ones, so a
+long `ParamChanged` line that wraps in the narrow column can still be short on visible space before
+the `TextEditor`'s own scrolling kicks in.
 
 **The diff is computed from two full graph snapshots, never the raw patch JSON.** This is the
 whole point, not an implementation detail: diffing the patch JSON against the live graph would
@@ -214,13 +238,14 @@ graph:
   reference nodes by `id`, meaningful only within one snapshot) are resolved to `uuid` via each
   snapshot's own `id -> uuid` map before comparing.
 - **Replace mode has no stable node identity between snapshots.** `applyJSONToGraph` only
-  preserves `id`/`uuid` on the trusted path, and a replace-mode apply is always untrusted, so a
-  replace-mode diff shows the entire prior graph removed and the entire new patch added — even
-  where a node is conceptually unchanged. This matches what actually happens to the running graph
-  (every processor really is destroyed and recreated on replace) and is not the common case in
-  practice: `AIChatComponent`'s merge-vs-replace inference routes any tweak-shaped request
-  ("change", "add", "more", "brighter", …) to merge, so replace is reserved for from-scratch
-  patches where "+ everything" is the correct diff.
+  preserves `id`/`uuid` on the trusted path, and a replace-mode apply is always untrusted, so
+  `computeDiff` over a replace-mode before/after pair reports the entire prior graph removed and
+  the entire new patch added — even where a node is conceptually unchanged. That's technically
+  correct (every processor really is destroyed and recreated on replace) but not useful to a user
+  reviewing a brand-new patch, which is why `PatchCard` never feeds a replace-mode preview through
+  `computeDiff` — it calls `summarizePatch()` instead (below). `computeDiff` itself stays
+  mode-agnostic and correct for any snapshot pair; this is a note about how the UI uses it, not a
+  limitation of the function.
 - **`graphToJSON` already collapses attenuverter chains into a `modulations` array** (scanning
   `AttenuverterModule` nodes and their wires), so `computeDiff` does not need to pattern-match
   attenuverter plumbing itself — it diffs `modulations` directly. It does exclude
@@ -237,9 +262,21 @@ graph:
   when not found; numeric values render at ~3 significant figures (no per-module unit-formatting
   table exists in this codebase, so no units are shown).
 
-Tests: `Tests/PatchDiffTests.cpp` — pure `computeDiff` cases plus two regression tests
-(`MergeModeAutoWireAppearsInDiff`, `UntrustedRescaleShowsLandedValueNotRawPatchValue`) proving the
-snapshot-diff catches what a raw-patch-vs-live-graph diff would miss.
+`Source/AI/PatchDiff.h` also exposes two smaller pure helpers used only by the UI:
+
+- **`summarizePatch(after)`** returns a `PatchSummary` (node type list, in snapshot node order,
+  plus a non-attenuverter connection count) read from a single snapshot. This is what
+  replace-mode `PatchCard`s render instead of `computeDiff` output — see above.
+- **`groupChangesByKind(changes)`** stable-sorts a `computeDiff` result by `PatchChange::Kind`
+  (`Kind`'s declaration order already matches the desired grouping: adds/removes, then param
+  changes, then connection adds/removes, then modulation adds/removes), so changes sharing a kind
+  keep `computeDiff`'s original relative order. Used only for merge-mode `PatchCard` rendering;
+  `computeDiff`'s own output order is untouched and still what its tests assert on.
+
+Tests: `Tests/PatchDiffTests.cpp` — pure `computeDiff` cases, `summarizePatch`/`groupChangesByKind`
+coverage, plus two regression tests (`MergeModeAutoWireAppearsInDiff`,
+`UntrustedRescaleShowsLandedValueNotRawPatchValue`) proving the snapshot-diff catches what a
+raw-patch-vs-live-graph diff would miss.
 
 ### AI Patch Undo/Redo Contract
 


### PR DESCRIPTION
## Summary

Roadmap P6-2: replace the AI chat's patch card raw-JSON dump (fixed 200px box) with a human-readable preview shown before the user clicks Apply/Merge.

- New `Source/AI/PatchDiff.h/.cpp` (Core, headless): `computeDiff()` diffs two `AIStateMapper::graphToJSON()` snapshots (before = live graph, after = a scratch graph the candidate patch was actually applied to) — never the raw patch JSON against the live graph, since that would misreport merge-mode's auto-wiring of new nodes, replace-mode's implicit deletions, and the untrusted-apply `[0,1]` rescale heuristic. Node identity keyed on `graphToJSON`'s `uuid` field (stable across snapshots), not the integer `id`.
- `AIIntegrationService` gains `computePatchPreview()` + the extracted `replayLiveGraphTrusted()` helper, reused by the existing `PatchEval` regression check.
- `PatchCard`'s default view:
  - **Replace mode** ("New Patch"): no longer diffs at all — shows a plain summary ("New patch: N modules" + list + connection count), since replace mode has no stable identity between the old and new graph and a full diff was pure noise.
  - **Merge mode** ("Patch Update"): groups changes by kind (adds, param changes, connection changes, modulation changes) instead of interleaving, color-coded (green/red/amber).
  - Raw JSON stays behind a "View JSON" toggle, now pretty-printed/indented instead of one unreadable line.
- Fixed a real mojibake bug found during manual testing: an em-dash in two UI strings rendered as garbage in JUCE's `TextEditor`; replaced with plain ASCII.

The diff display is functional but not yet polished — flagged in `roadmap.json` for a future pass (denser param-change formatting, possibly a richer row-based view instead of a flat text list).

## Test plan
- [x] `Tests/PatchDiffTests.cpp`: node/param/connection/modulation add+remove, no-op patch, merge-mode auto-wire regression, untrusted-rescale regression, `summarizePatch()`/`groupChangesByKind()` coverage
- [x] Full suite: 1609/1609 passing
- [x] Built and launched locally (Release + Debug), manually verified in the running app

🤖 Generated with [Claude Code](https://claude.com/claude-code)