### PR TITLE
feat(ai): thumbs up/down feedback on patch cards (P6-3)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,6 +158,8 @@ add_library(Core STATIC
     Source/AI/AuthClient.cpp
     Source/AI/AccountService.h
     Source/AI/AccountService.cpp
+    Source/AI/PatchFeedbackStore.h
+    Source/AI/PatchFeedbackStore.cpp
     # Auth (device-code sign-in: token storage, no UI)
     Source/Auth/TokenStore.h
     Source/Auth/InMemoryTokenStore.h

--- a/Source/AI/PatchFeedbackStore.cpp
+++ b/Source/AI/PatchFeedbackStore.cpp
@@ -1,0 +1,41 @@
+#include "PatchFeedbackStore.h"
+#include "../Branding.h"
+
+namespace synth {
+
+namespace {
+juce::File defaultFeedbackFile() {
+    return juce::File::getSpecialLocation(juce::File::userApplicationDataDirectory)
+        .getChildFile(synth::branding::kSettingsFolderName)
+        .getChildFile("patch_feedback.jsonl");
+}
+} // namespace
+
+PatchFeedbackStore::PatchFeedbackStore()
+    : file(defaultFeedbackFile()) {}
+
+PatchFeedbackStore::PatchFeedbackStore(juce::File feedbackFile)
+    : file(std::move(feedbackFile)) {}
+
+void PatchFeedbackStore::record(const juce::String& patchJson, Rating rating, const juce::String& comment) {
+    auto* obj = new juce::DynamicObject();
+    juce::var root(obj);
+    obj->setProperty("timestamp", juce::Time::getCurrentTime().toISO8601(true));
+    obj->setProperty("rating", rating == Rating::Up ? "up" : "down");
+    if (comment.isNotEmpty())
+        obj->setProperty("comment", comment);
+
+    juce::var parsedPatch = juce::JSON::parse(patchJson);
+    if (!parsedPatch.isVoid())
+        obj->setProperty("patch", parsedPatch);
+    else
+        obj->setProperty("patchRaw", patchJson);
+
+    const auto parent = file.getParentDirectory();
+    if (!parent.exists())
+        parent.createDirectory();
+
+    file.appendText(juce::JSON::toString(root, /*allOnOneLine=*/true) + "\n");
+}
+
+} // namespace synth

--- a/Source/AI/PatchFeedbackStore.h
+++ b/Source/AI/PatchFeedbackStore.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <juce_core/juce_core.h>
+
+namespace synth {
+
+/**
+ * P6-3: local, append-only log of thumbs up/down feedback on AI-generated patches. This is the
+ * client-only half of P6-3 — there is no server endpoint yet to send it to (packages/conversations'
+ * ConversationMessage has no rating field, and the client doesn't hold a conversation id to key one
+ * on until P6-8 ships), so entries live only on this device until a future task wires up sync. See
+ * docs/AI_Engine.md.
+ *
+ * One JSON object per line (JSON Lines), appended — never rewritten. A user who edits a comment
+ * after the fact produces a second line for the same patch/rating rather than mutating the first;
+ * this is a log, not a keyed table, so a reader that cares about edits should treat the last entry
+ * as authoritative.
+ */
+class PatchFeedbackStore {
+public:
+    enum class Rating { Up, Down };
+
+    // Real on-disk location: <user app data>/<kSettingsFolderName>/patch_feedback.jsonl
+    PatchFeedbackStore();
+    // Test injection point — mirrors DeviceIdStore's file-taking constructor.
+    explicit PatchFeedbackStore(juce::File feedbackFile);
+
+    // Appends one record. Creates the parent directory if needed. `patchJson` should be the
+    // patch's raw JSON text (the same string PatchCard renders); malformed JSON is stored verbatim
+    // under "patchRaw" rather than dropped.
+    void record(const juce::String& patchJson, Rating rating, const juce::String& comment = {});
+
+private:
+    juce::File file;
+};
+
+} // namespace synth

--- a/Source/UI/AIChatComponent.cpp
+++ b/Source/UI/AIChatComponent.cpp
@@ -76,9 +76,13 @@ public:
     // snapshots, so a diff would show the entire prior graph removed and the entire new patch
     // added — technically correct, useless to read. See PatchDiff.h.
     PatchCard(const juce::String& json, std::function<void()> applyCallback, bool isMerge,
-              const std::vector<PatchChange>& changes, bool diffAvailable, const PatchSummary& summary)
+              const std::vector<PatchChange>& changes, bool diffAvailable, const PatchSummary& summary,
+              AIChatComponent::PatchRatingUiState initialRating, const juce::String& initialComment,
+              std::function<void(AIChatComponent::PatchRatingUiState, const juce::String&)> onRateCallback)
         : patchJson(json)
-        , onApply(applyCallback) {
+        , onApply(applyCallback)
+        , onRate(std::move(onRateCallback))
+        , currentRating(initialRating) {
 
         addAndMakeVisible(headerLabel);
         headerLabel.setText(isMerge ? "Patch Update" : "New Patch", juce::dontSendNotification);
@@ -101,6 +105,29 @@ public:
         applyButton.setColour(juce::TextButton::buttonColourId,
                               isMerge ? juce::Colour(0xFF8B6914) : juce::Colours::darkgreen);
         applyButton.onClick = onApply;
+
+        addAndMakeVisible(thumbsUpButton);
+        thumbsUpButton.setButtonText("Good");
+        thumbsUpButton.setTooltip("This patch was helpful");
+        thumbsUpButton.onClick = [this]() { setRating(AIChatComponent::PatchRatingUiState::Up); };
+
+        addAndMakeVisible(thumbsDownButton);
+        thumbsDownButton.setButtonText("Bad");
+        thumbsDownButton.setTooltip("This patch missed the mark");
+        thumbsDownButton.onClick = [this]() { setRating(AIChatComponent::PatchRatingUiState::Down); };
+
+        addAndMakeVisible(commentField);
+        commentField.setComponentID("patchFeedbackComment");
+        commentField.setText(initialComment, juce::dontSendNotification);
+        commentField.setTextToShowWhenEmpty("Optional: why? (Enter to save)", juce::Colours::grey);
+        commentField.onReturnKey = [this]() { notifyRate(); };
+
+        addAndMakeVisible(commentSaveButton);
+        commentSaveButton.setButtonText("Save");
+        commentSaveButton.setTooltip("Save your comment with the rating");
+        commentSaveButton.onClick = [this]() { notifyRate(); };
+
+        updateThumbColours();
 
         addAndMakeVisible(diffDisplay);
         diffDisplay.setMultiLine(true);
@@ -162,6 +189,23 @@ public:
         expandButton.setBounds(buttons.removeFromRight(90).reduced(2));
 
         b.removeFromTop(5);
+
+        // Feedback row: thumbs are always visible on a patch card; the comment field/save button
+        // only appear once a rating has been picked, so a patch nobody has judged yet doesn't
+        // invite a comment with nothing to attach it to.
+        auto feedbackRow = b.removeFromTop(kFeedbackRowHeight);
+        thumbsUpButton.setBounds(feedbackRow.removeFromLeft(50).reduced(2));
+        thumbsDownButton.setBounds(feedbackRow.removeFromLeft(50).reduced(2));
+        bool showComment = currentRating != AIChatComponent::PatchRatingUiState::None;
+        commentSaveButton.setVisible(showComment);
+        commentField.setVisible(showComment);
+        if (showComment) {
+            feedbackRow.removeFromLeft(5);
+            commentSaveButton.setBounds(feedbackRow.removeFromRight(55).reduced(2));
+            commentField.setBounds(feedbackRow.reduced(2));
+        }
+        b.removeFromTop(5);
+
         if (isExpanded) {
             diffDisplay.setBounds(b.removeFromTop(diffAreaHeight()));
             b.removeFromTop(5);
@@ -174,10 +218,32 @@ public:
     }
 
     int getRequiredHeight() const {
-        int height = 35 + diffAreaHeight();
+        int height = 35 + kFeedbackRowHeight + 5 + diffAreaHeight();
         if (isExpanded)
             height += 5 + kRawJsonHeight;
         return height;
+    }
+
+    void setRating(AIChatComponent::PatchRatingUiState rating) {
+        currentRating = rating;
+        updateThumbColours();
+        resized();
+        notifyRate();
+    }
+
+    void notifyRate() {
+        if (onRate)
+            onRate(currentRating, commentField.getText());
+    }
+
+    void updateThumbColours() {
+        auto neutral = juce::Colours::darkgrey;
+        thumbsUpButton.setColour(juce::TextButton::buttonColourId,
+                                 currentRating == AIChatComponent::PatchRatingUiState::Up ? juce::Colours::darkgreen
+                                                                                          : neutral);
+        thumbsDownButton.setColour(juce::TextButton::buttonColourId,
+                                   currentRating == AIChatComponent::PatchRatingUiState::Down ? juce::Colour(0xFF8B3A3A)
+                                                                                              : neutral);
     }
 
 private:
@@ -190,8 +256,12 @@ private:
     // Grew from 160: pretty-printed (indented) JSON runs noticeably taller than the single
     // unbroken line this used to hold.
     static constexpr int kRawJsonHeight = 240;
+    static constexpr int kFeedbackRowHeight = 24;
 
     int diffAreaHeight() const { return juce::jlimit(kMinDiffHeight, kMaxDiffHeight, diffLineCount * kLineHeight + 8); }
+
+    std::function<void(AIChatComponent::PatchRatingUiState, const juce::String&)> onRate;
+    AIChatComponent::PatchRatingUiState currentRating = AIChatComponent::PatchRatingUiState::None;
 
     juce::String patchJson;
     std::function<void()> onApply;
@@ -201,6 +271,10 @@ private:
     juce::Label headerLabel;
     juce::TextButton expandButton;
     juce::TextButton applyButton;
+    juce::TextButton thumbsUpButton;
+    juce::TextButton thumbsDownButton;
+    juce::TextEditor commentField;
+    juce::TextButton commentSaveButton;
     juce::TextEditor diffDisplay;
     juce::TextEditor jsonDisplay;
 };
@@ -210,7 +284,8 @@ class AIChatComponent::MessageBubble : public juce::Component {
 public:
     MessageBubble(const MessageData& data, std::function<void(const juce::String&)> applyPatch, bool isMerge,
                   std::function<void(const juce::URL&)> urlOpener, const std::vector<PatchChange>& patchDiff,
-                  bool patchDiffAvailable, const PatchSummary& patchSummary) {
+                  bool patchDiffAvailable, const PatchSummary& patchSummary,
+                  std::function<void(AIChatComponent::PatchRatingUiState, const juce::String&)> onRate) {
         role = data.role;
         text = data.text;
 
@@ -222,7 +297,7 @@ public:
         if (data.jsonPatch.isNotEmpty()) {
             patchCard = std::make_unique<PatchCard>(
                 data.jsonPatch, [applyPatch, json = data.jsonPatch]() { applyPatch(json); }, isMerge, patchDiff,
-                patchDiffAvailable, patchSummary);
+                patchDiffAvailable, patchSummary, data.ratingState, data.ratingComment, onRate);
             addAndMakeVisible(*patchCard);
         }
 
@@ -890,7 +965,20 @@ void AIChatComponent::updateChatDisplay() {
                         refreshLater();
                     });
             },
-            isMerge, urlOpener, data.patchDiff, data.patchDiffAvailable, data.patchSummary);
+            isMerge, urlOpener, data.patchDiff, data.patchDiffAvailable, data.patchSummary,
+            [this, i](PatchRatingUiState newRating, const juce::String& comment) {
+                if (i >= messages.size())
+                    return;
+                auto& msg = messages[i];
+                msg.ratingState = newRating;
+                msg.ratingComment = comment;
+                if (newRating != PatchRatingUiState::None) {
+                    patchFeedbackStore.record(msg.jsonPatch,
+                                              newRating == PatchRatingUiState::Up ? PatchFeedbackStore::Rating::Up
+                                                                                  : PatchFeedbackStore::Rating::Down,
+                                              comment);
+                }
+            });
         messageList.addAndMakeVisible(bubble);
     }
 

--- a/Source/UI/AIChatComponent.h
+++ b/Source/UI/AIChatComponent.h
@@ -3,6 +3,7 @@
 #include "../AI/AIIntegrationService.h"
 #include "../AI/AccountService.h"
 #include "../AI/PatchDiff.h"
+#include "../AI/PatchFeedbackStore.h"
 #include "AccountRow.h"
 #include "PlanBadge.h"
 #include "Theme/AppLookAndFeel.h"
@@ -86,6 +87,10 @@ public:
     // Testing hook: replaces the real "open in default browser" action a Quota error's Upgrade
     // button invokes, so tests can assert on the URL without ever launching a real browser.
     void setUrlOpenerForTesting(std::function<void(const juce::URL&)> opener) { urlOpener = std::move(opener); }
+
+    // Testing hook: redirects the local feedback log to a caller-supplied file so tests never
+    // touch the real per-user app-data location. Mirrors setUrlOpenerForTesting.
+    void setPatchFeedbackFileForTesting(const juce::File& file) { patchFeedbackStore = PatchFeedbackStore(file); }
 
 private:
     void timerCallback() override;
@@ -194,6 +199,10 @@ private:
     // setUrlOpenerForTesting() so no test ever launches a real browser.
     std::function<void(const juce::URL&)> urlOpener = [](const juce::URL& u) { u.launchInDefaultBrowser(); };
 
+    // P6-3: local, append-only feedback log — see PatchFeedbackStore's doc comment for why this
+    // is client-only for now (no server endpoint exists yet to sync to).
+    PatchFeedbackStore patchFeedbackStore;
+
     void updateChatDisplay();
     void scrollToBottom();
 
@@ -202,6 +211,10 @@ private:
     // for the async model fetch) from refreshModels() — the same post-setProvider() resync point
     // documented for model discovery (see CLAUDE.md "AI model discovery ordering").
     void updateHostedModeNotice();
+
+    // P6-3: thumbs up/down on a patch card. `None` is the UI's un-rated default and is never
+    // itself written to PatchFeedbackStore — only Up/Down get persisted.
+    enum class PatchRatingUiState { None, Up, Down };
 
     struct MessageData {
         juce::String role;
@@ -213,6 +226,11 @@ private:
         // constructor, so a New Chat or app restart drops it along with the rest of that turn's
         // transient UI state (mirrors how Cancel-button/spinner state is session-only).
         bool showUpgradeAction = false;
+
+        // P6-3: session-scoped UI rating state, same "not reconstructed on replay" precedent as
+        // showUpgradeAction just above — the durable record lives in patchFeedbackStore, not here.
+        PatchRatingUiState ratingState = PatchRatingUiState::None;
+        juce::String ratingComment;
 
         // Patch diff preview, computed ONCE (attachPatchPreview()) at the point this message is
         // created, not on every updateChatDisplay() re-render — see that method's doc comment.

--- a/Tests/AIChatComponentTests.cpp
+++ b/Tests/AIChatComponentTests.cpp
@@ -138,6 +138,36 @@ private:
     juce::String currentModel;
 };
 
+// Returns an assistant response containing a single fenced ```json patch, so tests can exercise
+// AIChatComponent's PatchCard (and its P6-3 thumbs feedback) without a real provider.
+class MockPatchProvider : public synth::AIProvider {
+public:
+    juce::String getProviderName() const override { return "MockPatchProvider"; }
+
+    void fetchAvailableModels(std::function<void(const juce::StringArray&, bool)> callback) override {
+        callback({"MockModel"}, true);
+    }
+
+    RequestId sendPrompt(const std::vector<synth::AIProvider::Message>&, CompletionCallback callback,
+                         const juce::var& = juce::var(), std::function<void(const juce::String&)> = {}) override {
+        AIResponse response;
+        response.success = true;
+        response.content = "```json\n"
+                           R"({"nodes":[{"id":1,"type":"Oscillator"},{"id":2,"type":"Audio Output"}],)"
+                           R"("connections":[{"src":1,"srcPort":0,"dst":2,"dstPort":0}]})"
+                           "\n```";
+        callback(response);
+        return {};
+    }
+
+    void cancel(RequestId) override {}
+    void setModel(const juce::String& name) override { currentModel = name; }
+    juce::String getCurrentModel() const override { return currentModel; }
+
+private:
+    juce::String currentModel;
+};
+
 // Finds the juce::Viewport AIChatComponent adds as a direct child and returns its viewed
 // component (messageList) — the parent of every rendered MessageBubble. MessageBubble itself is a
 // private nested type, but its base juce::Component* children (labels, buttons) are inspectable
@@ -702,4 +732,84 @@ TEST_F(AIChatComponentTest, UpgradeButtonDoesNotSurviveNewChat) {
 
     EXPECT_EQ(findDescendantWithText<juce::TextButton>(findMessageList(chatComponent), "Upgrade to Pro"), nullptr)
         << "New Chat must not resurrect the upgrade button";
+}
+
+TEST_F(AIChatComponentTest, PatchCardShowsThumbsButtons) {
+    AudioEngine engine;
+    synth::AIIntegrationService service(engine.getGraph());
+    service.setProvider(std::make_unique<MockPatchProvider>());
+
+    juce::ApplicationProperties props;
+    juce::PropertiesFile::Options options;
+    options.applicationName = "Test";
+    options.filenameSuffix = "test";
+    options.storageFormat = juce::PropertiesFile::storeAsXML;
+    props.setStorageParameters(options);
+
+    synth::AIChatComponent chatComponent(service, props);
+    chatComponent.setSize(400, 600);
+
+    juce::TextEditor* inputField = nullptr;
+    for (auto* child : chatComponent.getChildren()) {
+        if (auto* editor = dynamic_cast<juce::TextEditor*>(child))
+            inputField = editor;
+    }
+    ASSERT_NE(inputField, nullptr);
+    inputField->setText("give me a patch");
+    chatComponent.triggerSend();
+    juce::MessageManager::getInstance()->runDispatchLoopUntil(100);
+
+    auto* messageList = findMessageList(chatComponent);
+    ASSERT_NE(messageList, nullptr);
+    EXPECT_NE(findDescendantWithText<juce::TextButton>(messageList, "Good"), nullptr);
+    EXPECT_NE(findDescendantWithText<juce::TextButton>(messageList, "Bad"), nullptr);
+}
+
+TEST_F(AIChatComponentTest, ClickingThumbsUpRecordsFeedbackLocally) {
+    AudioEngine engine;
+    synth::AIIntegrationService service(engine.getGraph());
+    service.setProvider(std::make_unique<MockPatchProvider>());
+
+    juce::ApplicationProperties props;
+    juce::PropertiesFile::Options options;
+    options.applicationName = "Test";
+    options.filenameSuffix = "test";
+    options.storageFormat = juce::PropertiesFile::storeAsXML;
+    props.setStorageParameters(options);
+
+    synth::AIChatComponent chatComponent(service, props);
+    chatComponent.setSize(400, 600);
+
+    auto feedbackFile = juce::File::getSpecialLocation(juce::File::tempDirectory)
+                            .getChildFile("AIChatComponentTest_" + juce::Uuid().toString())
+                            .getChildFile("patch_feedback.jsonl");
+    chatComponent.setPatchFeedbackFileForTesting(feedbackFile);
+
+    juce::TextEditor* inputField = nullptr;
+    for (auto* child : chatComponent.getChildren()) {
+        if (auto* editor = dynamic_cast<juce::TextEditor*>(child))
+            inputField = editor;
+    }
+    ASSERT_NE(inputField, nullptr);
+    inputField->setText("give me a patch");
+    chatComponent.triggerSend();
+    juce::MessageManager::getInstance()->runDispatchLoopUntil(100);
+
+    auto* messageList = findMessageList(chatComponent);
+    auto* goodButton = findDescendantWithText<juce::TextButton>(messageList, "Good");
+    ASSERT_NE(goodButton, nullptr);
+    // triggerClick() posts an async command message (Button::triggerClick() ->
+    // postCommandMessage); call onClick() directly for synchronous test behaviour, same as
+    // newChatButton->onClick() above.
+    goodButton->onClick();
+
+    ASSERT_TRUE(feedbackFile.existsAsFile());
+    // Parse rather than substring-match: JSON::toString's allOnOneLine mode still spaces after
+    // colons ("rating": "up"), so a naive `contains("\"rating\":\"up\"")` undercounts.
+    auto recordVar = juce::JSON::parse(feedbackFile.loadFileAsString());
+    auto* record = recordVar.getDynamicObject();
+    ASSERT_NE(record, nullptr);
+    EXPECT_EQ(record->getProperty("rating").toString(), "up");
+
+    feedbackFile.getParentDirectory().deleteRecursively();
 }

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -44,6 +44,7 @@ add_executable(Tests
     AccountServiceTests.cpp
     KeychainTokenStoreTests.cpp
     DeviceIdStoreTests.cpp
+    PatchFeedbackStoreTests.cpp
     MainComponentTests.cpp
     GraphEditorTests.cpp
     ModuleComponentTests.cpp

--- a/Tests/PatchFeedbackStoreTests.cpp
+++ b/Tests/PatchFeedbackStoreTests.cpp
@@ -1,0 +1,107 @@
+#include "../Source/AI/PatchFeedbackStore.h"
+#include <gtest/gtest.h>
+
+namespace synth {
+
+class PatchFeedbackStoreTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        tempFile = juce::File::getSpecialLocation(juce::File::tempDirectory)
+                       .getChildFile("PatchFeedbackStoreTest_" + juce::Uuid().toString())
+                       .getChildFile("patch_feedback.jsonl");
+    }
+
+    void TearDown() override { tempFile.getParentDirectory().deleteRecursively(); }
+
+    juce::StringArray lines() const {
+        juce::StringArray result;
+        result.addLines(tempFile.loadFileAsString());
+        result.removeEmptyStrings();
+        return result;
+    }
+
+    juce::File tempFile;
+};
+
+TEST_F(PatchFeedbackStoreTest, RecordCreatesParentDirectoryAndFile) {
+    PatchFeedbackStore store(tempFile);
+    store.record(R"({"mode":"merge","nodes":[],"connections":[]})", PatchFeedbackStore::Rating::Up);
+    EXPECT_TRUE(tempFile.existsAsFile());
+}
+
+TEST_F(PatchFeedbackStoreTest, RecordsRatingAsUpOrDown) {
+    PatchFeedbackStore store(tempFile);
+    store.record(R"({"mode":"merge","nodes":[],"connections":[]})", PatchFeedbackStore::Rating::Up);
+    store.record(R"({"mode":"merge","nodes":[],"connections":[]})", PatchFeedbackStore::Rating::Down);
+
+    auto entries = lines();
+    ASSERT_EQ(entries.size(), 2);
+
+    auto first = juce::JSON::parse(entries[0]);
+    EXPECT_EQ(first.getDynamicObject()->getProperty("rating").toString(), "up");
+
+    auto second = juce::JSON::parse(entries[1]);
+    EXPECT_EQ(second.getDynamicObject()->getProperty("rating").toString(), "down");
+}
+
+TEST_F(PatchFeedbackStoreTest, OmitsCommentWhenEmptyIncludesWhenPresent) {
+    PatchFeedbackStore store(tempFile);
+    store.record(R"({"nodes":[]})", PatchFeedbackStore::Rating::Up);
+    store.record(R"({"nodes":[]})", PatchFeedbackStore::Rating::Down, "too much reverb");
+
+    auto entries = lines();
+    ASSERT_EQ(entries.size(), 2);
+
+    // Keep the parsed `var` alive for the lifetime of the raw DynamicObject* it owns —
+    // chaining `.getDynamicObject()` straight off a temporary leaves a dangling pointer the
+    // instant the full-expression ends and the temporary's refcount drops to zero.
+    auto firstVar = juce::JSON::parse(entries[0]);
+    auto* first = firstVar.getDynamicObject();
+    EXPECT_FALSE(first->hasProperty("comment"));
+
+    auto secondVar = juce::JSON::parse(entries[1]);
+    auto* second = secondVar.getDynamicObject();
+    EXPECT_EQ(second->getProperty("comment").toString(), "too much reverb");
+}
+
+TEST_F(PatchFeedbackStoreTest, EmbedsParsedPatchJsonWhenValid) {
+    PatchFeedbackStore store(tempFile);
+    store.record(R"({"mode":"merge","nodes":[{"id":1,"type":"Reverb"}],"connections":[]})",
+                 PatchFeedbackStore::Rating::Up);
+
+    auto entryVar = juce::JSON::parse(lines()[0]);
+    auto* entry = entryVar.getDynamicObject();
+    ASSERT_TRUE(entry->hasProperty("patch"));
+    auto* patchObj = entry->getProperty("patch").getDynamicObject();
+    ASSERT_NE(patchObj, nullptr);
+    EXPECT_EQ(patchObj->getProperty("mode").toString(), "merge");
+}
+
+TEST_F(PatchFeedbackStoreTest, FallsBackToRawStringOnMalformedJson) {
+    PatchFeedbackStore store(tempFile);
+    store.record("not valid json {{{", PatchFeedbackStore::Rating::Down);
+
+    auto entryVar = juce::JSON::parse(lines()[0]);
+    auto* entry = entryVar.getDynamicObject();
+    EXPECT_FALSE(entry->hasProperty("patch"));
+    EXPECT_EQ(entry->getProperty("patchRaw").toString(), "not valid json {{{");
+}
+
+TEST_F(PatchFeedbackStoreTest, EachCallAppendsRatherThanOverwrites) {
+    PatchFeedbackStore store(tempFile);
+    for (int i = 0; i < 3; ++i)
+        store.record(R"({"nodes":[]})", PatchFeedbackStore::Rating::Up);
+
+    EXPECT_EQ(lines().size(), 3);
+}
+
+TEST_F(PatchFeedbackStoreTest, IncludesTimestamp) {
+    PatchFeedbackStore store(tempFile);
+    store.record(R"({"nodes":[]})", PatchFeedbackStore::Rating::Up);
+
+    auto entryVar = juce::JSON::parse(lines()[0]);
+    auto* entry = entryVar.getDynamicObject();
+    EXPECT_TRUE(entry->getProperty("timestamp").toString().isNotEmpty());
+}
+
+} // namespace synth

--- a/docs/AI_Engine.md
+++ b/docs/AI_Engine.md
@@ -278,6 +278,27 @@ coverage, plus two regression tests (`MergeModeAutoWireAppearsInDiff`,
 `UntrustedRescaleShowsLandedValueNotRawPatchValue`) proving the snapshot-diff catches what a
 raw-patch-vs-live-graph diff would miss.
 
+### Patch Feedback (thumbs up/down, P6-3)
+
+`AIChatComponent::PatchCard` carries a "Good"/"Bad" pair next to the diff preview, plus an
+optional single-line comment revealed once a rating is picked. Clicking either commits
+immediately — thumbs are meant to be zero-friction, not a form — and reveals the comment field for
+anyone who wants to say why; submitting a comment later (Enter or "Save") writes a second record
+rather than mutating the first, since the underlying store is an append-only log, not a keyed
+table.
+
+**This is the client-only half of the roadmap's P6·3.** `Source/AI/PatchFeedbackStore` appends one
+JSON object per line to `<user app data>/Agent Synth/patch_feedback.jsonl` (`{timestamp, rating,
+comment?, patch}` — `patch` is the parsed patch JSON, falling back to a `patchRaw` string if it
+doesn't parse). There is currently nowhere on the server to send this: `packages/conversations`'
+`ConversationMessage` (synth-platform) has no rating field, and the client doesn't hold a
+conversation id to key a rating against until P6·8 ships. Syncing this log to the server is tracked
+separately (P6·9 in `synth-platform/roadmap.json`), gated on P6·8.
+
+The rating lives on `MessageData::ratingState`/`ratingComment` for the session (same
+"not reconstructed on replay" precedent as `showUpgradeAction`, just above) — the durable copy is
+the JSONL log, not the in-memory chat history.
+
 ### AI Patch Undo/Redo Contract
 
 `AIIntegrationService::applyPatch()` routes through `AppUndoManager::recordAIPatch()` whenever an


### PR DESCRIPTION
## Summary
- `AIChatComponent::PatchCard` gets "Good"/"Bad" buttons plus an optional one-line comment (revealed once a rating is picked, submitted via Enter or "Save").
- `Source/AI/PatchFeedbackStore` appends each rating to a local, append-only JSON-Lines log — `<user app data>/Agent Synth/patch_feedback.jsonl` — never mutating a prior line.
- Client-only for now: `packages/conversations` has no rating field, and the client has no conversation id to key one on until P6-8 ships. Server sync tracked separately as **P6-9** in synth-platform's roadmap ([PR #63](https://github.com/Diabl0269/synth-platform/pull/63)).

## Test plan
- [x] `Tests/PatchFeedbackStoreTests.cpp` — 7 new unit tests (directory creation, up/down, comment omit/include, valid-JSON embed, malformed-JSON fallback, append-not-overwrite, timestamp)
- [x] `Tests/AIChatComponentTests.cpp` — 2 new tests (thumbs buttons appear on a patch card; clicking "Good" writes a record)
- [x] Full suite: `./build/Tests/Tests` — 1624/1624 passed
- [x] `clang-format --dry-run -Werror` clean on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)